### PR TITLE
Remove unnecessary secrets environ variable

### DIFF
--- a/pages/1_✨_Generate_Scenario.py
+++ b/pages/1_✨_Generate_Scenario.py
@@ -15,7 +15,6 @@ from mitreattack.stix20 import MitreAttackData
 os.environ["LANGCHAIN_TRACING_V2"]="true"
 os.environ["LANGCHAIN_ENDPOINT"] = "https://api.smith.langchain.com"
 os.environ["LANGCHAIN_PROJECT"] = "AttackGen"
-os.environ["LANGCHAIN_API_KEY"] = st.secrets["LANGCHAIN_API_KEY"]
 
 openai_api_key = st.session_state["openai_api_key"]
 industry = st.session_state["industry"]

--- a/👋_Welcome.py
+++ b/👋_Welcome.py
@@ -54,7 +54,7 @@ with st.sidebar:
     st.sidebar.markdown("""
                         Created by [Matt Adams](https://www.linkedin.com/in/matthewrwadams)
                         
-                        View the source code on [GitHub](https://https://github.com/mrwadams/attackgen)
+                        View the source code on [GitHub](https://github.com/mrwadams/attackgen)
                         """)
 
 


### PR DESCRIPTION
A secrets file was placed in the gitignore file but used as a location for a environ variable causing an error during runtime. Removed it since it wasn't necessary as the openai key was utilized.