### PR TITLE
fix: bump base image digest and upgrade pip to address CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use specific version with SHA256 for reproducibility and security
-FROM python:3.12-slim@sha256:d86b4c74b936c438cd4cc3a9f7256b9a7c27ad68c7caf8c205e18d9845af0164
+FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
 
 # Create non-root user for security
 RUN groupadd -r attackgen && \
@@ -9,8 +9,10 @@ RUN groupadd -r attackgen && \
 WORKDIR /app
 
 # Copy and install dependencies as root (better layer caching)
+# Upgrade pip first to pick up fixes for CVE-2025-8869 (symlink extraction)
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt && \
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt && \
     pip check
 
 # Set up Streamlit cache directory with proper permissions


### PR DESCRIPTION
## Summary
- Refresh `python:3.12-slim` digest to the latest build (pushed 2026-05-22) to clear stale OS-layer CVEs flagged by Trivy code scanning.
- Upgrade `pip` before installing requirements so the build picks up the fix for **CVE-2025-8869** (missing symlink checks during package extraction).

## Context
Trivy reported 62 open code scanning alerts against the Docker image — 11 medium and 51 low. The pip CVE is the only one with a fix we can apply directly in this repo; most low-severity findings live in the Debian base layer and should clear (or reduce) when the digest is refreshed. The 9 `CVE-2025-14104` (util-linux) alerts will remain until Debian ships a patched package.

Note: dependabot has an open branch proposing `python:3.14-slim`. This PR intentionally stays on 3.12 — it's a security refresh, not a Python upgrade. The 3.14 bump can be evaluated separately.

## Test plan
- [ ] `docker build -t attackgen .` succeeds
- [ ] Container starts and Streamlit health check passes (`docker run -p 8501:8501 attackgen`)
- [ ] Re-run Trivy / wait for code scanning to confirm alert count drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)