### PR TITLE
Feature/v0.10

### DIFF
--- a/00_👋_Welcome.py
+++ b/00_👋_Welcome.py
@@ -81,9 +81,9 @@ with st.sidebar:
         # Add model selection input field to the sidebar
         model_name = st.selectbox(
             "Select the model you would like to use:",
-            ["o4-mini", "o3", "o3-mini", "o1", "o1-pro", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-4o"],
+            ["gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-4.1", "gpt-4.1-mini", "gpt-4o", "o3-pro", "o3", "o3-mini", "o4-mini"],
             key="selected_model",
-            help="O-series models are OpenAI's reasoning models, with o4-mini being the latest. GPT-4.1 is OpenAI's most capable general model, with lighter alternatives available. o1-pro offers enhanced reasoning capabilities.",
+            help="GPT-5 is the best model for coding and agentic tasks. GPT-5-mini and GPT-5-nano are faster, cost-efficient versions. GPT-4.1 is the smartest non-reasoning model. O-series models (o3-pro, o3, o3-mini, o4-mini) are reasoning models for complex problem-solving. All models use the advanced Responses API with built-in tools.",
         )
         st.session_state["model_name"] = model_name
 

--- a/00_👋_Welcome.py
+++ b/00_👋_Welcome.py
@@ -104,9 +104,9 @@ with st.sidebar:
         # Add model selection input field to the sidebar
         model_name = st.selectbox(
             "Select the model you would like to use:",
-            ["claude-opus-4-20250514", "claude-sonnet-4-20250514", "claude-3-7-sonnet-latest", "claude-3-5-haiku-latest"],
+            ["claude-sonnet-4-5-20250929", "claude-sonnet-4-20250514", "claude-3-7-sonnet-20250219", "claude-opus-4-1-20250805", "claude-opus-4-20250514", "claude-3-5-haiku-latest"],
             key="selected_model",
-            help="Claude Opus 4 is Anthropic's most capable model for complex tasks. Claude Sonnet 4 offers a balance of performance and cost. Claude 3.7 Sonnet and Claude 3.5 Haiku are optimized for specific use cases.",
+            help="Claude Sonnet 4.5 is Anthropic's latest and most capable model. Claude Sonnet 4 offers excellent performance and cost balance. Claude Opus 4.1 and 4 are optimized for the most complex tasks. Claude 3.7 Sonnet and 3.5 Haiku are efficient options for specific use cases.",
         )
         st.session_state["anthropic_model"] = model_name
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+AttackGen is a cybersecurity incident response testing tool that generates tailored attack scenarios based on MITRE ATT&CK framework and threat actor groups using large language models. It's built as a Streamlit web application with support for multiple LLM providers.
+
+## Development Commands
+
+### Running the Application
+```bash
+streamlit run 00_👋_Welcome.py
+```
+
+### Installing Dependencies
+```bash
+pip install -r requirements.txt
+```
+
+### Docker Usage
+```bash
+# Build image
+docker build -t attackgen .
+
+# Run container
+docker run -p 8501:8501 attackgen
+```
+
+## Architecture
+
+### Core Components
+- **00_👋_Welcome.py**: Main entry point and configuration UI
+- **pages/**: Streamlit pages for different functionality
+  - **1_🛡️_Threat_Group_Scenarios.py**: Generate scenarios based on threat actor groups
+  - **2_🛠️_Custom_Scenarios.py**: Generate custom scenarios from selected ATT&CK techniques  
+  - **3_💬_AttackGen_Assistant.py**: Chat interface for refining scenarios
+
+### Data Files
+- **data/enterprise-attack.json**: MITRE ATT&CK Enterprise matrix (STIX format)
+- **data/ics-attack.json**: MITRE ATT&CK ICS matrix (STIX format)
+- **data/groups.json**: Threat actor group mappings for Enterprise
+- **data/groups_ics.json**: Threat actor group mappings for ICS
+
+### Configuration
+- **.env**: API keys and secrets (not tracked in git)
+- **.streamlit/secrets.toml**: Streamlit secrets for LangSmith integration
+- **requirements.txt**: Python dependencies including langchain, streamlit, pandas, mitreattack-python
+
+### Key Libraries
+- **Streamlit**: Web application framework
+- **LangChain**: LLM integration and prompt management  
+- **mitreattack-python**: MITRE ATT&CK data processing
+- **pandas**: Data manipulation for technique selection
+- **python-dotenv**: Environment variable management
+
+### LLM Provider Support
+The application supports multiple model providers through a unified interface:
+- OpenAI API (including o-series reasoning models, GPT-4.1 series)
+- Anthropic API (Claude models)
+- Azure OpenAI Service
+- Google AI API (Gemini models)
+- Mistral API
+- Groq API  
+- Ollama (local models)
+- Custom OpenAI-compatible endpoints
+
+### Scenario Generation Flow
+1. User selects model provider and configures API credentials
+2. User chooses organization details (industry, size) and ATT&CK matrix
+3. For threat group scenarios: Select threat actor group → Extract techniques → Generate scenario
+4. For custom scenarios: Select individual ATT&CK techniques → Generate scenario
+5. Optional: Use AttackGen Assistant to refine generated scenarios
+
+### Environment Variables
+Key environment variables loaded from .env:
+- Model API keys: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, etc.
+- Azure-specific: `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_DEPLOYMENT`
+- Optional: `LANGCHAIN_API_KEY` for LangSmith tracing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ docker run -p 8501:8501 attackgen
 
 ### LLM Provider Support
 The application supports multiple model providers through a unified interface:
-- OpenAI API (including o-series reasoning models, GPT-4.1 series)
+- OpenAI API (using new Responses API)
 - Anthropic API (Claude models)
 - Azure OpenAI Service
 - Google AI API (Gemini models)
@@ -64,6 +64,13 @@ The application supports multiple model providers through a unified interface:
 - Groq API  
 - Ollama (local models)
 - Custom OpenAI-compatible endpoints
+
+### OpenAI Responses API Integration
+AttackGen now uses OpenAI's latest Responses API for all supported models, providing:
+- Unified interface across all OpenAI models (GPT-5, GPT-4.1, GPT-4o, o-series)
+- Improved response formatting with proper markdown rendering
+- Simplified code architecture without model-specific handling
+- Enhanced structured output parsing from the API
 
 ### Scenario Generation Flow
 1. User selects model provider and configures API credentials

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you find AttackGen useful, please consider starring the repository on GitHub.
 - AttackGen Assistant - a chat interface for updating and/or asking questions about generated scenarios.
 - Capture user feedback on the quality of the generated scenarios.
 - Downloadable scenarios in Markdown format.
-- Use the OpenAI API (including new 'reasoning' models), Anthropic API (Claude models), Azure OpenAI Service, Google AI API, Mistral API, Groq API, locally hosted Ollama models, or custom OpenAI-compatible API endpoints to generate incident response scenarios.
+- Use the OpenAI API, Anthropic API (Claude models), Azure OpenAI Service, Google AI API, Mistral API, Groq API, locally hosted Ollama models, or custom OpenAI-compatible API endpoints to generate incident response scenarios.
 - Available as a Docker container image for easy deployment.
 - Optional integration with [LangSmith](https://docs.smith.langchain.com/) for powerful debugging, testing, and monitoring of model performance.
 - Secure credential management using .env file for API keys and secrets.
@@ -37,6 +37,13 @@ If you find AttackGen useful, please consider starring the repository on GitHub.
 ![AttackGen Screenshot](./images/screenshot.png)
 
 ## Releases
+
+### v0.10
+| What's new? | Why is it useful? |
+| ----------- | ----------------- |
+| OpenAI Responses API Integration | - Next-Generation API: AttackGen now uses OpenAI's latest Responses API for all supported models, providing a unified and enhanced interface. |
+| Latest Frontier Model Support | - GPT-5 Integration: Added support for OpenAI's latest GPT-5 model series including gpt-5, gpt-5-mini, and gpt-5-nano, providing access to the most advanced AI capabilities for scenario generation. |
+| Bug Fixes and Improvements | - Fixed Streamlit Deprecation Warning: Replaced deprecated `use_container_width` parameter with the new `width` parameter to ensure compatibility with future Streamlit versions.<br><br>- Enhanced Documentation: Updated CLAUDE.md with comprehensive guidance for future development work and added detailed architecture information. |
 
 ### v0.9
 | What's new? | Why is it useful? |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you find AttackGen useful, please consider starring the repository on GitHub.
 | What's new? | Why is it useful? |
 | ----------- | ----------------- |
 | OpenAI Responses API Integration | - Next-Generation API: AttackGen now uses OpenAI's latest Responses API for all supported models, providing a unified and enhanced interface. |
-| Latest Frontier Model Support | - GPT-5 Integration: Added support for OpenAI's latest GPT-5 model series including gpt-5, gpt-5-mini, and gpt-5-nano, providing access to the most advanced AI capabilities for scenario generation. |
+| Latest Frontier Model Support | - GPT-5 Integration: Added support for OpenAI's latest GPT-5 model series including gpt-5, gpt-5-mini, and gpt-5-nano, providing access to the most advanced AI capabilities for scenario generation.<br><br>- Claude Sonnet 4.5: Added support for Anthropic's latest Claude Sonnet 4.5 (claude-sonnet-4-5-20250929) model, along with updated Claude model versions including Claude Opus 4.1 (claude-opus-4-1-20250805). |
 | Bug Fixes and Improvements | - Fixed Streamlit Deprecation Warning: Replaced deprecated `use_container_width` parameter with the new `width` parameter to ensure compatibility with future Streamlit versions.<br><br>- Enhanced Documentation: Updated CLAUDE.md with comprehensive guidance for future development work and added detailed architecture information. |
 
 ### v0.9

--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -727,7 +727,7 @@ try:
             # Create an expander for the techniques
             with st.expander("Associated ATT&CK Techniques"):
                 # Use the st.table function to display the DataFrame
-                st.dataframe(data=techniques_df, height=200, use_container_width=True, hide_index=True)
+                st.dataframe(data=techniques_df, height=200, width='stretch', hide_index=True)
 
         # Create an empty list to hold the kill chain information
         kill_chain = []


### PR DESCRIPTION
## Summary

This PR introduces v0.10 of AttackGen with major enhancements including OpenAI's Responses API integration, support for the latest frontier models from OpenAI and Anthropic, and important bug fixes.

### Key Changes

**🚀 OpenAI Responses API Integration**
- Migrated all OpenAI models to use the new Responses API (`output_version="responses/v1"`)
- Unified API interface across all OpenAI models (GPT-5, GPT-4.1, GPT-4o, o-series)
- Simplified response handling by removing model-specific conditional logic
- Improved markdown rendering in generated scenarios

**🤖 Latest Frontier Model Support**
- **OpenAI GPT-5 Series**: Added `gpt-5`, `gpt-5-mini`, `gpt-5-nano` for cutting-edge AI capabilities
- **Updated o-series Models**: Includes `o3-pro`, `o3`, `o3-mini`, `o4-mini` with unified Responses API
handling
- **Anthropic Claude Sonnet 4.5**: Added `claude-sonnet-4-5-20250929` (latest and most capable)
- **Updated Claude Models**: Added `claude-opus-4-1-20250805` and `claude-3-7-sonnet-20250219`

**🔧 Bug Fixes and Improvements**
- Fixed Streamlit deprecation warning by replacing `use_container_width` with `width` parameter
- Enhanced system prompts to explicitly request markdown formatting for better readability
- Updated CLAUDE.md with comprehensive architecture and development guidance

### Technical Details

**Files Modified:**
- `00_👋_Welcome.py` - Updated model selections for OpenAI and Anthropic providers
- `pages/1_🛡️_Threat_Group_Scenarios.py` - Implemented Responses API integration
- `pages/2_🛠️_Custom_Scenarios.py` - Implemented Responses API integration
- `pages/3_💬_AttackGen_Assistant.py` - Updated prompts for markdown formatting
- `CLAUDE.md` - Added OpenAI Responses API documentation
- `README.md` - Updated release notes for v0.10

**Key Code Changes:**
- Replaced `llm.generate(messages=[messages])` with `llm.invoke(messages)`
- Updated response extraction to use `response.content` for structured output
- Added `output_version="responses/v1"` to all OpenAI ChatOpenAI initializations
- Removed unnecessary web search tool bindings (saved for future implementation)

### Test Plan

- [x] Test OpenAI GPT-5 models for scenario generation
- [x] Test Anthropic Claude Sonnet 4.5 for scenario generation
- [x] Verify markdown rendering in all three pages (Threat Group, Custom, Assistant)
- [x] Confirm no Streamlit deprecation warnings
- [x] Validate response parsing with Responses API format

🤖 Generated with [Claude Code](https://claude.com/claude-code)