### PR TITLE
add openai api custom endpoint (base_url)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv/
 .streamlit/secrets.toml
+.vscode/

--- a/👋_Welcome.py
+++ b/👋_Welcome.py
@@ -51,7 +51,7 @@ with st.sidebar:
         
         st.session_state["openai_api_endpoint"] = st.text_input(
             "Enter your OpenAI API endpoint:",
-            help="Example endpoint: https://api.openai.com",
+            help="Example endpoint: https://api.openai.com/v1",
         )
 
         # Add model selection input field to the sidebar

--- a/👋_Welcome.py
+++ b/👋_Welcome.py
@@ -48,6 +48,11 @@ with st.sidebar:
             type="password",
             help="You can find your OpenAI API key on the [OpenAI dashboard](https://platform.openai.com/account/api-keys).",
         )
+        
+        st.session_state["openai_api_endpoint"] = st.text_input(
+            "Enter your OpenAI API endpoint:",
+            help="Example endpoint: https://api.openai.com",
+        )
 
         # Add model selection input field to the sidebar
         model_name = st.selectbox(


### PR DESCRIPTION
There are many types of non-official OpenAI API proxies, such as OneAPI, Kimi, etc. They can all be switched directly by using ChatOpenAI(base_url=https://api.openai.com/v1), so I added one and it runs perfectly.
