### PR TITLE
Route all LLM calls through LiteLLM via a single core/ wrapper

### DIFF
--- a/00_👋_Welcome.py
+++ b/00_👋_Welcome.py
@@ -44,12 +44,25 @@ restore_from_query_params()
 with st.sidebar:
     st.sidebar.markdown("### <span style='color: #1DB954;'>Setup</span>", unsafe_allow_html=True)
 
+    # NB: no `key=` on this (or any) widget that backs a persisted shadow key.
+    # Streamlit clears widget-key entries from session_state when navigating to
+    # a page that doesn't host the widget, which would lose the user's choices
+    # the moment they leave Welcome. Seeding via `index=` from the shadow key
+    # avoids that and keeps the URL → shadow → widget pipeline one-directional.
+    provider_options = list(PROVIDERS.keys())
+    persisted_provider = st.session_state.get("chosen_model_provider")
+    provider_idx = (
+        provider_options.index(persisted_provider)
+        if persisted_provider in provider_options
+        else 0
+    )
     model_provider = st.selectbox(
         "Select your preferred model provider:",
-        list(PROVIDERS.keys()),
-        key="chosen_model_provider",
+        provider_options,
+        index=provider_idx,
         help="Select the model provider you would like to use. This will determine the models available for selection.",
     )
+    st.session_state["chosen_model_provider"] = model_provider
 
     provider_info = PROVIDERS[model_provider]
 
@@ -110,7 +123,6 @@ with st.sidebar:
             "Select the model you would like to use:",
             labels,
             index=default_idx,
-            key=f"selected_model_{model_provider}",
             help="\n".join(f"**{mid}** — {help_map[mid] or 'No description.'}" for mid in labels),
         )
         st.session_state["llm_model_name"] = chosen
@@ -125,11 +137,18 @@ with st.sidebar:
 
     st.markdown("""---""")
 
+    matrix_options = ["Enterprise", "ICS", "ATLAS"]
+    persisted_matrix = st.session_state.get("matrix")
+    matrix_idx = (
+        matrix_options.index(persisted_matrix)
+        if persisted_matrix in matrix_options
+        else 0
+    )
     matrix = st.sidebar.radio(
         "Select MITRE Framework:",
-        ["Enterprise", "ICS", "ATLAS"],
-        key="selected_matrix",
-        help="Enterprise and ICS are ATT&CK matrices for traditional IT and industrial control systems. ATLAS focuses on adversarial threats to AI/ML systems."
+        matrix_options,
+        index=matrix_idx,
+        help="Enterprise and ICS are ATT&CK matrices for traditional IT and industrial control systems. ATLAS focuses on adversarial threats to AI/ML systems.",
     )
     st.session_state["matrix"] = matrix
 

--- a/00_👋_Welcome.py
+++ b/00_👋_Welcome.py
@@ -3,7 +3,7 @@ Copyright (C) 2024, Matthew Adams
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or 
+the Free Software Foundation, either version 3 of the License, or
 any later version.
 
 This program is distributed in the hope that it will be useful,
@@ -15,10 +15,12 @@ A copy of the licence is provided with this program. If you are unable
 to view it, please see https://www.gnu.org/licenses/
 """
 
-import streamlit as st
-import requests
 import os
+
+import streamlit as st
 from dotenv import load_dotenv
+
+from core.models import PROVIDERS, get_models_for_provider
 
 # Load environment variables from .env file
 load_dotenv()
@@ -35,206 +37,74 @@ st.set_page_config(
 
 with st.sidebar:
     st.sidebar.markdown("### <span style='color: #1DB954;'>Setup</span>", unsafe_allow_html=True)
-    # Add model selection input field to the sidebar
+
     model_provider = st.selectbox(
         "Select your preferred model provider:",
-        ["OpenAI API", "Anthropic API", "Azure OpenAI Service", "Google AI API", "Mistral API", "Groq API", "Ollama", "Custom"],
-        key="model_provider",
+        list(PROVIDERS.keys()),
+        key="chosen_model_provider",
         help="Select the model provider you would like to use. This will determine the models available for selection.",
     )
 
-    # Save the selected model provider to the session state
-    st.session_state["chosen_model_provider"] = model_provider
+    provider_info = PROVIDERS[model_provider]
 
-    if model_provider == "Custom":
-        # Add input fields for custom API configuration
-        st.session_state["custom_api_key"] = st.text_input(
-            "Enter your API key:",
+    # ---- API key ----
+    if provider_info.needs_api_key:
+        env_key = os.getenv(provider_info.env_var) if provider_info.env_var else None
+        if env_key:
+            st.session_state["llm_api_key"] = env_key
+            st.success("API key loaded from .env")
+        else:
+            api_key_help = (
+                f"You can find your API key at [{provider_info.api_key_url}]({provider_info.api_key_url})."
+                if provider_info.api_key_url
+                else "Enter the API key for your chosen provider."
+            )
+            st.session_state["llm_api_key"] = st.text_input(
+                f"Enter your {provider_info.name} API key:",
+                type="password",
+                help=api_key_help,
+            )
+    else:
+        # Optional key for Custom (some local endpoints accept any string)
+        env_key = os.getenv(provider_info.env_var) if provider_info.env_var else None
+        st.session_state["llm_api_key"] = st.text_input(
+            "API key (optional):",
             type="password",
-            help="Enter the API key for your custom model provider.",
+            value=env_key or "",
+            help="Optional. Leave blank if your endpoint doesn't require authentication.",
         )
 
-        st.session_state["custom_model_name"] = st.text_input(
-            "Enter the model name:",
-            help="Enter the model name for your custom model provider.",
+    # ---- Base URL (Custom only) ----
+    if provider_info.needs_api_base:
+        env_base = os.getenv("CUSTOM_BASE_URL")
+        st.session_state["llm_api_base"] = st.text_input(
+            "Base URL:",
+            value=env_base or provider_info.default_api_base or "",
+            help="Base URL of your OpenAI-compatible endpoint. Example: http://localhost:11434/v1 for Ollama, http://localhost:1234/v1 for LM Studio.",
         )
+    else:
+        st.session_state["llm_api_base"] = None
 
-        st.session_state["custom_base_url"] = st.text_input(
-            "Enter the base URL:",
-            help="Enter the base URL for your custom provider (e.g., http://localhost:1234/v1). Must be OpenAI API compatible.",
-        )
-
-    if model_provider == "OpenAI API":
-        # Check if OpenAI API key is in environment variables
-        openai_api_key = os.getenv("OPENAI_API_KEY")
-        if not openai_api_key:
-            # Add OpenAI API key input field to the sidebar if not in environment
-            st.session_state["openai_api_key"] = st.text_input(
-                "Enter your OpenAI API key:",
-                type="password",
-                help="You can find your OpenAI API key on the [OpenAI dashboard](https://platform.openai.com/account/api-keys).",
-            )
-        else:
-            st.session_state["openai_api_key"] = openai_api_key
-            st.success("API key loaded from .env")
-
-        # Add model selection input field to the sidebar
-        model_name = st.selectbox(
+    # ---- Model selection ----
+    models = get_models_for_provider(model_provider)
+    if models:
+        labels = [m.model_id for m in models]
+        help_map = {m.model_id: m.help_text for m in models}
+        chosen = st.selectbox(
             "Select the model you would like to use:",
-            ["gpt-5.2", "gpt-5-mini", "gpt-5-nano", "gpt-5.2-pro", "gpt-5", "gpt-4.1"],
+            labels,
             key="selected_model",
-            help="GPT-5.2 is the best model for coding and agentic tasks. GPT-5.2 pro produces smarter, more precise responses. GPT-5-mini and nano are faster, cost-efficient versions. GPT-4.1 is the smartest non-reasoning model with 1M token context.",
+            help="\n".join(f"**{mid}** — {help_map[mid] or 'No description.'}" for mid in labels),
         )
-        st.session_state["model_name"] = model_name
-
-    if model_provider == "Anthropic API":
-        # Check if Anthropic API key is in environment variables
-        anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
-        if not anthropic_api_key:
-            # Add Anthropic API key input field to the sidebar if not in environment
-            st.session_state["anthropic_api_key"] = st.text_input(
-                "Enter your Anthropic API key:",
-                type="password",
-                help="You can find your Anthropic API key on the [Anthropic console](https://console.anthropic.com/account/keys).",
-            )
-        else:
-            st.session_state["anthropic_api_key"] = anthropic_api_key
-            st.success("API key loaded from .env")
-
-        # Add model selection input field to the sidebar
-        model_name = st.selectbox(
-            "Select the model you would like to use:",
-            ["claude-sonnet-4-5-20250929", "claude-haiku-4-5-20251001", "claude-opus-4-5-20251101"],
-            key="selected_model",
-            help="Claude Sonnet 4.5 is the best balance of performance and cost. Claude Haiku 4.5 is the fastest option. Claude Opus 4.5 is the most capable model for complex tasks.",
+        st.session_state["llm_model_name"] = chosen
+    else:
+        # Custom: user types the model id
+        env_model = os.getenv("CUSTOM_MODEL_NAME")
+        st.session_state["llm_model_name"] = st.text_input(
+            "Model name:",
+            value=env_model or "",
+            help="Model identifier as expected by your endpoint (e.g. 'llama3.1', 'qwen3:32b').",
         )
-        st.session_state["anthropic_model"] = model_name
-
-    if model_provider == "Azure OpenAI Service":
-        # Check if Azure OpenAI API key is in environment variables
-        azure_api_key = os.getenv("AZURE_OPENAI_API_KEY")
-        if not azure_api_key:
-            # Add Azure OpenAI API key input field to the sidebar if not in environment
-            st.session_state["AZURE_OPENAI_API_KEY"] = st.text_input(
-                "Azure OpenAI API key:",
-                type="password",
-                help="You can find your Azure OpenAI API key on the [Azure portal](https://portal.azure.com/).",
-            )
-        else:
-            st.session_state["AZURE_OPENAI_API_KEY"] = azure_api_key
-            st.success("API key loaded from .env")
-        
-        # Check if Azure OpenAI endpoint is in environment variables
-        azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
-        if not azure_endpoint:
-            # Add Azure OpenAI endpoint input field to the sidebar if not in environment
-            st.session_state["AZURE_OPENAI_ENDPOINT"] = st.text_input(
-                "Azure OpenAI endpoint:",
-                help="Example endpoint: https://YOUR_RESOURCE_NAME.openai.azure.com/",
-            )
-        else:
-            st.session_state["AZURE_OPENAI_ENDPOINT"] = azure_endpoint
-            st.success("Endpoint loaded from .env")
-
-        # Add Azure OpenAI deployment name input field to the sidebar
-        azure_deployment = os.getenv("AZURE_DEPLOYMENT")
-        if not azure_deployment:
-            st.session_state["AZURE_DEPLOYMENT"] = st.text_input(
-                "Deployment name:",
-                help="This is the name of your Azure OpenAI deployment.",
-            )
-        else:
-            st.session_state["AZURE_DEPLOYMENT"] = azure_deployment
-            st.success("Deployment name loaded from .env")
-        
-        # Add API version dropdown selector to the sidebar
-        st.session_state["openai_api_version"] = st.selectbox("API version:", ["2023-12-01-preview", "2023-05-15"], key="api_version", help="Select OpenAI API version used by your deployment.")
-
-    if model_provider == "Google AI API":
-        # Check if Google API key is in environment variables
-        google_api_key = os.getenv("GOOGLE_API_KEY")
-        if not google_api_key:
-            # Add Google API key input field to the sidebar if not in environment
-            st.session_state["GOOGLE_API_KEY"] = st.text_input(
-                "Enter your Google AI API key:",
-                type="password",
-                help="You can generate a Google AI API key in the [Google AI Studio](https://makersuite.google.com/app/apikey).",
-            )
-        else:
-            st.session_state["GOOGLE_API_KEY"] = google_api_key
-            st.success("API key loaded from .env")
-
-        # Add model selection input field to the sidebar
-        st.session_state["google_model"] = st.selectbox(
-            "Select the model you would like to use:",
-            ["gemini-3-pro-preview", "gemini-3-flash-preview", "gemini-2.5-flash", "gemini-2.5-flash-lite"],
-            key="selected_model",
-            help="Gemini 3 Pro is the most capable model. Gemini 3 Flash offers a good balance. Gemini 2.5 Flash and Flash Lite are faster, cost-efficient options.",
-        )
-
-    if model_provider == "Groq API":
-        # Check if Groq API key is in environment variables
-        groq_api_key = os.getenv("GROQ_API_KEY")
-        if not groq_api_key:
-            # Add Groq API key input field to the sidebar if not in environment
-            st.session_state["GROQ_API_KEY"] = st.text_input(
-                "Enter your Groq API key:",
-                type="password",
-                help="You can find your Groq API key in the [Groq Console](https://console.groq.com/keys).",
-            )
-        else:
-            st.session_state["GROQ_API_KEY"] = groq_api_key
-            st.success("API key loaded from .env")
-
-        # Add model selection input field to the sidebar
-        st.session_state["groq_model"] = st.selectbox(
-            "Select the model you would like to use:",
-            ["openai/gpt-oss-120b", "openai/gpt-oss-20b", "llama-3.3-70b-versatile", "llama-3.1-8b-instant"],
-            key="selected_model",
-            help="GPT-OSS 120B is the most capable model. GPT-OSS 20B is a smaller, faster option. Llama 3.3 70B offers strong performance. Llama 3.1 8B is the fastest option.",
-        )
-
-    if model_provider == "Mistral API":
-        # Check if Mistral API key is in environment variables
-        mistral_api_key = os.getenv("MISTRAL_API_KEY")
-        if not mistral_api_key:
-            # Add Mistral API key input field to the sidebar if not in environment
-            st.session_state["MISTRAL_API_KEY"] = st.text_input(
-                "Enter your Mistral API key:",
-                type="password",
-                help="You can generate a Mistral API key in the [Mistral console](https://console.mistral.ai/api-keys/).",
-            )
-        else:
-            st.session_state["MISTRAL_API_KEY"] = mistral_api_key
-            st.success("API key loaded from .env")
-
-        # Add model selection input field to the sidebar
-        st.session_state["mistral_model"] = st.selectbox(
-            "Select the model you would like to use:",
-            ["mistral-large-2512", "mistral-medium-2508", "mistral-small-2506", "ministral-14b-2512"],
-            key="selected_model",
-            help="Mistral Large is the most capable model. Mistral Medium and Small offer good performance at lower cost. Ministral 14B is a compact, efficient option.",
-        )
-
-    if model_provider == "Ollama":
-        # Make a request to the Ollama API to get the list of available models
-        try:
-            response = requests.get("http://localhost:11434/api/tags", timeout=5)
-            response.raise_for_status()  # Raises a HTTPError if the status is 4xx, 5xx
-        except requests.exceptions.RequestException as e:
-            st.error("Ollama endpoint not found, please select a different model provider.")
-            response = None
-
-        if response:
-            data = response.json()
-            available_models = [model["name"] for model in data["models"]]
-            # Add model selection input field to the sidebar
-            ollama_model = st.selectbox(
-            "Select the model you would like to use:",
-            available_models,
-            key="selected_model",
-            )
-            st.session_state["ollama_model"] = ollama_model
 
     st.markdown("""---""")
 
@@ -246,29 +116,33 @@ with st.sidebar:
     )
     st.session_state["matrix"] = matrix
 
-    # Add the drop-down selectors for Industry and Company Size
     industry = st.selectbox(
-    "Select your company's industry:",
-    sorted(['Aerospace / Defense', 'Agriculture / Food Services', 
-            'Automotive', 'Construction', 'Education', 
-            'Energy / Utilities', 'Finance / Banking', 
-            'Government / Public Sector', 'Healthcare', 
-            'Hospitality / Tourism', 'Insurance', 
-            'Legal Services', 'Manufacturing', 
-            'Media / Entertainment', 'Non-profit', 
-            'Real Estate', 'Retail / E-commerce', 
-            'Technology / IT', 'Telecommunication', 
-            'Transportation / Logistics'])
-    , placeholder="Select Industry")
+        "Select your company's industry:",
+        sorted(['Aerospace / Defense', 'Agriculture / Food Services',
+                'Automotive', 'Construction', 'Education',
+                'Energy / Utilities', 'Finance / Banking',
+                'Government / Public Sector', 'Healthcare',
+                'Hospitality / Tourism', 'Insurance',
+                'Legal Services', 'Manufacturing',
+                'Media / Entertainment', 'Non-profit',
+                'Real Estate', 'Retail / E-commerce',
+                'Technology / IT', 'Telecommunication',
+                'Transportation / Logistics']),
+        placeholder="Select Industry",
+    )
     st.session_state["industry"] = industry
 
-    company_size = st.selectbox("Select your company's size:", ['Small (1-50 employees)', 'Medium (51-200 employees)', 'Large (201-1,000 employees)', 'Enterprise (1,001-10,000 employees)', 'Large Enterprise (10,000+ employees)'], placeholder="Select Company Size")
+    company_size = st.selectbox(
+        "Select your company's size:",
+        ['Small (1-50 employees)', 'Medium (51-200 employees)', 'Large (201-1,000 employees)', 'Enterprise (1,001-10,000 employees)', 'Large Enterprise (10,000+ employees)'],
+        placeholder="Select Company Size",
+    )
     st.session_state["company_size"] = company_size
 
     st.sidebar.markdown("---")
 
-    st.sidebar.markdown("### <span style='color: #1DB954;'>About</span>", unsafe_allow_html=True)        
-    
+    st.sidebar.markdown("### <span style='color: #1DB954;'>About</span>", unsafe_allow_html=True)
+
     st.sidebar.markdown("Created by [Matt Adams](https://www.linkedin.com/in/matthewrwadams)")
 
     st.sidebar.markdown(
@@ -292,78 +166,15 @@ st.markdown("""
             AttackGen also generates **AI Insider Threat Scenarios** — incident response exercises in which a frontier AI agent deployed inside your organisation behaves as an insider threat. These are based on the threat model from [*Actions Speak Louder Than Tokens: An Insider Threat Model for Frontier AI Agents*](https://ai-insider-threat.matt-adams.co.uk).
             """)
 
-if st.session_state.get('chosen_model_provider') == "Azure OpenAI Service":
-    st.markdown("""          
+st.markdown("""
             ### Getting Started
 
-            1. Enter the details of your Azure OpenAI Service model deployment, including the API key, endpoint, deployment name, and API version. 
-            2. Select your industry, company size, and MITRE framework (ATT&CK Enterprise, ICS, or ATLAS) from the sidebar.
-            3. Go to the `Threat Group Scenarios` page to generate a scenario based on a threat actor group or ATLAS case study, or go to the `Custom Scenarios` page to generate a scenario based on your own selection of techniques.
-            4. Use `AttackGen Assistant` to refine / update the generated scenario, or ask more general questions about incident response testing.
-            """)
+            1. From the sidebar, pick your model provider, enter the API key (if required), and choose a model.
+            2. Select your industry, company size, and MITRE framework (ATT&CK Enterprise, ICS, or ATLAS).
+            3. Open the `Threat Group Scenarios` page to generate a scenario based on a threat actor group or ATLAS case study, or the `Custom Scenarios` page to generate one from your own selection of techniques.
+            4. Use the `AttackGen Assistant` to refine the generated scenario, or to ask wider questions about incident response testing.
 
-elif st.session_state.get('chosen_model_provider') == "Anthropic API":
-    st.markdown("""          
-            ### Getting Started
-
-            1. Enter your Anthropic API key, then select your preferred Claude model, industry, company size, and MITRE framework from the sidebar.
-            2. Go to the `Threat Group Scenarios` page to generate a scenario based on a threat actor group or ATLAS case study, or go to the `Custom Scenarios` page to generate a scenario based on your own selection of techniques.
-            3. Use `AttackGen Assistant` to refine / update the generated scenario, or ask more general questions about incident response testing.
-            """)
-    
-elif st.session_state.get('chosen_model_provider') == "Google AI API":
-    st.markdown("""          
-            ### Getting Started
-
-            1. Enter your Google AI API key, then select your preferred model, industry, company size, and MITRE framework from the sidebar.
-            2. Go to the `Threat Group Scenarios` page to generate a scenario based on a threat actor group or ATLAS case study, or go to the `Custom Scenarios` page to generate a scenario based on your own selection of techniques.
-            3. Use `AttackGen Assistant` to refine / update the generated scenario, or ask more general questions about incident response testing.
-            """)
-    
-elif st.session_state.get('chosen_model_provider') == "Mistral API":
-    st.markdown("""          
-            ### Getting Started
-
-            1. Enter your Mistral API key, then select your preferred model, industry, company size, and MITRE framework from the sidebar.
-            2. Go to the `Threat Group Scenarios` page to generate a scenario based on a threat actor group or ATLAS case study, or go to the `Custom Scenarios` page to generate a scenario based on your own selection of techniques.
-            3. Use `AttackGen Assistant` to refine / update the generated scenario, or ask more general questions about incident response testing.
-            """)
-
-elif st.session_state.get('chosen_model_provider') == "Ollama":
-    st.markdown("""          
-            ### Getting Started
-
-            1. Select your locally hosted model from the sidebar, then select your industry, company size, and MITRE framework.
-            2. Go to the `Threat Group Scenarios` page to generate a scenario based on a threat actor group or ATLAS case study, or go to the `Custom Scenarios` page to generate a scenario based on your own selection of techniques.
-            3. Use `AttackGen Assistant` to refine / update the generated scenario, or ask more general questions about incident response testing.
-            """)
-
-elif st.session_state.get('chosen_model_provider') == "Groq API":
-    st.markdown("""          
-            ### Getting Started
-
-            1. Enter your Groq API key, then select your preferred model, industry, company size, and MITRE framework from the sidebar.
-            2. Go to the `Threat Group Scenarios` page to generate a scenario based on a threat actor group or ATLAS case study, or go to the `Custom Scenarios` page to generate a scenario based on your own selection of techniques.
-            3. Use `AttackGen Assistant` to refine / update the generated scenario, or ask more general questions about incident response testing.
-            """)
-    
-elif st.session_state.get('chosen_model_provider') == "Custom":
-    st.markdown("""          
-            ### Getting Started
-
-            1. Enter your custom model provider's API key (if required), base URL, and model name.
-            2. Select your industry, company size, and MITRE framework from the sidebar.
-            3. Go to the `Threat Group Scenarios` page to generate a scenario based on a threat actor group or ATLAS case study, or go to the `Custom Scenarios` page to generate a scenario based on your own selection of techniques.
-            4. Use `AttackGen Assistant` to refine / update the generated scenario, or ask more general questions about incident response testing.
-            """)
-
-else:
-    st.markdown("""
-            ### Getting Started
-
-            1. Enter your OpenAI API key, then select your preferred model, industry, company size, and MITRE framework from the sidebar.
-            2. Go to the `Threat Group Scenarios` page to generate a scenario based on a threat actor group or ATLAS case study, or go to the `Custom Scenarios` page to generate a scenario based on your own selection of techniques.
-            3. Use `AttackGen Assistant` to refine / update the generated scenario, or ask more general questions about incident response testing.
+            **Running a local model?** Pick the **Custom** provider and point the base URL at your OpenAI-compatible endpoint (e.g. `http://localhost:11434/v1` for Ollama, `http://localhost:1234/v1` for LM Studio), then type the model name your runtime expects.
             """)
 
 st.markdown("""

--- a/00_👋_Welcome.py
+++ b/00_👋_Welcome.py
@@ -21,6 +21,7 @@ import streamlit as st
 from dotenv import load_dotenv
 
 from core.models import PROVIDERS, get_models_for_provider
+from core.state import restore_from_query_params, sync_to_query_params
 
 # Load environment variables from .env file
 load_dotenv()
@@ -31,6 +32,11 @@ st.set_page_config(
     page_title="AttackGen",
     page_icon="👾",
 )
+
+# Restore sidebar selections from ?p=...&m=... query params (set on previous
+# visits via sync_to_query_params below). Runs before any widgets so that the
+# selectboxes/radios pick up the restored values via their `key=`/`index=`.
+restore_from_query_params()
 
 
 # ------------------ Sidebar ------------------ #
@@ -76,10 +82,15 @@ with st.sidebar:
 
     # ---- Base URL (Custom only) ----
     if provider_info.needs_api_base:
-        env_base = os.getenv("CUSTOM_BASE_URL")
+        initial_base = (
+            st.session_state.get("llm_api_base")
+            or os.getenv("CUSTOM_BASE_URL")
+            or provider_info.default_api_base
+            or ""
+        )
         st.session_state["llm_api_base"] = st.text_input(
             "Base URL:",
-            value=env_base or provider_info.default_api_base or "",
+            value=initial_base,
             help="Base URL of your OpenAI-compatible endpoint. Example: http://localhost:11434/v1 for Ollama, http://localhost:1234/v1 for LM Studio.",
         )
     else:
@@ -87,22 +98,28 @@ with st.sidebar:
 
     # ---- Model selection ----
     models = get_models_for_provider(model_provider)
+    persisted_model = st.session_state.get("llm_model_name")
     if models:
         labels = [m.model_id for m in models]
         help_map = {m.model_id: m.help_text for m in models}
+        # Seed the selectbox's value if the persisted model belongs to this
+        # provider — otherwise (e.g. after switching providers) fall back to
+        # the first option.
+        default_idx = labels.index(persisted_model) if persisted_model in labels else 0
         chosen = st.selectbox(
             "Select the model you would like to use:",
             labels,
-            key="selected_model",
+            index=default_idx,
+            key=f"selected_model_{model_provider}",
             help="\n".join(f"**{mid}** — {help_map[mid] or 'No description.'}" for mid in labels),
         )
         st.session_state["llm_model_name"] = chosen
     else:
         # Custom: user types the model id
-        env_model = os.getenv("CUSTOM_MODEL_NAME")
+        initial_model = persisted_model or os.getenv("CUSTOM_MODEL_NAME") or ""
         st.session_state["llm_model_name"] = st.text_input(
             "Model name:",
-            value=env_model or "",
+            value=initial_model,
             help="Model identifier as expected by your endpoint (e.g. 'llama3.1', 'qwen3:32b').",
         )
 
@@ -116,28 +133,46 @@ with st.sidebar:
     )
     st.session_state["matrix"] = matrix
 
+    industries = sorted([
+        'Aerospace / Defense', 'Agriculture / Food Services',
+        'Automotive', 'Construction', 'Education',
+        'Energy / Utilities', 'Finance / Banking',
+        'Government / Public Sector', 'Healthcare',
+        'Hospitality / Tourism', 'Insurance',
+        'Legal Services', 'Manufacturing',
+        'Media / Entertainment', 'Non-profit',
+        'Real Estate', 'Retail / E-commerce',
+        'Technology / IT', 'Telecommunication',
+        'Transportation / Logistics',
+    ])
+    persisted_industry = st.session_state.get("industry")
     industry = st.selectbox(
         "Select your company's industry:",
-        sorted(['Aerospace / Defense', 'Agriculture / Food Services',
-                'Automotive', 'Construction', 'Education',
-                'Energy / Utilities', 'Finance / Banking',
-                'Government / Public Sector', 'Healthcare',
-                'Hospitality / Tourism', 'Insurance',
-                'Legal Services', 'Manufacturing',
-                'Media / Entertainment', 'Non-profit',
-                'Real Estate', 'Retail / E-commerce',
-                'Technology / IT', 'Telecommunication',
-                'Transportation / Logistics']),
+        industries,
+        index=industries.index(persisted_industry) if persisted_industry in industries else None,
         placeholder="Select Industry",
     )
     st.session_state["industry"] = industry
 
+    sizes = [
+        'Small (1-50 employees)',
+        'Medium (51-200 employees)',
+        'Large (201-1,000 employees)',
+        'Enterprise (1,001-10,000 employees)',
+        'Large Enterprise (10,000+ employees)',
+    ]
+    persisted_size = st.session_state.get("company_size")
     company_size = st.selectbox(
         "Select your company's size:",
-        ['Small (1-50 employees)', 'Medium (51-200 employees)', 'Large (201-1,000 employees)', 'Enterprise (1,001-10,000 employees)', 'Large Enterprise (10,000+ employees)'],
+        sizes,
+        index=sizes.index(persisted_size) if persisted_size in sizes else None,
         placeholder="Select Company Size",
     )
     st.session_state["company_size"] = company_size
+
+    # Mirror the sidebar selections into the URL so a refresh restores them.
+    # API keys are intentionally excluded — see core/state.py.
+    sync_to_query_params()
 
     st.sidebar.markdown("---")
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AttackGen is a cybersecurity incident response testing tool that generates tailored attack scenarios based on MITRE ATT&CK framework and threat actor groups using large language models. It's built as a Streamlit web application with support for multiple LLM providers.
+AttackGen is a cybersecurity incident response testing tool that generates tailored attack scenarios based on the MITRE ATT&CK and ATLAS frameworks using large language models. It is built as a Streamlit web application with support for multiple LLM providers.
 
 ## Development Commands
 
@@ -30,59 +30,62 @@ docker run -p 8501:8501 attackgen
 ## Architecture
 
 ### Core Components
-- **00_👋_Welcome.py**: Main entry point and configuration UI
+- **00_👋_Welcome.py**: Main entry point and configuration UI (sidebar is registry-driven from `core/models.py`)
+- **core/**: Unified LLM wrapper. All provider integration lives here — pages never call provider SDKs directly.
+  - **core/llm.py**: `call_llm(config, messages)` — the single entry point. Routes to providers via LiteLLM, applies provider-specific kwargs, wraps in LangSmith `@traceable` when a LangSmith client is available.
+  - **core/models.py**: Provider + model registry (`PROVIDERS`, `MODELS`). Add or update a model by editing this file alone.
+  - **core/schemas.py**: `LLMConfig` dataclass and `LLMConfig.from_session_state(...)` factory.
 - **pages/**: Streamlit pages for different functionality
-  - **1_🛡️_Threat_Group_Scenarios.py**: Generate scenarios based on threat actor groups
-  - **2_🛠️_Custom_Scenarios.py**: Generate custom scenarios from selected ATT&CK techniques  
+  - **1_🛡️_Threat_Group_Scenarios.py**: Generate scenarios based on threat actor groups (ATT&CK) or case studies (ATLAS)
+  - **2_🛠️_Custom_Scenarios.py**: Generate custom scenarios from selected ATT&CK / ATLAS techniques
   - **3_🤖_AI_Insider_Threat_Scenarios.py**: Generate scenarios where a frontier AI agent deployed inside the organisation acts as an insider threat (based on the "Actions Speak Louder Than Tokens" threat model). Driven by deployment archetype, threat taxonomy, and STRIDE threats rather than a MITRE matrix.
   - **4_💬_AttackGen_Assistant.py**: Chat interface for refining scenarios
 
 ### Data Files
 - **data/enterprise-attack.json**: MITRE ATT&CK Enterprise matrix (STIX format)
 - **data/ics-attack.json**: MITRE ATT&CK ICS matrix (STIX format)
+- **data/stix-atlas.json**: MITRE ATLAS matrix (STIX format)
 - **data/groups.json**: Threat actor group mappings for Enterprise
 - **data/groups_ics.json**: Threat actor group mappings for ICS
+- **data/atlas-case-studies.json**: ATLAS case studies
 - **data/ai_insider_threats.py**: AI insider threat framework (deployment archetypes, threat taxonomy, STRIDE threats, CERT dimensions, detection strategies, NIST CSF controls, and templates) used by the AI Insider Threat Scenarios page
 
 ### Configuration
 - **.env**: API keys and secrets (not tracked in git)
 - **.streamlit/secrets.toml**: Streamlit secrets for LangSmith integration
-- **requirements.txt**: Python dependencies including langchain, streamlit, pandas, mitreattack-python
+- **requirements.txt**: Python dependencies — `litellm`, `streamlit`, `mitreattack-python`, `pandas`, `langsmith`
 
 ### Key Libraries
 - **Streamlit**: Web application framework
-- **LangChain**: LLM integration and prompt management  
+- **LiteLLM**: Unified interface to all LLM providers — wrapped by `core/llm.py`
 - **mitreattack-python**: MITRE ATT&CK data processing
 - **pandas**: Data manipulation for technique selection
 - **python-dotenv**: Environment variable management
+- **langsmith**: Optional tracing (`@traceable`) and feedback logging
 
 ### LLM Provider Support
-The application supports multiple model providers through a unified interface:
-- OpenAI API (using new Responses API)
-- Anthropic API (Claude models)
-- Azure OpenAI Service
-- Google AI API (Gemini models)
+All providers go through `core/llm.py:call_llm`. Currently supported:
+- OpenAI API (GPT-5.x family)
+- Anthropic API (Claude 4.x family)
+- Google AI API (Gemini 3.x family)
 - Mistral API
-- Groq API  
-- Ollama (local models)
-- Custom OpenAI-compatible endpoints
+- Groq API
+- Custom (any OpenAI-compatible endpoint — e.g. `http://localhost:11434/v1` for Ollama, `http://localhost:1234/v1` for LM Studio, OpenRouter, an Azure OpenAI deployment, etc.)
 
-### OpenAI Responses API Integration
-AttackGen now uses OpenAI's latest Responses API for all supported models, providing:
-- Unified interface across all OpenAI models (GPT-5, GPT-4.1, GPT-4o, o-series)
-- Improved response formatting with proper markdown rendering
-- Simplified code architecture without model-specific handling
-- Enhanced structured output parsing from the API
+**Adding a new model** is a one-file change: add a `ModelInfo` entry to the `MODELS` list in `core/models.py`. The sidebar picks it up automatically.
+
+**Adding a new provider** also lives in `core/models.py` — add a `ProviderInfo` entry with the appropriate `litellm_prefix`.
 
 ### Scenario Generation Flow
-1. User selects model provider and configures API credentials
-2. User chooses organization details (industry, size) and ATT&CK matrix
-3. For threat group scenarios: Select threat actor group → Extract techniques → Generate scenario
-4. For custom scenarios: Select individual ATT&CK techniques → Generate scenario
-5. Optional: Use AttackGen Assistant to refine generated scenarios
+1. User selects model provider and configures API credentials (sidebar).
+2. User chooses organisation details (industry, size) and MITRE framework.
+3. For threat group scenarios: select threat actor group / ATLAS case study → extract techniques → generate scenario.
+4. For custom scenarios: select individual ATT&CK / ATLAS techniques → generate scenario.
+5. For AI insider threat scenarios: pick deployment archetype, threat categories and STRIDE threats → generate scenario.
+6. Optional: use the AttackGen Assistant to refine generated scenarios.
 
 ### Environment Variables
-Key environment variables loaded from .env:
-- Model API keys: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, etc.
-- Azure-specific: `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_DEPLOYMENT`
-- Optional: `LANGCHAIN_API_KEY` for LangSmith tracing
+Loaded from `.env`:
+- Model API keys: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `MISTRAL_API_KEY`, `GROQ_API_KEY`, `CUSTOM_API_KEY`
+- Custom endpoint: `CUSTOM_BASE_URL`, `CUSTOM_MODEL_NAME`
+- Optional: `LANGCHAIN_API_KEY` for LangSmith tracing (also configurable via `.streamlit/secrets.toml`)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you find AttackGen useful, please consider starring the repository on GitHub.
 - AttackGen Assistant - a chat interface for updating and/or asking questions about generated scenarios.
 - Capture user feedback on the quality of the generated scenarios.
 - Downloadable scenarios in Markdown format.
-- Use the OpenAI API, Anthropic API (Claude models), Azure OpenAI Service, Google AI API, Mistral API, Groq API, locally hosted Ollama models, or custom OpenAI-compatible API endpoints to generate incident response scenarios.
+- Use the OpenAI API, Anthropic API (Claude models), Google AI API, Mistral API, Groq API, or any custom OpenAI-compatible endpoint (Ollama, LM Studio, Azure OpenAI, OpenRouter, etc.) to generate incident response scenarios. All providers are routed through [LiteLLM](https://github.com/BerriAI/litellm) behind a single internal wrapper, so adding a new model is a one-line change.
 - Available as a Docker container image for easy deployment.
 - Optional integration with [LangSmith](https://docs.smith.langchain.com/) for powerful debugging, testing, and monitoring of model performance.
 - Secure credential management using .env file for API keys and secrets.
@@ -43,7 +43,8 @@ If you find AttackGen useful, please consider starring the repository on GitHub.
 ### v0.12
 | What's new? | Why is it useful? |
 | ----------- | ----------------- |
-| AI Insider Threat Scenarios | - New Scenario Type: A dedicated page generates incident response tabletop exercises in which a frontier AI agent deployed inside your organisation behaves as an insider threat — through misalignment, reward hacking, emergent objectives, or prompt-injection compromise. Based on the threat model from [*Actions Speak Louder Than Tokens: An Insider Threat Model for Frontier AI Agents*](https://ai-insider-threat.matt-adams.co.uk).<br><br>- Deployment Archetype-Driven: Scenarios are shaped by the agent's autonomy level (L1 supervised assistant → L4 fully autonomous fleet), which is the primary determinant of its threat surface and detection posture.<br><br>- Five Insider Threat Categories: Credential Compromise, Supply Chain Sabotage, Data Exfiltration, Infrastructure Sabotage, and Deception & Evasion — each mapped to concrete AI-agent manifestations rather than human motivations.<br><br>- 23 STRIDE Threats for AI Agents: A complete STRIDE taxonomy (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege) adapted for frontier AI agents, optionally used to narrow scenario scope.<br><br>- NIST CSF-Aligned Controls: Generated scenarios include prioritised mitigations mapped to the NIST Cybersecurity Framework (Identify, Protect, Detect, Respond, Recover).<br><br>- Provider Parity: Supports the same provider set as the rest of AttackGen — OpenAI, Anthropic, Azure OpenAI, Google AI, Mistral, Groq, Ollama, and custom OpenAI-compatible endpoints — with optional LangSmith tracing. |
+| AI Insider Threat Scenarios | - New Scenario Type: A dedicated page generates incident response tabletop exercises in which a frontier AI agent deployed inside your organisation behaves as an insider threat — through misalignment, reward hacking, emergent objectives, or prompt-injection compromise. Based on the threat model from [*Actions Speak Louder Than Tokens: An Insider Threat Model for Frontier AI Agents*](https://ai-insider-threat.matt-adams.co.uk).<br><br>- Deployment Archetype-Driven: Scenarios are shaped by the agent's autonomy level (L1 supervised assistant → L4 fully autonomous fleet), which is the primary determinant of its threat surface and detection posture.<br><br>- Five Insider Threat Categories: Credential Compromise, Supply Chain Sabotage, Data Exfiltration, Infrastructure Sabotage, and Deception & Evasion — each mapped to concrete AI-agent manifestations rather than human motivations.<br><br>- 23 STRIDE Threats for AI Agents: A complete STRIDE taxonomy (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege) adapted for frontier AI agents, optionally used to narrow scenario scope.<br><br>- NIST CSF-Aligned Controls: Generated scenarios include prioritised mitigations mapped to the NIST Cybersecurity Framework (Identify, Protect, Detect, Respond, Recover).<br><br>- Provider Parity: Supports the same provider set as the rest of AttackGen with optional LangSmith tracing. |
+| LiteLLM Migration & Provider Consolidation | - Unified LLM Wrapper: All provider integration now flows through a single `core/llm.py` wrapper that uses [LiteLLM](https://github.com/BerriAI/litellm). Adding a new model is a one-line edit to the `MODELS` list in `core/models.py`; adding a provider is a single `ProviderInfo` entry. Mirrors the pattern used in [stride-gpt](https://github.com/mrwadams/stride-gpt).<br><br>- Massive Code Reduction: Removed ~3,800 lines of duplicated per-provider branching across the four pages (~1,000 lines of `if model_provider == ...` blocks plus eight near-identical wrapper functions per page). Each page now builds plain message dicts and calls `call_llm(config, messages)`.<br><br>- Registry-Driven Sidebar: The Welcome sidebar is now generated from the provider registry, replacing eight hand-coded provider blocks with one loop.<br><br>- Refreshed Model Lists: Updated to the latest models — OpenAI GPT-5.5 / 5.4 family, Anthropic Claude 4.6 / 4.7 / 4.8, Google Gemini 3.x preview, Mistral Large 3 / Magistral, Groq GPT-OSS and Qwen3.<br><br>- Provider Consolidation: Replaced the separate Azure OpenAI Service and Ollama entries with a single **Custom (OpenAI-compatible)** option. Azure deployments, Ollama (`http://localhost:11434/v1`), LM Studio (`http://localhost:1234/v1`), OpenRouter and self-hosted endpoints all work through this one path.<br><br>- Smaller Dependency Footprint: Dropped the `langchain`, `langchain-anthropic`, `langchain-core`, `langchain-community`, `langchain-google-genai`, `langchain-mistralai`, `langchain-openai` and `anthropic` packages — replaced by a single `litellm>=1.40` dependency. `langsmith` is retained for optional tracing.<br><br>- LangSmith Tracing Preserved: The `@traceable` decorator and feedback widget continue to work transparently; `core/llm.py` wraps `call_llm` in `@traceable` when a LangSmith client is available. |
 | Docker Image Security Refresh | - Refreshed Base Image: Updated the `python:3.12-slim` digest to clear stale OS-layer CVEs flagged by Trivy code scanning, reducing the open alert count against the published container image.<br><br>- pip CVE-2025-8869 Fix: `pip` is now upgraded before installing requirements, picking up the fix for missing symlink checks during package extraction. |
 
 ### v0.11
@@ -235,8 +236,8 @@ This command will start the container and map port 8501 (default for Streamlit a
 ### Generating Scenarios
 
 #### Standard Scenario Generation
-1. Choose whether to use the OpenAI API, Azure OpenAI Service, Google AI API, Mistral API, Groq API, or locally hosted Ollama models.
-2. Enter your API key for the chosen model provider, or the API key and deployment details for your model on the Azure OpenAI Service.
+1. Choose whether to use the OpenAI API, Anthropic API, Google AI API, Mistral API, Groq API, or a custom OpenAI-compatible endpoint (for Ollama, LM Studio, Azure OpenAI deployments, OpenRouter, etc.).
+2. Enter your API key for the chosen provider. For the Custom provider, also enter the base URL and model name.
 3. Select your preferred model from the dropdown.
 4. Select your organisation's industry and size from the dropdown menus.
 5. Navigate to the `Threat Group Scenarios` page.
@@ -245,8 +246,8 @@ This command will start the container and map port 8501 (default for Streamlit a
 8. Use the 👍 or 👎 buttons to provide feedback on the quality of the generated scenario. N.B. The feedback buttons only appear if a value for LANGCHAIN_API_KEY has been set in the `.streamlit/secrets.toml` file.
 
 #### Custom Scenario Generation
-1. Choose whether to use the OpenAI API, Azure OpenAI Service, Google AI API, Mistral API, Groq API, or locally hosted Ollama models.
-2. Enter your API key for the chosen model provider, or the API key and deployment details for your model on the Azure OpenAI Service.
+1. Choose whether to use the OpenAI API, Anthropic API, Google AI API, Mistral API, Groq API, or a custom OpenAI-compatible endpoint.
+2. Enter your API key for the chosen provider. For the Custom provider, also enter the base URL and model name.
 3. Select your preferred model from the dropdown.
 4. Select your organisation's industry and size from the dropdown menus.
 5. Navigate to the `Custom Scenario` page.
@@ -255,7 +256,7 @@ This command will start the container and map port 8501 (default for Streamlit a
 8. Use the 👍 or 👎 buttons to provide feedback on the quality of the generated scenario. N.B. The feedback buttons only appear if a value for LANGCHAIN_API_KEY has been set in the `.streamlit/secrets.toml` file.
 
 #### AI Insider Threat Scenario Generation
-1. Choose your model provider and enter the relevant API key (or deployment details for the Azure OpenAI Service).
+1. Choose your model provider and enter the relevant API key (use the Custom provider for Azure OpenAI deployments or local models).
 2. Select your preferred model from the dropdown.
 3. Select your organisation's industry and size from the dropdown menus.
 4. Navigate to the `AI Insider Threat Scenarios` page.

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,19 @@
+"""Unified LLM wrapper for AttackGen.
+
+All provider integration lives in `core/llm.py`. Never call `litellm.completion`
+directly from outside this package — go through `call_llm`.
+"""
+
+from core.llm import call_llm
+from core.models import PROVIDERS, MODELS, ModelInfo, ProviderInfo, get_models_for_provider
+from core.schemas import LLMConfig
+
+__all__ = [
+    "call_llm",
+    "LLMConfig",
+    "PROVIDERS",
+    "MODELS",
+    "ModelInfo",
+    "ProviderInfo",
+    "get_models_for_provider",
+]

--- a/core/llm.py
+++ b/core/llm.py
@@ -99,6 +99,13 @@ def _build_litellm_kwargs(config: LLMConfig) -> dict:
         kwargs["safety_settings"] = GEMINI_SAFETY_SETTINGS
 
     if provider and provider.provider_key == "Custom":
+        # Force the OpenAI-compatible path explicitly. LiteLLM's model-string
+        # auto-detection misroutes when the user-typed model name contains a
+        # slash (e.g. "qwen/qwen3-32b"), interpreting the part before the slash
+        # as the provider. Setting custom_llm_provider bypasses that, and we
+        # pass the bare model name so the endpoint receives it unchanged.
+        kwargs["model"] = config.model_name
+        kwargs["custom_llm_provider"] = "openai"
         # litellm needs an api_key even when the endpoint doesn't require one.
         kwargs.setdefault("api_key", "not-required")
 

--- a/core/llm.py
+++ b/core/llm.py
@@ -51,14 +51,12 @@ GEMINI_SAFETY_SETTINGS = [
 try:
     from langsmith import Client
     from langsmith.run_helpers import traceable
-    from langsmith.run_trees import RunTree
 
     _langsmith_api_key = os.getenv("LANGCHAIN_API_KEY")
     _langsmith_client: Client | None = Client() if _langsmith_api_key else None
 except Exception:
     _langsmith_client = None
     traceable = None  # type: ignore[assignment]
-    RunTree = None  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
@@ -137,7 +135,7 @@ def call_llm(config: LLMConfig, messages: list[dict]) -> str:
             tags=list(config.trace_tags),
             client=_langsmith_client,
         )
-        def _traced(messages: list[dict], *, run_tree: "RunTree") -> str:
+        def _traced(messages: list[dict], *, run_tree) -> str:
             content = _raw_call(config, messages)
             st.session_state["run_id"] = str(run_tree.id)
             return content

--- a/core/llm.py
+++ b/core/llm.py
@@ -1,0 +1,140 @@
+"""Unified LLM interface. All providers routed through LiteLLM.
+
+Public entrypoint: `call_llm(config, messages) -> str`.
+
+Provider-specific quirks (Gemini safety, Anthropic max_tokens, OpenAI reasoning
+models, Custom api_base) are handled in `_build_litellm_kwargs` and driven off
+the registry in `core/models.py`, not by name-matching at the call site.
+
+LangSmith tracing wraps `call_llm` via `@traceable` when a `Client` is available;
+the active run id is stashed in `st.session_state['run_id']` so the existing
+feedback widget on each page continues to work without changes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+# Silence LiteLLM's import-time WARNINGs about optional AWS deps (Bedrock /
+# SageMaker pre-load) — we don't use them, and they fire before
+# `litellm.suppress_debug_info = True` would take effect.
+logging.getLogger("LiteLLM").setLevel(logging.ERROR)
+
+import litellm  # noqa: E402  (logger setup above must run first)
+import streamlit as st  # noqa: E402
+
+from core.models import (
+    get_litellm_prefix,
+    get_provider,
+    model_uses_completion_tokens,
+)
+from core.schemas import LLMConfig
+
+# Suppress LiteLLM's verbose logging
+litellm.suppress_debug_info = True
+
+
+# Gemini safety settings — allow security-related content generation
+GEMINI_SAFETY_SETTINGS = [
+    {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"},
+    {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"},
+    {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_NONE"},
+    {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_NONE"},
+]
+
+
+# ---------------------------------------------------------------------------
+# LangSmith setup — optional. Kept for the existing feedback widget.
+# ---------------------------------------------------------------------------
+
+try:
+    from langsmith import Client
+    from langsmith.run_helpers import traceable
+    from langsmith.run_trees import RunTree
+
+    _langsmith_api_key = os.getenv("LANGCHAIN_API_KEY")
+    _langsmith_client: Client | None = Client() if _langsmith_api_key else None
+except Exception:
+    _langsmith_client = None
+    traceable = None  # type: ignore[assignment]
+    RunTree = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# LiteLLM kwargs assembly
+# ---------------------------------------------------------------------------
+
+
+def _build_litellm_kwargs(config: LLMConfig) -> dict:
+    provider = get_provider(config.provider)
+    prefix = get_litellm_prefix(config.provider)
+    model = prefix + config.model_name
+
+    kwargs: dict = {
+        "model": model,
+        "temperature": config.temperature,
+        # Retry transient errors (429s, timeouts, 5xx). LiteLLM defers to the
+        # provider SDK, which uses exponential backoff and respects Retry-After.
+        "num_retries": 3,
+    }
+
+    if config.api_key:
+        kwargs["api_key"] = config.api_key
+
+    if config.api_base:
+        kwargs["api_base"] = config.api_base
+
+    # OpenAI reasoning models (gpt-5.x) use max_completion_tokens
+    if model_uses_completion_tokens(config.provider, config.model_name):
+        if config.max_tokens:
+            kwargs["max_completion_tokens"] = config.max_tokens
+    elif config.provider == "Anthropic API":
+        # Anthropic requires max_tokens; default generously for full scenarios.
+        kwargs["max_tokens"] = config.max_tokens or 16000
+    elif config.max_tokens:
+        kwargs["max_tokens"] = config.max_tokens
+
+    if config.provider == "Google AI API":
+        kwargs["safety_settings"] = GEMINI_SAFETY_SETTINGS
+
+    if provider and provider.provider_key == "Custom":
+        # litellm needs an api_key even when the endpoint doesn't require one.
+        kwargs.setdefault("api_key", "not-required")
+
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _raw_call(config: LLMConfig, messages: list[dict]) -> str:
+    kwargs = _build_litellm_kwargs(config)
+    response = litellm.completion(messages=messages, **kwargs)
+    return response.choices[0].message.content or ""
+
+
+def call_llm(config: LLMConfig, messages: list[dict]) -> str:
+    """Generate a single text response from any supported provider.
+
+    Returns the assistant's content as a plain string. Raises on transport
+    errors after LiteLLM has exhausted its retries — callers handle that with
+    a try/except + st.error, the same pattern the old per-provider wrappers used.
+    """
+    if _langsmith_client is not None and traceable is not None:
+        @traceable(
+            run_type="llm",
+            name=config.trace_name,
+            tags=list(config.trace_tags),
+            client=_langsmith_client,
+        )
+        def _traced(messages: list[dict], *, run_tree: "RunTree") -> str:
+            content = _raw_call(config, messages)
+            st.session_state["run_id"] = str(run_tree.id)
+            return content
+
+        return _traced(messages)
+
+    return _raw_call(config, messages)

--- a/core/models.py
+++ b/core/models.py
@@ -1,0 +1,252 @@
+"""Unified model registry — single source of truth for providers and models.
+
+To add or update a model, edit the MODELS list below. Nothing else needs to change.
+Mirrored from mrwadams/stride-gpt:stride_gpt/models.py (reviewed 2026-05-30).
+
+Provider model listing pages:
+  - Anthropic: https://docs.anthropic.com/en/docs/about-claude/models
+  - OpenAI:    https://platform.openai.com/docs/models
+  - Google AI: https://ai.google.dev/gemini-api/docs/models
+  - Mistral:   https://docs.mistral.ai/getting-started/models
+  - Groq:      https://console.groq.com/docs/models
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProviderInfo:
+    name: str                          # Display name shown in the sidebar
+    provider_key: str                  # Routing key used in LLMConfig.provider
+    litellm_prefix: str                # Prefix prepended to model_name for LiteLLM
+    env_var: str | None = None         # .env variable that supplies the API key
+    needs_api_key: bool = True
+    needs_api_base: bool = False
+    default_api_base: str | None = None
+    api_key_url: str = ""              # Where the user can generate a key
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    model_id: str
+    provider_key: str
+    uses_max_completion_tokens: bool = False   # OpenAI reasoning models (gpt-5.x)
+    supports_thinking: bool = False            # Claude/Gemini extended thinking
+    help_text: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Provider registry — order determines sidebar display order
+# ---------------------------------------------------------------------------
+
+PROVIDERS: dict[str, ProviderInfo] = {
+    "OpenAI API": ProviderInfo(
+        name="OpenAI",
+        provider_key="OpenAI API",
+        litellm_prefix="",
+        env_var="OPENAI_API_KEY",
+        api_key_url="https://platform.openai.com/account/api-keys",
+    ),
+    "Anthropic API": ProviderInfo(
+        name="Anthropic",
+        provider_key="Anthropic API",
+        litellm_prefix="anthropic/",
+        env_var="ANTHROPIC_API_KEY",
+        api_key_url="https://console.anthropic.com/settings/keys",
+    ),
+    "Google AI API": ProviderInfo(
+        name="Google AI",
+        provider_key="Google AI API",
+        litellm_prefix="gemini/",
+        env_var="GOOGLE_API_KEY",
+        api_key_url="https://makersuite.google.com/app/apikey",
+    ),
+    "Mistral API": ProviderInfo(
+        name="Mistral",
+        provider_key="Mistral API",
+        litellm_prefix="mistral/",
+        env_var="MISTRAL_API_KEY",
+        api_key_url="https://console.mistral.ai/api-keys/",
+    ),
+    "Groq API": ProviderInfo(
+        name="Groq",
+        provider_key="Groq API",
+        litellm_prefix="groq/",
+        env_var="GROQ_API_KEY",
+        api_key_url="https://console.groq.com/keys",
+    ),
+    "Custom": ProviderInfo(
+        name="Custom (OpenAI-compatible)",
+        provider_key="Custom",
+        litellm_prefix="openai/",
+        env_var="CUSTOM_API_KEY",
+        needs_api_key=False,           # Many local endpoints don't need a key
+        needs_api_base=True,
+        default_api_base="http://localhost:11434/v1",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Model registry — order determines UI display order per provider
+# ---------------------------------------------------------------------------
+
+MODELS: list[ModelInfo] = [
+    # --- OpenAI ---
+    ModelInfo(
+        model_id="gpt-5.5",
+        provider_key="OpenAI API",
+        uses_max_completion_tokens=True,
+        help_text="GPT-5.5 is OpenAI's latest flagship model.",
+    ),
+    ModelInfo(
+        model_id="gpt-5.4",
+        provider_key="OpenAI API",
+        uses_max_completion_tokens=True,
+        help_text="GPT-5.4 is OpenAI's previous flagship model with 1M+ context.",
+    ),
+    ModelInfo(
+        model_id="gpt-5.4-pro",
+        provider_key="OpenAI API",
+        uses_max_completion_tokens=True,
+        help_text="GPT-5.4 Pro produces smarter, more precise responses.",
+    ),
+    ModelInfo(
+        model_id="gpt-5.4-mini",
+        provider_key="OpenAI API",
+        uses_max_completion_tokens=True,
+        help_text="GPT-5.4 Mini is a fast, cost-efficient version.",
+    ),
+    ModelInfo(
+        model_id="gpt-5.4-nano",
+        provider_key="OpenAI API",
+        uses_max_completion_tokens=True,
+        help_text="GPT-5.4 Nano is the fastest and most affordable option.",
+    ),
+    # --- Anthropic ---
+    ModelInfo(
+        model_id="claude-sonnet-4-6",
+        provider_key="Anthropic API",
+        supports_thinking=True,
+        help_text="Claude Sonnet 4.6 offers the best balance of performance and efficiency.",
+    ),
+    ModelInfo(
+        model_id="claude-opus-4-8",
+        provider_key="Anthropic API",
+        supports_thinking=True,
+        help_text="Claude Opus 4.8 is the most capable Claude model.",
+    ),
+    ModelInfo(
+        model_id="claude-opus-4-7",
+        provider_key="Anthropic API",
+        supports_thinking=True,
+        help_text="Claude Opus 4.7 is the previous-generation Opus.",
+    ),
+    ModelInfo(
+        model_id="claude-haiku-4-5-20251001",
+        provider_key="Anthropic API",
+        help_text="Claude Haiku 4.5 is the fastest and most cost-effective Claude model.",
+    ),
+    # --- Google AI ---
+    ModelInfo(
+        model_id="gemini-3.1-pro-preview",
+        provider_key="Google AI API",
+        supports_thinking=True,
+        help_text="Gemini 3.1 Pro is Google's most capable model with 1M context.",
+    ),
+    ModelInfo(
+        model_id="gemini-3.5-flash",
+        provider_key="Google AI API",
+        supports_thinking=True,
+        help_text="Gemini 3.5 Flash is Google's latest fast model with 1M context.",
+    ),
+    ModelInfo(
+        model_id="gemini-3.1-flash-lite",
+        provider_key="Google AI API",
+        supports_thinking=True,
+        help_text="Gemini 3.1 Flash Lite is the most cost-efficient option with 1M context.",
+    ),
+    ModelInfo(
+        model_id="gemini-3-flash-preview",
+        provider_key="Google AI API",
+        supports_thinking=True,
+        help_text="Gemini 3 Flash is optimized for speed with 1M context.",
+    ),
+    # --- Mistral ---
+    ModelInfo(
+        model_id="mistral-large-2512",
+        provider_key="Mistral API",
+        help_text="Mistral Large 3 offers premium capabilities.",
+    ),
+    ModelInfo(
+        model_id="mistral-small-2603",
+        provider_key="Mistral API",
+        help_text="Mistral Small 4 merges reasoning, vision, and coding in a 256k-context model.",
+    ),
+    ModelInfo(
+        model_id="mistral-medium-3-5",
+        provider_key="Mistral API",
+        help_text="Mistral Medium 3.5 provides balanced performance.",
+    ),
+    ModelInfo(
+        model_id="mistral-medium-2508",
+        provider_key="Mistral API",
+        help_text="Mistral Medium 3.1 provides balanced performance.",
+    ),
+    ModelInfo(
+        model_id="magistral-medium-2509",
+        provider_key="Mistral API",
+        help_text="Magistral Medium is a reasoning-focused model.",
+    ),
+    # --- Groq ---
+    ModelInfo(
+        model_id="openai/gpt-oss-120b",
+        provider_key="Groq API",
+        help_text="GPT-OSS 120B is an open-source reasoning model on Groq.",
+    ),
+    ModelInfo(
+        model_id="openai/gpt-oss-20b",
+        provider_key="Groq API",
+        help_text="GPT-OSS 20B is a fast open-source model on Groq.",
+    ),
+    ModelInfo(
+        model_id="llama-3.3-70b-versatile",
+        provider_key="Groq API",
+        help_text="Llama 3.3 70B excels at general-purpose tasks.",
+    ),
+    ModelInfo(
+        model_id="qwen/qwen3-32b",
+        provider_key="Groq API",
+        help_text="Qwen3 32B delivers balanced performance.",
+    ),
+    # --- Custom: no static list; the user types the model name in the sidebar ---
+]
+
+
+_MODEL_LOOKUP: dict[tuple[str, str], ModelInfo] = {
+    (m.provider_key, m.model_id): m for m in MODELS
+}
+
+
+def get_models_for_provider(provider_key: str) -> list[ModelInfo]:
+    return [m for m in MODELS if m.provider_key == provider_key]
+
+
+def get_model(provider_key: str, model_id: str) -> ModelInfo | None:
+    return _MODEL_LOOKUP.get((provider_key, model_id))
+
+
+def get_provider(provider_key: str) -> ProviderInfo | None:
+    return PROVIDERS.get(provider_key)
+
+
+def get_litellm_prefix(provider_key: str) -> str:
+    provider = PROVIDERS.get(provider_key)
+    return provider.litellm_prefix if provider else ""
+
+
+def model_uses_completion_tokens(provider_key: str, model_id: str) -> bool:
+    model = get_model(provider_key, model_id)
+    return bool(model and model.uses_max_completion_tokens)

--- a/core/models.py
+++ b/core/models.py
@@ -84,7 +84,7 @@ PROVIDERS: dict[str, ProviderInfo] = {
         env_var="CUSTOM_API_KEY",
         needs_api_key=False,           # Many local endpoints don't need a key
         needs_api_base=True,
-        default_api_base="http://localhost:11434/v1",
+        default_api_base="http://127.0.0.1:1234/v1",
     ),
 }
 

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -1,0 +1,41 @@
+"""Data models for LLM configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import streamlit as st
+
+
+@dataclass
+class LLMConfig:
+    """Configuration for a single LLM call.
+
+    Constructed by the UI layer from session state via `from_session_state`.
+    """
+
+    provider: str           # "OpenAI API", "Anthropic API", "Google AI API", "Mistral API", "Groq API", "Custom"
+    model_name: str         # Bare model id, e.g. "gpt-5.5", "claude-sonnet-4-6"
+    api_key: str | None = None
+    api_base: str | None = None      # For Custom (OpenAI-compatible) endpoints
+    temperature: float = 0.7
+    max_tokens: int | None = None
+    trace_name: str = "AttackGen LLM call"
+    trace_tags: tuple[str, ...] = ()
+
+    @classmethod
+    def from_session_state(
+        cls,
+        *,
+        trace_name: str = "AttackGen LLM call",
+        trace_tags: tuple[str, ...] = (),
+    ) -> "LLMConfig":
+        """Build an LLMConfig from the keys the Welcome sidebar populates."""
+        return cls(
+            provider=st.session_state.get("chosen_model_provider", "OpenAI API"),
+            model_name=st.session_state.get("llm_model_name", ""),
+            api_key=st.session_state.get("llm_api_key") or None,
+            api_base=st.session_state.get("llm_api_base") or None,
+            trace_name=trace_name,
+            trace_tags=trace_tags,
+        )

--- a/core/state.py
+++ b/core/state.py
@@ -1,0 +1,78 @@
+"""Sidebar-state persistence via URL query parameters.
+
+Streamlit's `st.session_state` is per-session and gets reset on browser refresh
+or when the user lands on a page directly. To keep the sidebar selections
+between refreshes (without storing API keys in the URL) we mirror a small set
+of keys into the URL via `st.query_params`.
+
+Every page calls `restore_from_query_params()` near the top so that a deep link
+to e.g. page 3 also restores the provider/model/industry the user had selected.
+The Welcome sidebar additionally calls `sync_to_query_params()` after rendering
+its widgets so the URL stays in sync as the user changes selections.
+
+API keys are intentionally excluded — the URL would expose them in browser
+history, server logs, and any link the user shares.
+"""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from core.models import PROVIDERS
+
+# Mapping: session_state key → short query-param name
+PERSISTED: dict[str, str] = {
+    "chosen_model_provider": "p",
+    "llm_model_name": "m",
+    "llm_api_base": "b",
+    "selected_matrix": "x",
+    "industry": "i",
+    "company_size": "s",
+}
+
+_QP_KEYS = set(PERSISTED.values())
+_VALID_MATRICES = {"Enterprise", "ICS", "ATLAS"}
+
+
+def restore_from_query_params() -> None:
+    """Seed `st.session_state` from the URL on first script run.
+
+    Safe to call multiple times — only sets keys that aren't already in
+    session_state, so user-driven widget changes always win over the URL.
+    """
+    qp = st.query_params
+    for ss_key, qp_key in PERSISTED.items():
+        if ss_key in st.session_state:
+            continue
+        if qp_key not in qp:
+            continue
+        value = qp[qp_key]
+        # Drop values that no longer correspond to a known provider/matrix —
+        # otherwise a stale URL could put us in an invalid state.
+        if ss_key == "chosen_model_provider" and value not in PROVIDERS:
+            continue
+        if ss_key == "selected_matrix" and value not in _VALID_MATRICES:
+            continue
+        st.session_state[ss_key] = value
+
+
+def sync_to_query_params() -> None:
+    """Mirror the current session_state into the URL.
+
+    Only rewrites if the managed keys have actually changed — avoids gratuitous
+    URL churn and any chance of a rerun loop.
+    """
+    desired = {
+        qp_key: str(st.session_state[ss_key])
+        for ss_key, qp_key in PERSISTED.items()
+        if st.session_state.get(ss_key)
+    }
+    current = {k: v for k, v in st.query_params.items() if k in _QP_KEYS}
+    if current == desired:
+        return
+
+    for k in list(st.query_params.keys()):
+        if k in _QP_KEYS:
+            del st.query_params[k]
+    for k, v in desired.items():
+        st.query_params[k] = v

--- a/core/state.py
+++ b/core/state.py
@@ -20,12 +20,15 @@ import streamlit as st
 
 from core.models import PROVIDERS
 
-# Mapping: session_state key → short query-param name
+# Mapping: session_state key → short query-param name.
+# These are *shadow* keys (not widget `key=` values). Streamlit clears
+# widget-key entries from session_state when navigating to a page that doesn't
+# host the widget; shadow keys persist across navigation regardless.
 PERSISTED: dict[str, str] = {
     "chosen_model_provider": "p",
     "llm_model_name": "m",
     "llm_api_base": "b",
-    "selected_matrix": "x",
+    "matrix": "x",
     "industry": "i",
     "company_size": "s",
 }
@@ -51,7 +54,7 @@ def restore_from_query_params() -> None:
         # otherwise a stale URL could put us in an invalid state.
         if ss_key == "chosen_model_provider" and value not in PROVIDERS:
             continue
-        if ss_key == "selected_matrix" and value not in _VALID_MATRICES:
+        if ss_key == "matrix" and value not in _VALID_MATRICES:
             continue
         st.session_state[ss_key] = value
 

--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -9,6 +9,11 @@ from mitreattack.stix20 import MitreAttackData
 from atlas_parser import ATLASData, get_techniques_from_case_study_procedure
 from core.llm import call_llm
 from core.schemas import LLMConfig
+from core.state import restore_from_query_params
+
+# Restore sidebar selections on direct page loads (e.g. browser refresh while
+# on this page). See core/state.py for the persisted-keys list.
+restore_from_query_params()
 
 
 # ------------------ LangSmith Setup ------------------ #

--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -1,808 +1,72 @@
 import os
-import pandas as pd
-import streamlit as st
 import re
 
-from langchain_anthropic import ChatAnthropic
-from langchain_community.llms import Ollama
-from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain_mistralai.chat_models import ChatMistralAI
-from langchain_openai import ChatOpenAI, AzureOpenAI
-from langchain_core.prompts import ChatPromptTemplate, HumanMessagePromptTemplate, SystemMessagePromptTemplate
-from langsmith import Client, RunTree, traceable
+import pandas as pd
+import streamlit as st
+from langsmith import Client
 from mitreattack.stix20 import MitreAttackData
-from openai import OpenAI
 
-from atlas_parser import ATLASData, load_atlas_case_studies, get_techniques_from_case_study_procedure
+from atlas_parser import ATLASData, get_techniques_from_case_study_procedure
+from core.llm import call_llm
+from core.schemas import LLMConfig
 
 
-# ------------------ Streamlit UI Configuration ------------------ #
+# ------------------ LangSmith Setup ------------------ #
 
-# Add environment variables for LangSmith
-os.environ["LANGCHAIN_TRACING_V2"]="true"
+os.environ["LANGCHAIN_TRACING_V2"] = "true"
 os.environ["LANGCHAIN_ENDPOINT"] = "https://api.smith.langchain.com"
 os.environ["LANGCHAIN_PROJECT"] = "AttackGen"
 
-# Initialise the LangSmith client conditionally based on the presence of an API key
 if "LANGCHAIN_API_KEY" in st.secrets:
-    langchain_api_key = st.secrets["LANGCHAIN_API_KEY"]
-    client = Client(api_key=langchain_api_key)
+    client = Client(api_key=st.secrets["LANGCHAIN_API_KEY"])
 else:
     client = None
 
-# Add environment variables from session state for Azure OpenAI Service
-if "AZURE_OPENAI_API_KEY" in st.session_state:
-    os.environ["AZURE_OPENAI_API_KEY"] = st.session_state["AZURE_OPENAI_API_KEY"]
-if "AZURE_OPENAI_ENDPOINT" in st.session_state:
-    os.environ["AZURE_OPENAI_ENDPOINT"] = st.session_state["AZURE_OPENAI_ENDPOINT"]
-if "azure_deployment" in st.session_state:
-    os.environ["AZURE_DEPLOYMENT"] = st.session_state["azure_deployment"]
-if "openai_api_version" in st.session_state:
-    os.environ["OPENAI_API_VERSION"] = st.session_state["openai_api_version"]
 
-# Add environment variables from session state for Google AI API
-if "GOOGLE_API_KEY" in st.session_state:
-    os.environ["GOOGLE_API_KEY"] = st.session_state["GOOGLE_API_KEY"]
-if "google_model" in st.session_state:
-    os.environ["GOOGLE_MODEL"] = st.session_state["google_model"]
+# ------------------ Streamlit Configuration ------------------ #
 
-# Add environment variables from session state for Mistral API
-if "MISTRAL_API_KEY" in st.session_state:
-    os.environ["MISTRAL_API_KEY"] = st.session_state["MISTRAL_API_KEY"]
-if "mistral_model" in st.session_state:
-    os.environ["MISTRAL_MODEL"] = st.session_state["mistral_model"]
+st.set_page_config(page_title="Generate Scenario", page_icon="🛡️")
 
-# Add environment variables from session state for Groq API
-if "GROQ_API_KEY" in st.session_state:
-    os.environ["GROQ_API_KEY"] = st.session_state["GROQ_API_KEY"]
-if "groq_model" in st.session_state:
-    os.environ["GROQ_MODEL"] = st.session_state["groq_model"]
+model_provider = st.session_state.get("chosen_model_provider", "OpenAI API")
+industry = st.session_state.get("industry")
+company_size = st.session_state.get("company_size")
 
-# Add environment variables from session state for Ollama
-if "ollama_model" in st.session_state:
-    os.environ["OLLAMA_MODEL"] = st.session_state["ollama_model"]
-
-# Add environment variables from session state for OpenAI API
-if "OPENAI_API_KEY" in st.session_state:
-    os.environ["OPENAI_API_KEY"] = st.session_state["OPENAI_API_KEY"]
-if "openai_model" in st.session_state:
-    os.environ["OPENAI_MODEL"] = st.session_state["openai_model"]
-if "openai_base_url" in st.session_state:
-    os.environ["OPENAI_BASE_URL"] = st.session_state["openai_base_url"]
-
-# Add environment variables from session state for Anthropic API
-if "ANTHROPIC_API_KEY" in st.session_state:
-    os.environ["ANTHROPIC_API_KEY"] = st.session_state["ANTHROPIC_API_KEY"]
-if "anthropic_model" in st.session_state:
-    os.environ["ANTHROPIC_MODEL"] = st.session_state["anthropic_model"]
-
-# Get the model provider and other required session state variables
-model_provider = st.session_state["chosen_model_provider"]
-industry = st.session_state["industry"]
-company_size = st.session_state["company_size"]
-
-# Set the default value for the scenario_generated session state variable
 if "scenario_generated" not in st.session_state:
     st.session_state["scenario_generated"] = False
 
-st.set_page_config(
-    page_title="Generate Scenario",
-    page_icon="🛡️",
-)
 
-# ------------------ Helper Functions ------------------ #
+# ------------------ Data Loading ------------------ #
 
-# Load and cache the MITRE ATT&CK and ATLAS data
 @st.cache_resource
 def load_attack_data():
-    enterprise_data = MitreAttackData("./data/enterprise-attack.json")
-    ics_data = MitreAttackData("./data/ics-attack.json")
-    atlas_data = ATLASData("./data/stix-atlas.json")
-    return {"enterprise": enterprise_data, "ics": ics_data, "atlas": atlas_data}
+    return {
+        "enterprise": MitreAttackData("./data/enterprise-attack.json"),
+        "ics": MitreAttackData("./data/ics-attack.json"),
+        "atlas": ATLASData("./data/stix-atlas.json"),
+    }
+
 
 attack_data = load_attack_data()
+
 
 @st.cache_resource
 def load_groups(matrix):
     if matrix == "Enterprise":
-        groups = pd.read_json("./data/groups.json")
-    elif matrix == "ICS":
-        groups = pd.read_json("./data/groups_ics.json")
-    else:  # ATLAS
-        groups = pd.read_json("./data/atlas-case-studies.json")
-    return groups
+        return pd.read_json("./data/groups.json")
+    if matrix == "ICS":
+        return pd.read_json("./data/groups_ics.json")
+    return pd.read_json("./data/atlas-case-studies.json")
 
-def generate_scenario_wrapper(openai_api_key, model_name, messages):
-    if client is not None:  # If LangChain client has been initialized
-        @traceable(run_type="llm", name="Threat Group Scenario", tags=["openai", "threat_group_scenario"], client=client)
-        def generate_scenario(openai_api_key, model_name, messages, *, run_tree: RunTree):
-            model_name = st.session_state["model_name"]
-            try:
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    
-                    # All models use the unified Responses API
-                    llm = ChatOpenAI(openai_api_key=openai_api_key, model_name=model_name, streaming=False, output_version="responses/v1")
-                    
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)  # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                st.error("An error occurred while generating the scenario: " + str(e))
-                st.session_state['run_id'] = str(run_tree.id)  # Ensure run_id is updated even on failure
-                return None
-    else:  # If LangChain client has not been initialized
-        def generate_scenario(openai_api_key, model_name, messages):
-            model_name = st.session_state["model_name"]
-            try:
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    
-                    # All models use the unified Responses API
-                    llm = ChatOpenAI(openai_api_key=openai_api_key, model_name=model_name, streaming=False, output_version="responses/v1")
-                    
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error("An error occurred while generating the scenario: " + str(e))
-                return None
-    
-    return generate_scenario(openai_api_key, model_name, messages)
 
-def generate_scenario_azure_wrapper(messages):
-    if client is not None:  # LangSmith client has been initialised
-        @traceable(run_type="llm", name="Threat Group Scenario (Azure OpenAI)", tags=["azure", "threat_group_scenario"], client=client if client is not None else None)
-        def generate_scenario_azure(messages, *, run_tree: RunTree):
-            try:
-                azure_api_key = os.getenv('AZURE_OPENAI_API_KEY')
-                azure_api_endpoint = os.getenv('AZURE_OPENAI_ENDPOINT')
-                azure_deployment_name = os.getenv('AZURE_DEPLOYMENT')
-                azure_api_version = os.getenv('OPENAI_API_VERSION')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = AzureOpenAI(api_key=azure_api_key,
-                                      azure_endpoint=azure_api_endpoint,
-                                      api_version=azure_api_version)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    
-                    # Convert message objects to the expected format
-                    formatted_messages = []
-                    for message in messages:
-                        if hasattr(message, 'role') and hasattr(message, 'content'):
-                            role = message.role
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        elif hasattr(message, 'type') and hasattr(message, 'content'):
-                            role = message.type
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        else:
-                            raise ValueError(f"Unsupported message format: {message}")
-                    
-                    response = llm.chat.completions.create(
-                        model=azure_deployment_name,
-                        messages=formatted_messages
-                    )
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)  # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)  # Ensure run_id is updated even on failure
-                return None
-    else:  # LangSmith client has not been initialised
-        def generate_scenario_azure(messages):
-            try:
-                azure_api_key = os.getenv('AZURE_OPENAI_API_KEY')
-                azure_api_endpoint = os.getenv('AZURE_OPENAI_ENDPOINT')
-                azure_deployment_name = os.getenv('AZURE_DEPLOYMENT')
-                azure_api_version = os.getenv('OPENAI_API_VERSION')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = AzureOpenAI(api_key=azure_api_key,
-                                      azure_endpoint=azure_api_endpoint,
-                                      api_version=azure_api_version)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    
-                    # Convert message objects to the expected format
-                    formatted_messages = []
-                    for message in messages:
-                        if hasattr(message, 'role') and hasattr(message, 'content'):
-                            role = message.role
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        elif hasattr(message, 'type') and hasattr(message, 'content'):
-                            role = message.type
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        else:
-                            raise ValueError(f"Unsupported message format: {message}")
-                    
-                    response = llm.chat.completions.create(
-                        model=azure_deployment_name,
-                        messages=formatted_messages
-                    )
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    return generate_scenario_azure(messages)
+# ------------------ Prompt Construction ------------------ #
 
-def generate_scenario_google_wrapper(google_api_key, model, messages):
-    if client is not None: # If LangSmith client has been initialised
-        @traceable(run_type="llm", name="Threat Group Scenario (Google AI API)", tags=["google", "threat_group_scenario"], client=client)
-        def generate_scenario_google(google_api_key, model, messages, *, run_tree: RunTree):
-            try:
-                google_api_key = os.getenv('GOOGLE_API_KEY')
-                model = os.getenv('GOOGLE_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatGoogleGenerativeAI(google_api_key=google_api_key, model=model)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id) # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id) # Ensure run_id is updated even on failure
-                return None
-    else: # If LangSmith client has not been initialised
-        def generate_scenario_google(google_api_key, model, messages):
-            try:
-                google_api_key = os.getenv('GOOGLE_API_KEY')
-                model = os.getenv('GOOGLE_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatGoogleGenerativeAI(google_api_key=google_api_key, model=model)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    
-    return generate_scenario_google(google_api_key, model, messages)
-
-def generate_scenario_mistral_wrapper(mistral_api_key, model_name, messages):
-    if client is not None: # If LangSmith client has been initialised
-        @traceable(run_type="llm", name="Threat Group Scenario (Mistral API)", tags=["mistral", "threat_group_scenario"], client=client)
-        def generate_scenario_mistral(mistral_api_key, model_name, messages, *, run_tree: RunTree):
-            try:
-                mistral_api_key = os.getenv('MISTRAL_API_KEY')
-                model = os.getenv('MISTRAL_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatMistralAI(mistral_api_key=mistral_api_key)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages, model=model)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id) # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id) # Ensure run_id is updated even on failure
-                return None
-    else: # If LangSmith client has not been initialised
-        def generate_scenario_mistral(mistral_api_key, model_name, messages):
-            try:
-                mistral_api_key = os.getenv('MISTRAL_API_KEY')
-                model = os.getenv('MISTRAL_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatMistralAI(mistral_api_key=mistral_api_key)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages, model=model)
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    
-    return generate_scenario_mistral(mistral_api_key, model_name, messages)
-
-def generate_scenario_ollama_wrapper(model):
-    if client is not None: # If LangSmith client has been initialised
-        @traceable(run_type="llm", name="Threat Group Scenario (Ollama)", tags=["ollama", "threat_group_scenario"], client=client)
-        def generate_scenario_ollama(model, *, run_tree: RunTree):
-            try:
-                model = os.getenv('OLLAMA_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = Ollama(model=model)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages, model=model)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)  # Store the run ID in the session state
-                return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)  # Ensure run_id is updated even on failure
-                return None
-    else: # If LangSmith client has not been initialised
-        def generate_scenario_ollama(model):
-            try:
-                model = os.getenv('OLLAMA_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = Ollama(model=model)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages, model=model)
-                    st.write("Scenario generated successfully.")
-                return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-
-    return generate_scenario_ollama(model)
-
-def generate_scenario_anthropic_wrapper(anthropic_api_key, model_name, messages):
-    if client is not None:  # If LangSmith client has been initialised
-        @traceable(run_type="llm", name="Threat Group Scenario (Anthropic)", tags=["anthropic", "threat_group_scenario"], client=client)
-        def generate_scenario_anthropic(anthropic_api_key, model_name, messages, *, run_tree: RunTree):
-            try:
-                anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')
-                model = os.getenv('ANTHROPIC_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    # Set max_tokens based on the model
-                    max_tokens = 8192  # Default for Haiku
-                    if "opus-4" in model:
-                        max_tokens = 32000
-                    elif "sonnet-4" in model or "3-7-sonnet" in model:
-                        max_tokens = 64000
-                    
-                    llm = ChatAnthropic(anthropic_api_key=anthropic_api_key, model_name=model, temperature=0.7, max_tokens=max_tokens)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)  # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)  # Ensure run_id is updated even on failure
-                return None
-    else:  # If LangSmith client has not been initialised
-        def generate_scenario_anthropic(anthropic_api_key, model_name, messages):
-            try:
-                anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')
-                model = os.getenv('ANTHROPIC_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    # Set max_tokens based on the model
-                    max_tokens = 8192  # Default for Haiku
-                    if "opus-4" in model:
-                        max_tokens = 32000
-                    elif "sonnet-4" in model or "3-7-sonnet" in model:
-                        max_tokens = 64000
-                    
-                    llm = ChatAnthropic(anthropic_api_key=anthropic_api_key, model_name=model, temperature=0.7, max_tokens=max_tokens)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    
-    return generate_scenario_anthropic(anthropic_api_key, model_name, messages)
-
-def generate_scenario_groq_wrapper(groq_api_key, model_name, messages):
-    if client is not None: # If LangSmith client has been initialised
-        @traceable(run_type="llm", name="Threat Group Scenario (Groq API)", tags=["groq", "threat_group_scenario"], client=client)
-        def generate_scenario_groq(groq_api_key, model_name, messages, *, run_tree: RunTree):
-            try:
-                groq_api_key = os.getenv('GROQ_API_KEY')
-                model = os.getenv('GROQ_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = OpenAI(
-                        api_key=groq_api_key,
-                        base_url="https://api.groq.com/openai/v1",
-                    )
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    
-                    # Convert message objects to the expected format
-                    formatted_messages = []
-                    for message in messages:
-                        if hasattr(message, 'role') and hasattr(message, 'content'):
-                            role = message.role
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        elif hasattr(message, 'type') and hasattr(message, 'content'):
-                            role = message.type
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        else:
-                            raise ValueError(f"Unsupported message format: {message}")
-                    
-                    response = llm.chat.completions.create(
-                        model=model,
-                        messages=formatted_messages
-                    )
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)  # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)  # Ensure run_id is updated even on failure
-                return None
-    else: # If LangSmith client has not been initialised
-        def generate_scenario_groq(groq_api_key, model_name, messages):
-            try:
-                groq_api_key = os.getenv('GROQ_API_KEY')
-                model = os.getenv('GROQ_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = OpenAI(
-                        api_key=groq_api_key,
-                        base_url="https://api.groq.com/openai/v1",
-                    )
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    
-                    # Convert message objects to the expected format
-                    formatted_messages = []
-                    for message in messages:
-                        if hasattr(message, 'role') and hasattr(message, 'content'):
-                            role = message.role
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        elif hasattr(message, 'type') and hasattr(message, 'content'):
-                            role = message.type
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        else:
-                            raise ValueError(f"Unsupported message format: {message}")
-                    
-                    response = llm.chat.completions.create(
-                        model=model,
-                        messages=formatted_messages
-                    )
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    
-    return generate_scenario_groq(groq_api_key, model_name, messages)
-
-# Modify the OpenAI client to use a custom base URL if provided
-def generate_scenario_openai_wrapper(messages):
-    base_url = st.session_state.get('custom_base_url')
-    openai_api_key = st.session_state.get('custom_api_key')
-    model_name = st.session_state.get('model_name') or os.environ.get('OPENAI_MODEL')
-
-    if not base_url:
-        st.error("Custom base URL must be set for the custom model provider.")
-        return None
-    if not model_name:
-        st.error("Custom model name must be set for the custom model provider.")
-        return None
-    # API key might be optional for some local endpoints, so no explicit check here
-
-    # Convert LangChain message objects to the expected dictionary format
-    formatted_messages = []
-    for message in messages:
-        if hasattr(message, 'role') and hasattr(message, 'content'):
-            role = message.role
-            if role == 'human':
-                role = 'user'  # Replace 'human' with 'user'
-            formatted_messages.append({"role": role, "content": message.content})
-        elif hasattr(message, 'type') and hasattr(message, 'content'):
-            role = message.type
-            if role == 'human':
-                role = 'user'  # Replace 'human' with 'user'
-            formatted_messages.append({"role": role, "content": message.content})
-        else:
-            # Attempt to handle SystemMessagePromptTemplate and HumanMessagePromptTemplate if needed
-            if hasattr(message, 'prompt') and hasattr(message.prompt, 'template'):
-                 # This case might need more specific handling depending on how templates are used
-                 # For now, we'll skip templates assuming 'messages' are already formatted instances
-                 st.warning(f"Skipping message template of type {type(message)}")
-                 continue
-            else:
-                 st.error(f"Unsupported message format: {type(message)} - {message}")
-                 return None # Stop processing if message format is wrong
-
-    if not formatted_messages:
-        st.error("No valid messages found to send to the model.")
-        return None
-
-    if client is not None:  # If LangChain client has been initialized
-        @traceable(run_type="llm", name="Threat Group Scenario (Custom)", tags=["custom", "threat_group_scenario"], client=client)
-        def generate_scenario_custom(formatted_messages_arg, *, run_tree: RunTree):
-            try:
-                # Re-fetch variables inside traceable function scope if necessary, though session_state should be accessible
-                custom_api_key = st.session_state.get('custom_api_key')
-                custom_model = st.session_state.get('model_name') or os.environ.get('OPENAI_MODEL')
-                custom_base_url = st.session_state.get('custom_base_url')
-
-                with st.status('Generating scenario with custom model...', expanded=True):
-                    st.write("Initialising custom AI model.")
-
-                    # Conditionally prepare client arguments
-                    client_args = {
-                        "base_url": custom_base_url,
-                    }
-                    if custom_api_key: # Only add api_key if it's not empty
-                        client_args["api_key"] = custom_api_key
-
-                    llm = OpenAI(**client_args)
-
-                    response = llm.chat.completions.create(
-                        model=custom_model,
-                        messages=formatted_messages_arg, # Use the formatted messages
-                        temperature=0.7,
-                        max_tokens=-1,
-                        stream=False
-                    )
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)  # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)  # Ensure run_id is updated even on failure
-                return None
-        return generate_scenario_custom(formatted_messages)
-
-    else:  # If LangChain client has not been initialized
-        def generate_scenario_custom_no_trace(formatted_messages_arg):
-            try:
-                # Fetch variables directly from session state
-                current_api_key = st.session_state.get('custom_api_key')
-                current_model = st.session_state.get('model_name') or os.environ.get('OPENAI_MODEL')
-                current_base_url = st.session_state.get('custom_base_url')
-
-                with st.status('Generating scenario with custom model...', expanded=True):
-                    st.write("Initialising custom AI model.")
-
-                    # Conditionally prepare client arguments
-                    client_args = {
-                        "base_url": current_base_url,
-                    }
-                    if current_api_key: # Only add api_key if it's not empty
-                        client_args["api_key"] = current_api_key
-
-                    llm = OpenAI(**client_args)
-
-                    response = llm.chat.completions.create(
-                        model=current_model,
-                        messages=formatted_messages_arg,
-                        temperature=0.7,
-                        max_tokens=-1,
-                        stream=False
-                    )
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-        return generate_scenario_custom_no_trace(formatted_messages)
-
-# ------------------ Streamlit UI ------------------ #
-
-st.markdown("# <span style='color: #1DB954;'>Generate Threat Group Scenario🛡️</span>", unsafe_allow_html=True)
-
-# Load groups based on the current matrix
-matrix = st.session_state.get("matrix", "Enterprise")
-groups = load_groups(matrix)
-
-# Conditional UI text based on matrix selection
-if matrix == "ATLAS":
-    st.markdown("""
-            ### Select a Case Study
-
-            Use the drop-down selector below to select a case study from the MITRE ATLAS framework.
-
-            You can then optionally view all of the ATLAS techniques associated with the case study and/or the case study's page on the MITRE ATLAS site.
-            """)
-    entity_label = "case study"
-    select_placeholder = "Select Case Study"
-else:
-    st.markdown(f"""
-            ### Select a Threat Actor Group
-
-            Use the drop-down selector below to select a threat actor group from the MITRE ATT&CK framework.
-
-            You can then optionally view all of the {matrix} ATT&CK techniques associated with the group and/or the group's page on the MITRE ATT&CK site.
-            """)
-    entity_label = "threat actor group"
-    select_placeholder = "Select Group"
-
-# Get the list of group names
-group_names = sorted(groups['group'].unique())
-
-# Set a default index that works for all matrices
-default_index = 0 if len(group_names) > 0 else None
-
-selected_group_alias = st.selectbox(
-    f"Select a {entity_label} for the scenario",
-    group_names,
-    index=default_index,
-    placeholder=select_placeholder,
-    label_visibility="hidden"
+SYSTEM_PROMPT = (
+    "You are a cybersecurity expert. Your task is to produce a comprehensive incident response "
+    "testing scenario based on the information provided. Format your response using proper "
+    "Markdown syntax with headers, bullet points, and formatting for readability."
 )
 
-# Define phase name order based on matrix
-if matrix == "ATLAS":
-    phase_name_order = ['Reconnaissance', 'Resource Development', 'Initial Access', 'AI Model Access',
-                        'Execution', 'Persistence', 'Privilege Escalation', 'Defense Evasion',
-                        'Credential Access', 'Discovery', 'Lateral Movement', 'Collection',
-                        'AI Attack Staging', 'Command and Control', 'Exfiltration', 'Impact']
-else:
-    phase_name_order = ['Reconnaissance', 'Resource Development', 'Initial Access', 'Execution', 'Persistence',
-                        'Privilege Escalation', 'Defense Evasion', 'Credential Access', 'Discovery', 'Lateral Movement',
-                        'Collection', 'Command and Control', 'Exfiltration', 'Impact']
-
-phase_name_category = pd.CategoricalDtype(categories=phase_name_order, ordered=True)
-
-
-
-try:
-    # Define techniques_df as an empty dataframe
-    techniques_df = pd.DataFrame()
-
-    # define selected_techniques_df as an empty dataframe before the if condition
-    selected_techniques_df = pd.DataFrame()
-
-    if selected_group_alias != select_placeholder:
-        # Get the group by the selected alias
-        matrix = st.session_state.get("matrix", "Enterprise")
-        group_url = groups[groups['group'] == selected_group_alias]['url'].values[0]
-
-        # Display the URL as a clickable link
-        if matrix == "ATLAS":
-            st.markdown(f"[View case study on atlas.mitre.org]({group_url})")
-        else:
-            st.markdown(f"[View {selected_group_alias}'s page on attack.mitre.org]({group_url})")
-
-        if matrix == "ATLAS":
-            # ATLAS: Extract techniques from case study procedure
-            case_study_row = groups[groups['group'] == selected_group_alias].iloc[0]
-            procedure = case_study_row.get('procedure', [])
-
-            if not procedure:
-                st.warning(f"There are no ATLAS techniques associated with the case study: {selected_group_alias}")
-                st.stop()
-
-            # Get techniques from the procedure
-            techniques_list = get_techniques_from_case_study_procedure(procedure, attack_data["atlas"])
-
-            if not techniques_list:
-                st.warning(f"Could not extract techniques from the case study: {selected_group_alias}")
-                st.stop()
-
-            # Create DataFrame from techniques list
-            techniques_df = pd.DataFrame(techniques_list)
-            techniques_df_llm = techniques_df.copy()
-
-            # Convert the 'Phase Name' column to the ordered category
-            techniques_df['Phase Name'] = techniques_df['Phase Name'].astype(phase_name_category)
-            techniques_df_llm['Phase Name'] = techniques_df_llm['Phase Name'].astype(phase_name_category)
-
-            # Sort by Phase Name
-            techniques_df = techniques_df.sort_values('Phase Name')
-            techniques_df_llm = techniques_df_llm.sort_values('Phase Name')
-
-            # For ATLAS, we use all techniques from the procedure (no random selection)
-            # as they represent the documented attack chain
-            selected_techniques_df = techniques_df_llm.copy()
-
-            # Select display columns
-            techniques_df = techniques_df[['Technique Name', 'ATT&CK ID', 'Phase Name']]
-
-        else:
-            # ATT&CK: Use standard group lookup
-            group = attack_data[matrix.lower()].get_groups_by_alias(selected_group_alias)
-
-            # Check if the group was found
-            if group:
-                # Get the STIX ID of the group
-                group_stix_id = group[0].id
-
-                # Get all techniques used by the group
-                techniques = attack_data[matrix.lower()].get_techniques_used_by_group(group_stix_id)
-
-                # Check if there are any techniques for the group
-                if not techniques:
-                    st.warning(f"There are no {matrix} ATT&CK techniques associated with the threat group: {selected_group_alias}")
-                    st.stop()
-                else:
-                    # Update techniques_df with the techniques
-                    techniques_df = pd.DataFrame(techniques)
-
-                # Create a copy of the DataFrame for generating the LLM prompt
-                techniques_df_llm = techniques_df.copy()
-
-                # Add a 'Technique Name' column to both DataFrames
-                techniques_df['Technique Name'] = techniques_df_llm['Technique Name'] = techniques_df['object'].apply(lambda x: x['name'])
-
-                # Add a 'ATT&CK ID' column to both DataFrames
-                techniques_df['ATT&CK ID'] = techniques_df_llm['ATT&CK ID'] = techniques_df['object'].apply(lambda x: attack_data[matrix.lower()].get_attack_id(x['id']))
-
-                # Add a 'Phase Name' column to both DataFrames
-                techniques_df['Phase Name'] = techniques_df_llm['Phase Name'] = techniques_df['object'].apply(lambda x: x['kill_chain_phases'][0]['phase_name'])
-
-                # Drop duplicate techniques based on Phase Name, Technique Name and ATT&CK ID
-                techniques_df = techniques_df.drop_duplicates(['Phase Name', 'Technique Name', 'ATT&CK ID'])
-
-                # Convert the 'Phase Name' to title case and replace hyphens with spaces
-                techniques_df['Phase Name'] = techniques_df['Phase Name'].str.replace('-', ' ').str.title()
-                techniques_df_llm['Phase Name'] = techniques_df_llm['Phase Name'].str.replace('-', ' ').str.title()
-
-                # Replace 'Command And Control' with 'Command and Control'
-                techniques_df['Phase Name'] = techniques_df['Phase Name'].replace('Command And Control', 'Command and Control')
-                techniques_df_llm['Phase Name'] = techniques_df_llm['Phase Name'].replace('Command And Control', 'Command and Control')
-
-                # Convert the 'Phase Name' column to the ordered category in both DataFrames
-                techniques_df['Phase Name'] = techniques_df['Phase Name'].astype(phase_name_category)
-                techniques_df_llm['Phase Name'] = techniques_df_llm['Phase Name'].astype(phase_name_category)
-
-                # Sort the DataFrame by the 'Phase Name' column
-                techniques_df = techniques_df.sort_values('Phase Name')
-                techniques_df_llm = techniques_df_llm.sort_values('Phase Name')
-
-                # Group by 'Phase Name' and randomly select one technique from each group
-                # Filter the groups to include only those that have at least one row in the LLM DataFrame
-                selected_techniques_df = (
-                    techniques_df_llm.groupby('Phase Name', observed=False)  # Use default group_keys behavior
-                    .apply(
-                        lambda x: x.sample(n=1) if not x.empty else pd.DataFrame(columns=x.columns),
-                        include_groups=False  # This ensures x in lambda doesn't have grouping columns
-                    )
-                    .reset_index()  # This will bring 'Phase Name' from the index into a column
-                )
-
-                # Sort the DataFrame by the 'Phase Name' column
-                techniques_df = techniques_df.sort_values('Phase Name')
-
-                # Select only the 'Technique Name', 'ATT&CK ID', and 'Phase Name' columns
-                techniques_df = techniques_df[['Technique Name', 'ATT&CK ID', 'Phase Name']]
-
-        if not techniques_df.empty:
-            # Create an expander for the techniques
-            expander_title = "Associated ATLAS Techniques" if matrix == "ATLAS" else "Associated ATT&CK Techniques"
-            with st.expander(expander_title):
-                # Use the st.table function to display the DataFrame
-                st.dataframe(data=techniques_df, height=200, width='stretch', hide_index=True)
-
-        # Create an empty list to hold the kill chain information
-        kill_chain = []
-
-        # Iterate over the rows in the DataFrame
-        for index, row in selected_techniques_df.iterrows():
-            # Extract the phase and technique information
-            phase_name = row['Phase Name']
-            technique_name = row['Technique Name']
-            attack_id = row['ATT&CK ID']
-
-            # Add a string with this information to the kill chain list
-            kill_chain.append(f"{phase_name}: {technique_name} ({attack_id})")
-
-        # Convert the kill chain list to a string with newline characters between each item
-        kill_chain_string = "\n".join(kill_chain)
-
-        # Create System Message Template
-        system_template = "You are a cybersecurity expert. Your task is to produce a comprehensive incident response testing scenario based on the information provided. Format your response using proper Markdown syntax with headers, bullet points, and formatting for readability."
-        system_message_prompt = SystemMessagePromptTemplate.from_template(system_template)
-
-        # Create Human Message Template - different for ATLAS vs ATT&CK
-        if matrix == "ATLAS":
-            human_template = ("""
+ATLAS_HUMAN_TEMPLATE = """
 **Background information:**
 The company operates in the '{industry}' industry and is of size '{company_size}'.
 They deploy AI/ML systems that may be vulnerable to adversarial attacks.
@@ -818,9 +82,9 @@ Create an incident response testing scenario based on this AI/ML attack case stu
 Focus on realistic attack vectors that target AI/ML infrastructure, including model manipulation, data poisoning, adversarial inputs, and AI supply chain attacks.
 
 Your response should be well structured and formatted using Markdown. Write in British English.
-""")
-        else:
-            human_template = ("""
+"""
+
+ATTACK_HUMAN_TEMPLATE = """
 **Background information:**
 The company operates in the '{industry}' industry and is of size '{company_size}'.
 
@@ -832,453 +96,306 @@ Threat actor group '{selected_group_alias}' is planning to target the company us
 Create an incident response testing scenario based on the information provided. The goal of the scenario is to test the company's incident response capabilities against the identified threat actor group, focusing on the {matrix} environment.
 
 Your response should be well structured and formatted using Markdown. Write in British English.
-""")
-        human_message_prompt = HumanMessagePromptTemplate.from_template(human_template)
+"""
 
-        # Construct the ChatPromptTemplate
-        chat_prompt = ChatPromptTemplate.from_messages([system_message_prompt, human_message_prompt])
 
-        # Format the prompt
-        messages = chat_prompt.format_prompt(selected_group_alias=selected_group_alias, 
-                                            kill_chain_string=kill_chain_string, 
-                                            industry=industry, 
-                                            company_size=company_size, 
-                                            matrix=matrix).to_messages()
+def build_messages(matrix, selected_group_alias, kill_chain_string):
+    template = ATLAS_HUMAN_TEMPLATE if matrix == "ATLAS" else ATTACK_HUMAN_TEMPLATE
+    user_content = template.format(
+        industry=industry,
+        company_size=company_size,
+        selected_group_alias=selected_group_alias,
+        kill_chain_string=kill_chain_string,
+        matrix=matrix,
+    )
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
 
-# Error handling for group selection
+
+def post_process(scenario_text: str) -> tuple[str | None, str]:
+    """Pull out <think>...</think> reasoning blocks emitted by some models."""
+    match = re.search(r'<think>(.*?)</think>', scenario_text, re.DOTALL)
+    thinking = match.group(1).strip() if match else None
+    cleaned = re.sub(r'<think>.*?</think>', '', scenario_text, flags=re.DOTALL).strip()
+    cleaned = re.sub(r'^```\w*\n|```$', '', cleaned, flags=re.MULTILINE).strip()
+    return thinking, cleaned
+
+
+# ------------------ Streamlit UI ------------------ #
+
+st.markdown("# <span style='color: #1DB954;'>Generate Threat Group Scenario🛡️</span>", unsafe_allow_html=True)
+
+matrix = st.session_state.get("matrix", "Enterprise")
+groups = load_groups(matrix)
+
+if matrix == "ATLAS":
+    st.markdown(
+        """
+        ### Select a Case Study
+
+        Use the drop-down selector below to select a case study from the MITRE ATLAS framework.
+
+        You can then optionally view all of the ATLAS techniques associated with the case study and/or the case study's page on the MITRE ATLAS site.
+        """
+    )
+    entity_label = "case study"
+    select_placeholder = "Select Case Study"
+else:
+    st.markdown(
+        f"""
+        ### Select a Threat Actor Group
+
+        Use the drop-down selector below to select a threat actor group from the MITRE ATT&CK framework.
+
+        You can then optionally view all of the {matrix} ATT&CK techniques associated with the group and/or the group's page on the MITRE ATT&CK site.
+        """
+    )
+    entity_label = "threat actor group"
+    select_placeholder = "Select Group"
+
+group_names = sorted(groups['group'].unique())
+default_index = 0 if group_names else None
+
+selected_group_alias = st.selectbox(
+    f"Select a {entity_label} for the scenario",
+    group_names,
+    index=default_index,
+    placeholder=select_placeholder,
+    label_visibility="hidden",
+)
+
+if matrix == "ATLAS":
+    phase_name_order = [
+        'Reconnaissance', 'Resource Development', 'Initial Access', 'AI Model Access',
+        'Execution', 'Persistence', 'Privilege Escalation', 'Defense Evasion',
+        'Credential Access', 'Discovery', 'Lateral Movement', 'Collection',
+        'AI Attack Staging', 'Command and Control', 'Exfiltration', 'Impact',
+    ]
+else:
+    phase_name_order = [
+        'Reconnaissance', 'Resource Development', 'Initial Access', 'Execution', 'Persistence',
+        'Privilege Escalation', 'Defense Evasion', 'Credential Access', 'Discovery', 'Lateral Movement',
+        'Collection', 'Command and Control', 'Exfiltration', 'Impact',
+    ]
+
+phase_name_category = pd.CategoricalDtype(categories=phase_name_order, ordered=True)
+
+
+messages = None
+techniques_df = pd.DataFrame()
+selected_techniques_df = pd.DataFrame()
+
+try:
+    if selected_group_alias != select_placeholder:
+        group_url = groups[groups['group'] == selected_group_alias]['url'].values[0]
+        if matrix == "ATLAS":
+            st.markdown(f"[View case study on atlas.mitre.org]({group_url})")
+        else:
+            st.markdown(f"[View {selected_group_alias}'s page on attack.mitre.org]({group_url})")
+
+        if matrix == "ATLAS":
+            case_study_row = groups[groups['group'] == selected_group_alias].iloc[0]
+            procedure = case_study_row.get('procedure', [])
+
+            if not procedure:
+                st.warning(f"There are no ATLAS techniques associated with the case study: {selected_group_alias}")
+                st.stop()
+
+            techniques_list = get_techniques_from_case_study_procedure(procedure, attack_data["atlas"])
+            if not techniques_list:
+                st.warning(f"Could not extract techniques from the case study: {selected_group_alias}")
+                st.stop()
+
+            techniques_df = pd.DataFrame(techniques_list)
+            techniques_df_llm = techniques_df.copy()
+            techniques_df['Phase Name'] = techniques_df['Phase Name'].astype(phase_name_category)
+            techniques_df_llm['Phase Name'] = techniques_df_llm['Phase Name'].astype(phase_name_category)
+            techniques_df = techniques_df.sort_values('Phase Name')
+            techniques_df_llm = techniques_df_llm.sort_values('Phase Name')
+
+            selected_techniques_df = techniques_df_llm.copy()
+            techniques_df = techniques_df[['Technique Name', 'ATT&CK ID', 'Phase Name']]
+        else:
+            group = attack_data[matrix.lower()].get_groups_by_alias(selected_group_alias)
+            if group:
+                group_stix_id = group[0].id
+                techniques = attack_data[matrix.lower()].get_techniques_used_by_group(group_stix_id)
+                if not techniques:
+                    st.warning(f"There are no {matrix} ATT&CK techniques associated with the threat group: {selected_group_alias}")
+                    st.stop()
+
+                techniques_df = pd.DataFrame(techniques)
+                techniques_df_llm = techniques_df.copy()
+                techniques_df['Technique Name'] = techniques_df_llm['Technique Name'] = techniques_df['object'].apply(lambda x: x['name'])
+                techniques_df['ATT&CK ID'] = techniques_df_llm['ATT&CK ID'] = techniques_df['object'].apply(lambda x: attack_data[matrix.lower()].get_attack_id(x['id']))
+                techniques_df['Phase Name'] = techniques_df_llm['Phase Name'] = techniques_df['object'].apply(lambda x: x['kill_chain_phases'][0]['phase_name'])
+                techniques_df = techniques_df.drop_duplicates(['Phase Name', 'Technique Name', 'ATT&CK ID'])
+
+                techniques_df['Phase Name'] = techniques_df['Phase Name'].str.replace('-', ' ').str.title()
+                techniques_df_llm['Phase Name'] = techniques_df_llm['Phase Name'].str.replace('-', ' ').str.title()
+                techniques_df['Phase Name'] = techniques_df['Phase Name'].replace('Command And Control', 'Command and Control')
+                techniques_df_llm['Phase Name'] = techniques_df_llm['Phase Name'].replace('Command And Control', 'Command and Control')
+                techniques_df['Phase Name'] = techniques_df['Phase Name'].astype(phase_name_category)
+                techniques_df_llm['Phase Name'] = techniques_df_llm['Phase Name'].astype(phase_name_category)
+                techniques_df = techniques_df.sort_values('Phase Name')
+                techniques_df_llm = techniques_df_llm.sort_values('Phase Name')
+
+                selected_techniques_df = (
+                    techniques_df_llm.groupby('Phase Name', observed=False)
+                    .apply(
+                        lambda x: x.sample(n=1) if not x.empty else pd.DataFrame(columns=x.columns),
+                        include_groups=False,
+                    )
+                    .reset_index()
+                )
+
+                techniques_df = techniques_df.sort_values('Phase Name')
+                techniques_df = techniques_df[['Technique Name', 'ATT&CK ID', 'Phase Name']]
+
+        if not techniques_df.empty:
+            expander_title = "Associated ATLAS Techniques" if matrix == "ATLAS" else "Associated ATT&CK Techniques"
+            with st.expander(expander_title):
+                st.dataframe(data=techniques_df, height=200, width='stretch', hide_index=True)
+
+        kill_chain = [
+            f"{row['Phase Name']}: {row['Technique Name']} ({row['ATT&CK ID']})"
+            for _, row in selected_techniques_df.iterrows()
+        ]
+        kill_chain_string = "\n".join(kill_chain)
+        messages = build_messages(matrix, selected_group_alias, kill_chain_string)
 except Exception as e:
     st.error("An error occurred: " + str(e))
+
 
 st.markdown("")
 
-# Display the scenario generation section
 if matrix == "ATLAS":
-    st.markdown("""
-            ### Generate a Scenario
+    st.markdown(
+        """
+        ### Generate a Scenario
 
-            Click the button below to generate a scenario based on the selected case study. The documented attack procedure from the case study will be used to generate the scenario.
+        Click the button below to generate a scenario based on the selected case study. The documented attack procedure from the case study will be used to generate the scenario.
 
-            It normally takes between 30-50 seconds to generate a scenario, although for local models this is highly dependent on your hardware and the selected model. ⏱️
-            """)
+        It normally takes between 30-50 seconds to generate a scenario, although for local models this is highly dependent on your hardware and the selected model. ⏱️
+        """
+    )
 else:
-    st.markdown("""
-            ### Generate a Scenario
+    st.markdown(
+        """
+        ### Generate a Scenario
 
-            Click the button below to generate a scenario based on the selected threat actor group. A selection of the group's known techniques will be chosen at random and used to generate the scenario.
+        Click the button below to generate a scenario based on the selected threat actor group. A selection of the group's known techniques will be chosen at random and used to generate the scenario.
 
-            It normally takes between 30-50 seconds to generate a scenario, although for local models this is highly dependent on your hardware and the selected model. ⏱️
-            """)
+        It normally takes between 30-50 seconds to generate a scenario, although for local models this is highly dependent on your hardware and the selected model. ⏱️
+        """
+    )
+
+
+def _render_scenario(scenario_text: str):
+    st.session_state['scenario_generated'] = True
+    st.session_state['scenario_text'] = scenario_text
+    st.markdown(scenario_text)
+    st.download_button(
+        label="Download Scenario",
+        data=scenario_text,
+        file_name="threat_group_scenario.md",
+        mime="text/markdown",
+    )
+    st.session_state['last_scenario'] = True
+    st.session_state['last_scenario_text'] = scenario_text
+
+
+def _ready() -> bool:
+    if model_provider != "Custom" and not st.session_state.get("llm_api_key"):
+        st.info("Please add your API key in the sidebar to continue.")
+        return False
+    if not st.session_state.get("llm_model_name"):
+        st.info("Please select a model in the sidebar to continue.")
+        return False
+    if not industry:
+        st.info("Please select your company's industry in the sidebar to continue.")
+        return False
+    if not company_size:
+        st.info("Please select your company's size in the sidebar to continue.")
+        return False
+    if techniques_df.empty:
+        st.info(f"Please select a {entity_label} with associated techniques.")
+        return False
+    return True
+
 
 try:
-    if model_provider == "Azure OpenAI Service":
-        if st.button('Generate Scenario', key='generate_scenario_azure'):
-            if not os.environ["AZURE_OPENAI_API_KEY"]:
-                st.info("Please add your Azure OpenAI Service API key to continue.")
-            if not os.environ["AZURE_OPENAI_ENDPOINT"]:
-                st.info("Please add your Azure OpenAI Service API endpoint to continue.")
-            if not os.environ["AZURE_DEPLOYMENT"]:
-                st.info("Please add the name of your Azure OpenAI Service Deployment to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif techniques_df.empty:
-                st.info(f"Please select a {entity_label} with associated techniques.")
-            else:
-                response = generate_scenario_azure_wrapper(messages)
-                st.markdown("---")
-                if response is not None:
-                    st.session_state['scenario_generated'] = True
-                    scenario_text = response.choices[0].message.content
-                    st.session_state['scenario_text'] = scenario_text  # Store the generated scenario in the session state
-                    st.markdown(scenario_text)
-                    st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
+    if st.button('Generate Scenario', key='generate_scenario'):
+        if _ready() and messages is not None:
+            config = LLMConfig.from_session_state(
+                trace_name="Threat Group Scenario",
+                trace_tags=("threat_group_scenario",),
+            )
+            scenario_text = None
+            try:
+                with st.status('Generating scenario...', expanded=True):
+                    st.write("Calling the model.")
+                    scenario_text = call_llm(config, messages)
+                    st.write("Scenario generated successfully.")
+            except Exception as e:
+                st.error(f"An error occurred while generating the scenario: {str(e)}")
 
-                    st.session_state['last_scenario'] = True
-                    st.session_state['last_scenario_text'] = scenario_text # Store the last scenario in the session state for use by the Scenario Assistant
+            st.markdown("---")
+            if scenario_text:
+                thinking, cleaned = post_process(scenario_text)
+                if thinking:
+                    with st.expander("View Model's Reasoning"):
+                        st.markdown(thinking)
+                _render_scenario(cleaned)
+            elif 'scenario_text' in st.session_state and st.session_state['scenario_generated']:
+                st.markdown("Displaying previously generated scenario:")
+                st.markdown(st.session_state['scenario_text'])
+                st.download_button(
+                    label="Download Scenario",
+                    data=st.session_state['scenario_text'],
+                    file_name="threat_group_scenario.md",
+                    mime="text/markdown",
+                )
 
-                else:
-                    # If a scenario has been generated previously, display it
-                    if 'scenario_text' in st.session_state and st.session_state['scenario_generated']:
-                        st.markdown("---")
-                        st.markdown(st.session_state['scenario_text'])
-                        st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-
-    elif model_provider == "Google AI API":
-        if st.button('Generate Scenario', key='generate_scenario_google'):
-            if not os.environ["GOOGLE_API_KEY"]:
-                st.info("Please add your Google AI API key to continue.")
-            if not os.environ["GOOGLE_MODEL"]:
-                st.info("Please select a model to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif techniques_df.empty:
-                st.info(f"Please select a {entity_label} with associated techniques.")
-            else:
-                google_api_key = st.session_state.get('google_api_key')
-                model_name = os.getenv('GOOGLE_MODEL')
-                response = generate_scenario_google_wrapper(google_api_key, model_name, messages)
-                st.markdown("---")
-                if response is not None:
-                    try:
-                        # Extract text content from structured response if needed
-                        if isinstance(response.content, list):
-                            # Find text blocks in the structured response
-                            text_blocks = [block.get('text', '') for block in response.content if isinstance(block, dict) and block.get('type') == 'text']
-                            scenario_text = '\n'.join(text_blocks)
-                        else:
-                            scenario_text = response.content
-
-                        st.session_state['scenario_generated'] = True
-                        st.session_state['scenario_text'] = scenario_text
-                        st.markdown(scenario_text)
-                        st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-
-                        st.session_state['last_scenario'] = True
-                        st.session_state['last_scenario_text'] = scenario_text
-                    except Exception as processing_error:
-                        st.error(f"An error occurred while processing the scenario response: {processing_error}")
-                        st.text("Raw response content:")
-                        st.json(str(response.content))
-                else:
-                    # If a scenario has been generated previously, display it
-                    if 'scenario_text' in st.session_state and st.session_state['scenario_generated']:
-                        st.markdown("---")
-                        st.markdown(st.session_state['scenario_text'])
-                        st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-
-    elif model_provider == "Mistral API":
-        if st.button('Generate Scenario', key='generate_scenario_mistral'):
-            if not os.environ["MISTRAL_API_KEY"]:
-                st.info("Please add your Mistral API key to continue.")
-            if not os.environ["MISTRAL_MODEL"]:
-                st.info("Please select a model to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif techniques_df.empty:
-                st.info(f"Please select a {entity_label} with associated techniques.")
-            else:
-                mistral_api_key = st.session_state.get('mistral_api_key')
-                model_name = os.getenv('MISTRAL_MODEL')
-                response = generate_scenario_mistral_wrapper(mistral_api_key, model_name, messages)
-                st.markdown("---")
-                if response is not None:
-                    st.session_state['scenario_generated'] = True
-                    scenario_text = response.content
-                    st.session_state['scenario_text'] = scenario_text  # Store the generated scenario in the session state
-                    st.markdown(scenario_text)
-                    st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-
-                    st.session_state['last_scenario'] = True
-                    st.session_state['last_scenario_text'] = scenario_text # Store the last scenario in the session state for use by the Scenario Assistant
-
-                else:
-                    # If a scenario has been generated previously, display it
-                    if 'scenario_text' in st.session_state and st.session_state['scenario_generated']:
-                        st.markdown("---")
-                        st.markdown(st.session_state['scenario_text'])
-                        st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-    
-    elif model_provider == "Ollama":
-        if st.button('Generate Scenario', key='generate_scenario_ollama'):
-            if not os.environ["OLLAMA_MODEL"]:
-                st.info("Please select a model to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif techniques_df.empty:
-                st.info(f"Please select a {entity_label} with associated techniques.")
-            else:
-                model = os.getenv('OLLAMA_MODEL')
-                response = generate_scenario_ollama_wrapper(model)
-                st.markdown("---")
-                if response is not None:
-                    st.session_state['scenario_generated'] = True
-                    scenario_text = response
-                    st.session_state['scenario_text'] = scenario_text  # Store the generated scenario in the session state
-                    st.markdown(scenario_text)
-                    st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-
-                    st.session_state['last_scenario'] = True
-                    st.session_state['last_scenario_text'] = scenario_text # Store the last scenario in the session state for use by the Scenario Assistant
-
-                else:
-                    # If a scenario has been generated previously, display it
-                    if 'scenario_text' in st.session_state and st.session_state['scenario_generated']:
-                        st.markdown("---")
-                        st.markdown(st.session_state['scenario_text'])
-                        st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-
-    elif model_provider == "Anthropic API":
-        if st.button('Generate Scenario', key='generate_scenario_anthropic'):
-            if not os.environ["ANTHROPIC_API_KEY"]:
-                st.info("Please add your Anthropic API key to continue.")
-            if not os.environ["ANTHROPIC_MODEL"]:
-                st.info("Please select a model to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif techniques_df.empty:
-                st.info(f"Please select a {entity_label} with associated techniques.")
-            else:
-                anthropic_api_key = st.session_state.get('anthropic_api_key')
-                model_name = os.getenv('ANTHROPIC_MODEL')
-                response = generate_scenario_anthropic_wrapper(anthropic_api_key, model_name, messages)
-                st.markdown("---")
-                if response is not None:
-                    st.session_state['scenario_generated'] = True
-                    scenario_text = response.content
-                    st.session_state['scenario_text'] = scenario_text  # Store the generated scenario in the session state
-                    st.markdown(scenario_text)
-                    st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-
-                    st.session_state['last_scenario'] = True
-                    st.session_state['last_scenario_text'] = scenario_text # Store the last scenario in the session state for use by the Scenario Assistant
-
-                else:
-                    # If a scenario has been generated previously, display it
-                    if 'scenario_text' in st.session_state and st.session_state['scenario_generated']:
-                        st.markdown("---")
-                        st.markdown(st.session_state['scenario_text'])
-                        st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-
-    elif model_provider == "Groq API":
-        if st.button('Generate Scenario', key='generate_scenario_groq'):
-            if not os.environ["GROQ_API_KEY"]:
-                st.info("Please add your Groq API key to continue.")
-            if not os.environ["GROQ_MODEL"]:
-                st.info("Please select a model to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif techniques_df.empty:
-                st.info(f"Please select a {entity_label} with associated techniques.")
-            else:
-                groq_api_key = st.session_state.get('GROQ_API_KEY')
-                model_name = os.getenv('GROQ_MODEL')
-                response = generate_scenario_groq_wrapper(groq_api_key, model_name, messages)
-                st.markdown("---")
-                if response is not None:
-                    st.session_state['scenario_generated'] = True
-                    content = response.choices[0].message.content
-                    
-                    # Check if this is DeepSeek output with thinking tags
-                    if re.search(r'<think>(.*?)</think>', content, re.DOTALL):
-                        # Extract the thinking content and the rest of the scenario
-                        thinking_match = re.search(r'<think>(.*?)</think>', content, re.DOTALL)
-                        thinking_content = thinking_match.group(1).strip()
-                        scenario_text = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL).strip()
-                        
-                        # Display thinking content in an expander
-                        with st.expander("View Model's Reasoning"):
-                            st.markdown(thinking_content)
-                    else:
-                        # If no thinking tags, use the entire content as the scenario
-                        scenario_text = content
-                    
-                    # Clean up the scenario text by removing code block markers if present
-                    scenario_text = re.sub(r'^```\w*\n|```$', '', scenario_text, flags=re.MULTILINE).strip()
-                    
-                    st.session_state['scenario_text'] = scenario_text  # Store the generated scenario in the session state
-                    st.markdown(scenario_text)
-                    st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-
-                    st.session_state['last_scenario'] = True
-                    st.session_state['last_scenario_text'] = scenario_text # Store the last scenario in the session state for use by the Scenario Assistant
-
-                else:
-                    # If a scenario has been generated previously, display it
-                    if 'scenario_text' in st.session_state and st.session_state['scenario_generated']:
-                        st.markdown("---")
-                        st.markdown(st.session_state['scenario_text'])
-                        st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-
-    elif model_provider == "OpenAI API":
-        if st.button('Generate Scenario', key='generate_scenario_openai'):
-            openai_api_key = st.session_state.get('openai_api_key') or os.environ.get('OPENAI_API_KEY')
-            model_name = st.session_state.get('model_name') or os.environ.get('OPENAI_MODEL')
-            if not openai_api_key:
-                st.info("Please add your OpenAI API key to continue.")
-            elif not model_name:
-                st.info("Please select a model to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif techniques_df.empty:
-                st.info(f"Please select a {entity_label} with associated techniques.")
-            else:
-                response = generate_scenario_wrapper(openai_api_key, model_name, messages)
-                st.markdown("---")
-                if response is not None:
-                    try:
-                        # Extract text content from Responses API structured response
-                        if isinstance(response.content, list):
-                            # Find text blocks in the structured response
-                            text_blocks = [block.get('text', '') for block in response.content if block.get('type') == 'text']
-                            scenario_text = '\n'.join(text_blocks)
-                        else:
-                            scenario_text = response.content
-                        
-                        st.session_state['scenario_generated'] = True
-                        st.session_state['scenario_text'] = scenario_text
-                        st.markdown(scenario_text)
-                        st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-                        st.session_state['last_scenario'] = True
-                        st.session_state['last_scenario_text'] = scenario_text
-                    except Exception as processing_error:
-                        st.error(f"An error occurred while processing the scenario response: {processing_error}")
-                        st.text("Raw response object:")
-                        st.json(str(response))
-                else:
-                    st.warning("Scenario generation failed. Check the error message above.")
-                    if 'scenario_text' in st.session_state and st.session_state['scenario_generated']:
-                        st.markdown("Displaying previously generated scenario:")
-                        st.markdown(st.session_state['scenario_text'])
-                        st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-
-    elif model_provider == "Custom":
-        if st.button('Generate Scenario', key='generate_scenario_custom'):
-            # Check for required custom settings
-            if not st.session_state.get('custom_base_url'):
-                st.info("Please set the Custom Base URL in the sidebar.")
-            elif not st.session_state.get('model_name'):
-                st.info("Please set the Custom Model Name in the sidebar.")
-            elif not industry:
-                st.info("Please select your company\'s industry to continue.")
-            elif not company_size:
-                st.info("Please select your company\'s size to continue.")
-            elif techniques_df.empty:
-                st.info(f"Please select a {entity_label} with associated techniques.")
-            else:
-                # Call the wrapper function (it now reads custom settings from session_state)
-                response = generate_scenario_openai_wrapper(messages)
-                st.markdown("---")
-                if response is not None:
-                    try:
-                        # Add more robust checking for the response structure
-                        if hasattr(response, 'choices') and response.choices:
-                            first_choice = response.choices[0]
-                            if hasattr(first_choice, 'message') and first_choice.message:
-                                if hasattr(first_choice.message, 'content') and first_choice.message.content:
-                                    st.session_state['scenario_generated'] = True
-                                    scenario_text = first_choice.message.content
-                                    st.session_state['scenario_text'] = scenario_text
-                                    st.markdown(scenario_text)
-                                    st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-
-                                    st.session_state['last_scenario'] = True
-                                    st.session_state['last_scenario_text'] = scenario_text
-                                else:
-                                    st.error("Error processing response: 'content' attribute missing from message.")
-                                    st.json(response.model_dump_json(indent=2)) # Display raw response
-                            else:
-                                st.error("Error processing response: 'message' attribute missing from the first choice.")
-                                st.json(response.model_dump_json(indent=2)) # Display raw response
-                        else:
-                            st.error("Error processing response: 'choices' list is missing or empty.")
-                            st.json(response.model_dump_json(indent=2)) # Display raw response
-                    except Exception as processing_error:
-                        st.error(f"An error occurred while processing the scenario response: {processing_error}")
-                        st.text("Raw response object:")
-                        st.json(response.model_dump_json(indent=2)) # Display raw response on processing error
-
-                else:
-                    # Response was None, likely due to an error during generation (already logged by the wrapper)
-                    st.warning("Scenario generation failed. Check the error message above.")
-                    # Optionally display previous scenario if needed
-                    if 'scenario_text' in st.session_state and st.session_state['scenario_generated']:
-                        st.markdown("Displaying previously generated scenario:")
-                        st.markdown(st.session_state['scenario_text'])
-                        st.download_button(label="Download Scenario", data=st.session_state['scenario_text'], file_name="threat_group_scenario.md", mime="text/markdown")
-
-    # Display an info message if no API key is set
     if 'LANGCHAIN_API_KEY' not in st.secrets:
-        st.info("ℹ️ No LangChain API key has been set. This run will not be logged to LangSmith.")                
+        st.info("ℹ️ No LangChain API key has been set. This run will not be logged to LangSmith.")
 
-    # Create a placeholder for the feedback message
     feedback_placeholder = st.empty()
-
-    # Show the thumbs_up and thumbs_down buttons only when a scenario has been generated
     st.markdown("---")
-    # Show the feedback buttons only if a scenario has been generated and the LangSmith client is initialized
     if st.session_state.get('scenario_generated', False) and client is not None:
         st.markdown("Rate the scenario to help improve this tool.")
-        col1, col2, col3 = st.columns([0.5,0.5,5])
+        col1, col2, _ = st.columns([0.5, 0.5, 5])
         with col1:
-            thumbs_up = st.button("👍")
-            if thumbs_up:
+            if st.button("👍"):
                 try:
                     run_id = st.session_state.get('run_id')
                     if run_id:
-                        feedback_type_str = "positive"
-                        score = 1  # or 0
-                        comment = ""
-
-                        # Record the feedback
-                        feedback_record = client.create_feedback(
-                            run_id,
-                            feedback_type_str,
-                            score=score,
-                            comment=comment,
-                        )
-                        st.session_state.feedback = {
-                            "feedback_id": str(feedback_record.id),
-                            "score": score,
-                        }
-                        # Update the feedback message in the placeholder
+                        feedback_record = client.create_feedback(run_id, "positive", score=1, comment="")
+                        st.session_state.feedback = {"feedback_id": str(feedback_record.id), "score": 1}
                         feedback_placeholder.success("Feedback submitted. Thank you.")
                     else:
-                        # Update the feedback message in the placeholder
                         feedback_placeholder.warning("No run ID found. Please generate a scenario first.")
                 except Exception as e:
-                    # Update the feedback message in the placeholder
                     feedback_placeholder.error(f"An error occurred while creating feedback: {str(e)}")
-
         with col2:
-            thumbs_down = st.button("👎")
-            if thumbs_down:
+            if st.button("👎"):
                 try:
                     run_id = st.session_state.get('run_id')
                     if run_id:
-                        feedback_type_str = "negative"
-                        score = 0  # or 0
-                        comment = ""
-
-                        # Record the feedback
-                        feedback_record = client.create_feedback(
-                            run_id,
-                            feedback_type_str,
-                            score=score,
-                            comment=comment,
-                        )
-                        st.session_state.feedback = {
-                            "feedback_id": str(feedback_record.id),
-                            "score": score,
-                        }
-                        # Update the feedback message in the placeholder
+                        feedback_record = client.create_feedback(run_id, "negative", score=0, comment="")
+                        st.session_state.feedback = {"feedback_id": str(feedback_record.id), "score": 0}
                         feedback_placeholder.success("Feedback submitted. Thank you.")
                     else:
-                        # Update the feedback message in the placeholder
                         feedback_placeholder.warning("No run ID found. Please generate a scenario first.")
                 except Exception as e:
-                    # Update the feedback message in the placeholder
                     feedback_placeholder.error(f"An error occurred while creating feedback: {str(e)}")
-
 except Exception as e:
     st.error("An error occurred: " + str(e))
 
-# Add a back button
-link_to_homepage = "/"
 
 st.markdown(
-    f'<a href="{link_to_homepage}" style="display: inline-block; padding: 5px 20px; color: white; text-align: center; text-decoration: none; font-size: 16px; border-radius: 4px;">⬅️ Back</a>',
-    unsafe_allow_html=True
+    '<a href="/" style="display: inline-block; padding: 5px 20px; color: white; text-align: center; text-decoration: none; font-size: 16px; border-radius: 4px;">⬅️ Back</a>',
+    unsafe_allow_html=True,
 )

--- a/pages/2_🛠️_Custom_Scenarios.py
+++ b/pages/2_🛠️_Custom_Scenarios.py
@@ -9,6 +9,11 @@ from mitreattack.stix20 import MitreAttackData
 from atlas_parser import ATLASData
 from core.llm import call_llm
 from core.schemas import LLMConfig
+from core.state import restore_from_query_params
+
+# Restore sidebar selections on direct page loads (e.g. browser refresh while
+# on this page). See core/state.py for the persisted-keys list.
+restore_from_query_params()
 
 
 # ------------------ LangSmith Setup ------------------ #

--- a/pages/2_🛠️_Custom_Scenarios.py
+++ b/pages/2_🛠️_Custom_Scenarios.py
@@ -1,97 +1,43 @@
 import os
-import pandas as pd
-import streamlit as st
 import re
 
-from langchain_anthropic import ChatAnthropic
-from langchain_community.llms import Ollama
-from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain_mistralai.chat_models import ChatMistralAI
-from langchain_openai import ChatOpenAI, AzureOpenAI
-from langchain_core.prompts import ChatPromptTemplate, HumanMessagePromptTemplate, SystemMessagePromptTemplate
-from langsmith import Client, RunTree, traceable
+import pandas as pd
+import streamlit as st
+from langsmith import Client
 from mitreattack.stix20 import MitreAttackData
-from openai import OpenAI
 
 from atlas_parser import ATLASData
+from core.llm import call_llm
+from core.schemas import LLMConfig
 
 
-# ------------------ Streamlit UI Configuration ------------------ #
+# ------------------ LangSmith Setup ------------------ #
 
-# Add environment variables for LangSmith
-os.environ["LANGCHAIN_TRACING_V2"]="true"
+os.environ["LANGCHAIN_TRACING_V2"] = "true"
 os.environ["LANGCHAIN_ENDPOINT"] = "https://api.smith.langchain.com"
 os.environ["LANGCHAIN_PROJECT"] = "AttackGen"
 
-# Initialise the LangChain client conditionally based on the presence of the secret
 if "LANGCHAIN_API_KEY" in st.secrets:
-    langchain_api_key = st.secrets["LANGCHAIN_API_KEY"]
-    client = Client(api_key=langchain_api_key)
+    client = Client(api_key=st.secrets["LANGCHAIN_API_KEY"])
 else:
     client = None
 
-# Add environment variables from session state for Azure OpenAI Service
-if "AZURE_OPENAI_API_KEY" in st.session_state:
-    os.environ["AZURE_OPENAI_API_KEY"] = st.session_state["AZURE_OPENAI_API_KEY"]
-if "AZURE_OPENAI_ENDPOINT" in st.session_state:
-    os.environ["AZURE_OPENAI_ENDPOINT"] = st.session_state["AZURE_OPENAI_ENDPOINT"]
-if "azure_deployment" in st.session_state:
-    os.environ["AZURE_DEPLOYMENT"] = st.session_state["azure_deployment"]
-if "openai_api_version" in st.session_state:
-    os.environ["OPENAI_API_VERSION"] = st.session_state["openai_api_version"]
 
-# Add environment variables from session state for Google AI API
-if "GOOGLE_API_KEY" in st.session_state:
-    os.environ["GOOGLE_API_KEY"] = st.session_state["GOOGLE_API_KEY"]
-if "google_model" in st.session_state:
-    os.environ["GOOGLE_MODEL"] = st.session_state["google_model"]
+# ------------------ Streamlit Configuration ------------------ #
 
-# Add environment variables from session state for Mistral API
-if "MISTRAL_API_KEY" in st.session_state:
-    os.environ["MISTRAL_API_KEY"] = st.session_state["MISTRAL_API_KEY"]
-if "mistral_model" in st.session_state:
-    os.environ["MISTRAL_MODEL"] = st.session_state["mistral_model"]
+st.set_page_config(page_title="Generate Custom Scenario", page_icon="🛠️")
 
-# Add environment variables from session state for Groq API
-if "GROQ_API_KEY" in st.session_state:
-    os.environ["GROQ_API_KEY"] = st.session_state["GROQ_API_KEY"]
-if "groq_model" in st.session_state:
-    os.environ["GROQ_MODEL"] = st.session_state["groq_model"]
+model_provider = st.session_state.get("chosen_model_provider", "OpenAI API")
+industry = st.session_state.get("industry")
+company_size = st.session_state.get("company_size")
+matrix = st.session_state.get("matrix", "Enterprise")
 
-# Add environment variables from session state for Ollama
-if "ollama_model" in st.session_state:
-    os.environ["OLLAMA_MODEL"] = st.session_state["ollama_model"]
-
-# Add environment variables from session state for Custom Provider
-if "custom_api_key" in st.session_state:
-    os.environ["CUSTOM_API_KEY"] = st.session_state["custom_api_key"]
-if "custom_model_name" in st.session_state:
-    os.environ["CUSTOM_MODEL_NAME"] = st.session_state["custom_model_name"]
-if "custom_base_url" in st.session_state:
-    os.environ["CUSTOM_BASE_URL"] = st.session_state["custom_base_url"]
-
-# Add environment variables from session state for Anthropic API
-if "ANTHROPIC_API_KEY" in st.session_state:
-    os.environ["ANTHROPIC_API_KEY"] = st.session_state["ANTHROPIC_API_KEY"]
-if "anthropic_model" in st.session_state:
-    os.environ["ANTHROPIC_MODEL"] = st.session_state["anthropic_model"]
-
-# Get the model provider and other required session state variables
-model_provider = st.session_state["chosen_model_provider"]
-industry = st.session_state["industry"]
-company_size = st.session_state["company_size"]
-matrix = st.session_state["matrix"]
-
-# Set the default value for the custom_scenario_generated session state variable
 if "custom_scenario_generated" not in st.session_state:
     st.session_state["custom_scenario_generated"] = False
 
-st.set_page_config(
-    page_title="Generate Custom Scenario",
-    page_icon="🛠️",
-)
 
 # ------------------ Incident Response Templates ------------------ #
+
 incident_response_templates = {
     "Enterprise": {
         "Phishing Attack": ["Spearphishing Attachment (T1193)", "User Execution (T1204)", "Browser Extensions (T1176)", "Credentials from Password Stores (T1555)", "Input Capture (T1056)", "Exfiltration Over C2 Channel (T1041)"],
@@ -115,650 +61,69 @@ incident_response_templates = {
         "Prompt Injection Attack": ["Acquire Public AI Artifacts (AML.T0002)", "LLM Prompt Injection (AML.T0051)", "AI Agent Tool Invocation (AML.T0053)", "Exfiltration via AI Inference API (AML.T0024)"],
         "LLM Jailbreak": ["LLM Jailbreak (AML.T0054)", "LLM Prompt Injection (AML.T0051)", "LLM Prompt Crafting (AML.T0065)", "Spearphishing via Social Engineering LLM (AML.T0052.000)"],
         "AI Supply Chain Attack": ["AI Supply Chain Compromise (AML.T0010)", "Publish Poisoned Datasets (AML.T0019)", "Manipulate AI Model (AML.T0018)", "Publish Poisoned Models (AML.T0058)"],
-    }
+    },
 }
 
 
-# ------------------ Helper Functions ------------------ #
+# ------------------ Data Loading ------------------ #
 
-# Load and cache the MITRE ATT&CK and ATLAS data
 @st.cache_resource
 def load_attack_data():
-    enterprise_data = MitreAttackData("./data/enterprise-attack.json")
-    ics_data = MitreAttackData("./data/ics-attack.json")
-    atlas_data = ATLASData("./data/stix-atlas.json")
-    return {"enterprise": enterprise_data, "ics": ics_data, "atlas": atlas_data}
+    return {
+        "enterprise": MitreAttackData("./data/enterprise-attack.json"),
+        "ics": MitreAttackData("./data/ics-attack.json"),
+        "atlas": ATLASData("./data/stix-atlas.json"),
+    }
+
 
 attack_data = load_attack_data()
 
-# Get all techniques
+
 @st.cache_resource
 def load_techniques():
     try:
-        matrix = st.session_state.get("matrix", "Enterprise")
-
-        if matrix == "ATLAS":
-            # Use custom ATLAS parser
+        current_matrix = st.session_state.get("matrix", "Enterprise")
+        if current_matrix == "ATLAS":
             techniques = attack_data["atlas"].get_techniques()
-            techniques_list = []
-            for tech in techniques:
-                techniques_list.append({
+            return pd.DataFrame([
+                {
                     'id': tech['id'],
                     'Technique Name': tech['name'],
                     'External ID': tech['external_id'],
-                    'Display Name': f"{tech['name']} ({tech['external_id']})"
-                })
-            techniques_df = pd.DataFrame(techniques_list)
-        else:
-            # Use standard ATT&CK parser
-            techniques = attack_data[matrix.lower()].get_techniques()
-            techniques_list = []
-            for technique in techniques:
-                for reference in technique.external_references:
-                    if "external_id" in reference:
-                        techniques_list.append({
-                            'id': technique.id,
-                            'Technique Name': technique.name,
-                            'External ID': reference['external_id'],
-                            'Display Name': f"{technique.name} ({reference['external_id']})"
-                        })
-            techniques_df = pd.DataFrame(techniques_list)
+                    'Display Name': f"{tech['name']} ({tech['external_id']})",
+                }
+                for tech in techniques
+            ])
 
-        return techniques_df
+        techniques = attack_data[current_matrix.lower()].get_techniques()
+        rows = []
+        for technique in techniques:
+            for reference in technique.external_references:
+                if "external_id" in reference:
+                    rows.append({
+                        'id': technique.id,
+                        'Technique Name': technique.name,
+                        'External ID': reference['external_id'],
+                        'Display Name': f"{technique.name} ({reference['external_id']})",
+                    })
+        return pd.DataFrame(rows)
     except Exception as e:
         print(f"Error in load_techniques: {e}")
-        return pd.DataFrame()  # Return an empty DataFrame
+        return pd.DataFrame()
+
 
 techniques_df = load_techniques()
 
-def generate_scenario_wrapper(openai_api_key, model_name, messages):
-    if client is not None:  # If LangChain client has been initialized
-        @traceable(run_type="llm", name="Custom Scenario", tags=["openai", "custom_scenario"], client=client)
-        def generate_scenario(openai_api_key, model_name, messages, *, run_tree: RunTree):
-            model_name = st.session_state["model_name"]
-            try:
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    
-                    # All models use the unified Responses API
-                    llm = ChatOpenAI(openai_api_key=openai_api_key, model_name=model_name, streaming=False, output_version="responses/v1")
-                    
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)  # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                st.error("An error occurred while generating the scenario: " + str(e))
-                st.session_state['run_id'] = str(run_tree.id)  # Ensure run_id is updated even on failure
-                return None
-    else:  # If LangChain client has not been initialized
-        def generate_scenario(openai_api_key, model_name, messages):
-            model_name = st.session_state["model_name"]
-            try:
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    
-                    # All models use the unified Responses API
-                    llm = ChatOpenAI(openai_api_key=openai_api_key, model_name=model_name, streaming=False, output_version="responses/v1")
-                    
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error("An error occurred while generating the scenario: " + str(e))
-                return None
-    
-    return generate_scenario(openai_api_key, model_name, messages)
 
-def generate_scenario_azure_wrapper(messages):
-    if client is not None:  # LangSmith client has been initialised
-        @traceable(run_type="llm", name="Custom Scenario (Azure OpenAI)", tags=["azure", "custom_scenario"], client=client if client is not None else None)
-        def generate_scenario_azure(messages, *, run_tree: RunTree):
-            try:
-                azure_api_key = os.getenv('AZURE_OPENAI_API_KEY')
-                azure_api_endpoint = os.getenv('AZURE_OPENAI_ENDPOINT')
-                azure_deployment_name = os.getenv('AZURE_DEPLOYMENT')
-                azure_api_version = os.getenv('OPENAI_API_VERSION')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = AzureOpenAI(api_key=azure_api_key,
-                                      azure_endpoint=azure_api_endpoint,
-                                      api_version=azure_api_version)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    
-                    # Convert message objects to the expected format
-                    formatted_messages = []
-                    for message in messages:
-                        if hasattr(message, 'role') and hasattr(message, 'content'):
-                            role = message.role
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        elif hasattr(message, 'type') and hasattr(message, 'content'):
-                            role = message.type
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        else:
-                            raise ValueError(f"Unsupported message format: {message}")
-                    
-                    response = llm.chat.completions.create(
-                        model=azure_deployment_name,
-                        messages=formatted_messages
-                    )
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)  # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)  # Ensure run_id is updated even on failure
-                return None
-    else:  # LangSmith client has not been initialised
-        def generate_scenario_azure(messages):
-            try:
-                azure_api_key = os.getenv('AZURE_OPENAI_API_KEY')
-                azure_api_endpoint = os.getenv('AZURE_OPENAI_ENDPOINT')
-                azure_deployment_name = os.getenv('AZURE_DEPLOYMENT')
-                azure_api_version = os.getenv('OPENAI_API_VERSION')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = AzureOpenAI(api_key=azure_api_key,
-                                      azure_endpoint=azure_api_endpoint,
-                                      api_version=azure_api_version)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    
-                    # Convert message objects to the expected format
-                    formatted_messages = []
-                    for message in messages:
-                        if hasattr(message, 'role') and hasattr(message, 'content'):
-                            role = message.role
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        elif hasattr(message, 'type') and hasattr(message, 'content'):
-                            role = message.type
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        else:
-                            raise ValueError(f"Unsupported message format: {message}")
-                    
-                    response = llm.chat.completions.create(
-                        model=azure_deployment_name,
-                        messages=formatted_messages
-                    )
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    return generate_scenario_azure(messages)
+# ------------------ Prompt Construction ------------------ #
 
-def generate_scenario_google_wrapper(google_api_key, model, messages):
-    if client is not None: # If LangSmith client has been initialised
-        @traceable(run_type="llm", name="Custom Scenario (Google AI API)", tags=["google", "custom_scenario"], client=client)
-        def generate_scenario_google(google_api_key, model, messages, *, run_tree: RunTree):
-            try:
-                google_api_key = os.getenv('GOOGLE_API_KEY')
-                model = os.getenv('GOOGLE_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatGoogleGenerativeAI(google_api_key=google_api_key, model=model)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id) # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id) # Ensure run_id is updated even on failure
-                return None
-    else: # If LangSmith client has not been initialised
-        def generate_scenario_google(google_api_key, model, messages):
-            try:
-                google_api_key = os.getenv('GOOGLE_API_KEY')
-                model = os.getenv('GOOGLE_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatGoogleGenerativeAI(google_api_key=google_api_key, model=model)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    
-    return generate_scenario_google(google_api_key, model, messages)
+SYSTEM_PROMPT = (
+    "You are a cybersecurity expert. Your task is to produce a comprehensive incident response "
+    "testing scenario based on the information provided. Format your response using proper "
+    "Markdown syntax with headers, bullet points, and formatting for readability."
+)
 
-def generate_scenario_mistral_wrapper(mistral_api_key, model_name, messages):
-    if client is not None: # If LangSmith client has been initialised
-        @traceable(run_type="llm", name="Custom Scenario (Mistral API)", tags=["mistral", "custom_scenario"], client=client)
-        def generate_scenario_mistral(mistral_api_key, model_name, messages, *, run_tree: RunTree):
-            try:
-                mistral_api_key = os.getenv('MISTRAL_API_KEY')
-                model = os.getenv('MISTRAL_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatMistralAI(mistral_api_key=mistral_api_key)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages, model=model)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id) # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id) # Ensure run_id is updated even on failure
-                return None
-    else: # If LangSmith client has not been initialised
-        def generate_scenario_mistral(mistral_api_key, model_name, messages):
-            try:
-                mistral_api_key = os.getenv('MISTRAL_API_KEY')
-                model = os.getenv('MISTRAL_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatMistralAI(mistral_api_key=mistral_api_key)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages, model=model)
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    
-    return generate_scenario_mistral(mistral_api_key, model_name, messages)
-
-def generate_scenario_groq_wrapper(groq_api_key, model_name, messages):
-    if client is not None: # If LangSmith client has been initialised
-        @traceable(run_type="llm", name="Custom Scenario (Groq API)", tags=["groq", "custom_scenario"], client=client)
-        def generate_scenario_groq(groq_api_key, model_name, messages, *, run_tree: RunTree):
-            try:
-                groq_api_key = os.getenv('GROQ_API_KEY')
-                model = os.getenv('GROQ_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = OpenAI(
-                        api_key=groq_api_key,
-                        base_url="https://api.groq.com/openai/v1",
-                    )
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    
-                    # Convert message objects to the expected format
-                    formatted_messages = []
-                    for message in messages:
-                        if hasattr(message, 'role') and hasattr(message, 'content'):
-                            role = message.role
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        elif hasattr(message, 'type') and hasattr(message, 'content'):
-                            role = message.type
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        else:
-                            raise ValueError(f"Unsupported message format: {message}")
-                    
-                    response = llm.chat.completions.create(
-                        model=model,
-                        messages=formatted_messages
-                    )
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)  # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)  # Ensure run_id is updated even on failure
-                return None
-    else: # If LangSmith client has not been initialised
-        def generate_scenario_groq(groq_api_key, model_name, messages):
-            try:
-                groq_api_key = os.getenv('GROQ_API_KEY')
-                model = os.getenv('GROQ_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = OpenAI(
-                        api_key=groq_api_key,
-                        base_url="https://api.groq.com/openai/v1",
-                    )
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    
-                    # Convert message objects to the expected format
-                    formatted_messages = []
-                    for message in messages:
-                        if hasattr(message, 'role') and hasattr(message, 'content'):
-                            role = message.role
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        elif hasattr(message, 'type') and hasattr(message, 'content'):
-                            role = message.type
-                            if role == 'human':
-                                role = 'user'  # Replace 'human' with 'user'
-                            formatted_messages.append({"role": role, "content": message.content})
-                        else:
-                            raise ValueError(f"Unsupported message format: {message}")
-                    
-                    response = llm.chat.completions.create(
-                        model=model,
-                        messages=formatted_messages
-                    )
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    
-    return generate_scenario_groq(groq_api_key, model_name, messages)
-
-def generate_scenario_ollama_wrapper(model):
-    if client is not None: # If LangSmith client has been initialised
-        @traceable(run_type="llm", name="Threat Group Scenario (Ollama)", tags=["ollama", "threat_group_scenario"], client=client)
-        def generate_scenario_ollama(model, *, run_tree: RunTree):
-            try:
-                model = os.getenv('OLLAMA_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = Ollama(model=model)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages, model=model)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)  # Store the run ID in the session state
-                return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)  # Ensure run_id is updated even on failure
-                return None
-    else: # If LangSmith client has not been initialised
-        def generate_scenario_ollama(model):
-            try:
-                model = os.getenv('OLLAMA_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = Ollama(model=model)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages, model=model)
-                    st.write("Scenario generated successfully.")
-                return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-
-    return generate_scenario_ollama(model)
-
-def generate_scenario_anthropic_wrapper(anthropic_api_key, model_name, messages):
-    if client is not None:  # If LangSmith client has been initialised
-        @traceable(run_type="llm", name="Custom Scenario (Anthropic)", tags=["anthropic", "custom_scenario"], client=client)
-        def generate_scenario_anthropic(anthropic_api_key, model_name, messages, *, run_tree: RunTree):
-            try:
-                anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')
-                model = os.getenv('ANTHROPIC_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    # Set max_tokens based on the model
-                    max_tokens = 8192  # Default for Haiku
-                    if "opus-4" in model:
-                        max_tokens = 32000
-                    elif "sonnet-4" in model or "3-7-sonnet" in model:
-                        max_tokens = 64000
-                    
-                    llm = ChatAnthropic(anthropic_api_key=anthropic_api_key, model_name=model, temperature=0.7, max_tokens=max_tokens)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)  # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)  # Ensure run_id is updated even on failure
-                return None
-    else:  # If LangSmith client has not been initialised
-        def generate_scenario_anthropic(anthropic_api_key, model_name, messages):
-            try:
-                anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')
-                model = os.getenv('ANTHROPIC_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    # Set max_tokens based on the model
-                    max_tokens = 8192  # Default for Haiku
-                    if "opus-4" in model:
-                        max_tokens = 32000
-                    elif "sonnet-4" in model or "3-7-sonnet" in model:
-                        max_tokens = 64000
-                    
-                    llm = ChatAnthropic(anthropic_api_key=anthropic_api_key, model_name=model, temperature=0.7, max_tokens=max_tokens)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    
-    return generate_scenario_anthropic(anthropic_api_key, model_name, messages)
-
-# Wrapper for Custom OpenAI-compatible endpoints
-def generate_custom_scenario_openai_wrapper(messages):
-    base_url = st.session_state.get('custom_base_url')
-    openai_api_key = st.session_state.get('custom_api_key')
-    model = st.session_state.get('custom_model_name')
-
-    if not base_url:
-        st.error("Custom base URL must be set for the custom model provider.")
-        return None
-    if not model:
-        st.error("Custom model name must be set for the custom model provider.")
-        return None
-    # API key might be optional for some local endpoints, so no explicit check here
-
-    # Convert LangChain message objects to the expected dictionary format
-    formatted_messages = []
-    for message in messages:
-        if hasattr(message, 'role') and hasattr(message, 'content'):
-            role = message.role
-            if role == 'human':
-                role = 'user'  # Replace 'human' with 'user'
-            formatted_messages.append({"role": role, "content": message.content})
-        elif hasattr(message, 'type') and hasattr(message, 'content'):
-            role = message.type
-            if role == 'human':
-                role = 'user'  # Replace 'human' with 'user'
-            formatted_messages.append({"role": role, "content": message.content})
-        else:
-            # Attempt to handle SystemMessagePromptTemplate and HumanMessagePromptTemplate if needed
-            if hasattr(message, 'prompt') and hasattr(message.prompt, 'template'):
-                 st.warning(f"Skipping message template of type {type(message)}")
-                 continue
-            else:
-                 st.error(f"Unsupported message format: {type(message)} - {message}")
-                 return None # Stop processing if message format is wrong
-
-    if not formatted_messages:
-        st.error("No valid messages found to send to the model.")
-        return None
-
-    if client is not None:  # If LangChain client has been initialized
-        @traceable(run_type="llm", name="Custom Scenario (Custom)", tags=["custom", "custom_scenario"], client=client)
-        def generate_scenario_custom(formatted_messages_arg, *, run_tree: RunTree):
-            try:
-                # Re-fetch variables inside traceable function scope if necessary
-                current_api_key = st.session_state.get('custom_api_key')
-                current_model = st.session_state.get('custom_model_name')
-                current_base_url = st.session_state.get('custom_base_url')
-
-                with st.status('Generating scenario with custom model...', expanded=True):
-                    st.write("Initialising custom AI model.")
-
-                    # Conditionally prepare client arguments
-                    client_args = {
-                        "base_url": current_base_url,
-                    }
-                    if current_api_key: # Only add api_key if it's not empty
-                        client_args["api_key"] = current_api_key
-
-                    llm = OpenAI(**client_args)
-
-                    response = llm.chat.completions.create(
-                        model=current_model,
-                        messages=formatted_messages_arg, # Use the formatted messages
-                        temperature=0.7,
-                        max_tokens=-1,
-                        stream=False
-                    )
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)  # Store the run ID in the session state
-                    return response
-            except Exception as e:
-                import traceback
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.error("Traceback:")
-                st.text(traceback.format_exc()) # Print the full traceback
-                st.session_state['run_id'] = str(run_tree.id)  # Ensure run_id is updated even on failure
-                return None
-        return generate_scenario_custom(formatted_messages)
-
-    else:  # If LangChain client has not been initialized
-        def generate_scenario_custom_no_trace(formatted_messages_arg):
-            try:
-                # Fetch variables directly from session state
-                current_api_key = st.session_state.get('custom_api_key')
-                current_model = st.session_state.get('custom_model_name')
-                current_base_url = st.session_state.get('custom_base_url')
-
-                with st.status('Generating scenario with custom model...', expanded=True):
-                    st.write("Initialising custom AI model.")
-
-                    # Conditionally prepare client arguments
-                    client_args = {
-                        "base_url": current_base_url,
-                    }
-                    if current_api_key: # Only add api_key if it's not empty
-                        client_args["api_key"] = current_api_key
-
-                    llm = OpenAI(**client_args)
-
-                    response = llm.chat.completions.create(
-                        model=current_model,
-                        messages=formatted_messages_arg,
-                        temperature=0.7,
-                        max_tokens=-1,
-                        stream=False
-                    )
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                import traceback
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.error("Traceback:")
-                st.text(traceback.format_exc()) # Print the full traceback
-                return None
-        return generate_scenario_custom_no_trace(formatted_messages)
-
-def template_selection(template, matrix):
-    try:
-        if template in incident_response_templates[matrix]:
-            template_techniques = incident_response_templates[matrix][template]
-
-            if matrix == "ATLAS":
-                # ATLAS returns techniques with external_id already included
-                matrix_techniques = attack_data["atlas"].get_techniques()
-                matrix_technique_names = [f"{tech['name']} ({tech['external_id']})" for tech in matrix_techniques]
-            else:
-                # ATT&CK uses get_attack_id to convert STIX ID to external ID
-                matrix_techniques = attack_data[matrix.lower()].get_techniques()
-                matrix_technique_names = [f"{technique['name']} ({attack_data[matrix.lower()].get_attack_id(technique['id'])})" for technique in matrix_techniques]
-
-            selected_techniques = [tech for tech in template_techniques if tech in matrix_technique_names]
-            st.session_state['selected_techniques'] = selected_techniques
-        else:
-            st.write(f"Template {template} not found in {matrix} matrix")
-    except Exception as e:
-        st.error(f"An error occurred in template_selection: {str(e)}")
-
-
-# ------------------ Streamlit UI ------------------ #
-
-# Get the current matrix from the session state
-matrix = st.session_state.get("matrix", "Enterprise")
-
-st.markdown("# <span style='color: #1DB954;'>Generate Custom Scenario🛠️</span>", unsafe_allow_html=True)
-
-if matrix == "ATLAS":
-    st.markdown("""
-            ### Select ATLAS Techniques
-            """)
-else:
-    st.markdown("""
-            ### Select ATT&CK Techniques
-            """)
-
-with st.expander("Use a Template (Optional)"):
-    if matrix == "ATLAS":
-        st.markdown("""
-                Select a template to quickly generate a custom scenario based on a predefined set of ATLAS techniques.
-                """)
-    else:
-        st.markdown("""
-                Select a template to quickly generate a custom scenario based on a predefined set of ATT&CK techniques.
-                """)
-
-    # Dropdown for selecting the incident response template
-    selected_template = st.selectbox(
-        "Select a template",
-        options=[""] + list(incident_response_templates[matrix].keys()),  # Add an empty option for no selection
-        format_func=lambda x: "Select a template" if x == "" else x  # Display placeholder text
-    )
-
-    # Automatically update selected techniques when a template is chosen
-    if selected_template:
-        template_selection(selected_template, matrix)
-st.markdown("")
-
-if matrix == "ATLAS":
-    st.markdown("""
-            Use the multi-select box below to add or update the ATLAS techniques that you would like to include in a custom incident response testing scenario.
-            """)
-else:
-    st.markdown("""
-            Use the multi-select box below to add or update the ATT&CK techniques that you would like to include in a custom incident response testing scenario.
-            """)
-
-selected_techniques = []
-if not techniques_df.empty:
-    if matrix == "ATLAS":
-        # Use ATLAS technique list from techniques_df
-        technique_options = techniques_df['Display Name'].tolist()
-    else:
-        # Use standard ATT&CK parsing
-        techniques = attack_data[matrix.lower()].get_techniques()
-        technique_options = [f"{technique['name']} ({attack_data[matrix.lower()].get_attack_id(technique['id'])})" for technique in techniques]
-
-    select_label = "Select ATLAS Techniques" if matrix == "ATLAS" else "Select ATT&CK Techniques"
-    selected_techniques = st.multiselect(select_label, options=technique_options, default=st.session_state.get('selected_techniques', []))
-
-    if matrix == "Enterprise":
-        st.info("📝 Techniques are searchable by either their name or technique ID (e.g. `T1556` or `Phishing`).")
-    elif matrix == "ICS":
-        st.info("📝 Techniques are searchable by either their name or technique ID (e.g. `T0814` or `Denial of Service`).")
-    elif matrix == "ATLAS":
-        st.info("📝 Techniques are searchable by either their name or technique ID (e.g. `AML.T0051` or `Prompt Injection`).")
-    else:
-        st.info("📝 Techniques are searchable by either their name or technique ID.")
-    
-try:
-    if len(selected_techniques) > 0:
-        selected_techniques_string = '\n'.join(selected_techniques)
-        template_info = f"This is a '{selected_template}' scenario." if selected_template else ""
-
-        # Create System Message Template
-        system_template = "You are a cybersecurity expert. Your task is to produce a comprehensive incident response testing scenario based on the information provided. Format your response using proper Markdown syntax with headers, bullet points, and formatting for readability."
-        system_message_prompt = SystemMessagePromptTemplate.from_template(system_template)
-
-        # Create Human Message Template - different for ATLAS vs ATT&CK
-        if matrix == "ATLAS":
-            human_template = ("""
+ATLAS_HUMAN_TEMPLATE = """
 **Background information:**
 The company operates in the '{industry}' industry and is of size '{company_size}'.
 They deploy AI/ML systems that may be vulnerable to adversarial attacks.
@@ -774,9 +139,9 @@ Create a custom incident response testing scenario focused on adversarial ML att
 Focus on realistic attack vectors that target AI/ML infrastructure, including model manipulation, data poisoning, adversarial inputs, prompt injection, and AI supply chain attacks.
 
 Your response should be well structured and formatted using Markdown. Write in British English.
-""")
-        else:
-            human_template = ("""
+"""
+
+ATTACK_HUMAN_TEMPLATE = """
 **Background information:**
 The company operates in the '{industry}' industry and is of size '{company_size}'.
 
@@ -789,424 +154,238 @@ The threat actor is known to use the following ATT&CK techniques from the {matri
 Create a custom incident response testing scenario based on the information provided. The goal of the scenario is to test the company's incident response capabilities against a threat actor group that uses the identified ATT&CK techniques.
 
 Your response should be well structured and formatted using Markdown.
-""")
-        human_message_prompt = HumanMessagePromptTemplate.from_template(human_template)
+"""
 
-        # Construct the ChatPromptTemplate
-        chat_prompt = ChatPromptTemplate.from_messages([system_message_prompt, human_message_prompt])
 
-        # Format the prompt
-        messages = chat_prompt.format_prompt(selected_techniques_string=selected_techniques_string, 
-                                            industry=industry, 
-                                            company_size=company_size,
-                                            template_info=template_info,
-                                            matrix=matrix).to_messages()
+def build_messages(selected_techniques_string, template_info):
+    template = ATLAS_HUMAN_TEMPLATE if matrix == "ATLAS" else ATTACK_HUMAN_TEMPLATE
+    user_content = template.format(
+        industry=industry,
+        company_size=company_size,
+        selected_techniques_string=selected_techniques_string,
+        template_info=template_info,
+        matrix=matrix,
+    )
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+
+def post_process(scenario_text: str) -> tuple[str | None, str]:
+    match = re.search(r'<think>(.*?)</think>', scenario_text, re.DOTALL)
+    thinking = match.group(1).strip() if match else None
+    cleaned = re.sub(r'<think>.*?</think>', '', scenario_text, flags=re.DOTALL).strip()
+    cleaned = re.sub(r'^```\w*\n|```$', '', cleaned, flags=re.MULTILINE).strip()
+    return thinking, cleaned
+
+
+def template_selection(template, current_matrix):
+    try:
+        if template not in incident_response_templates[current_matrix]:
+            st.write(f"Template {template} not found in {current_matrix} matrix")
+            return
+
+        template_techniques = incident_response_templates[current_matrix][template]
+        if current_matrix == "ATLAS":
+            matrix_techniques = attack_data["atlas"].get_techniques()
+            matrix_technique_names = [f"{tech['name']} ({tech['external_id']})" for tech in matrix_techniques]
+        else:
+            matrix_techniques = attack_data[current_matrix.lower()].get_techniques()
+            matrix_technique_names = [
+                f"{technique['name']} ({attack_data[current_matrix.lower()].get_attack_id(technique['id'])})"
+                for technique in matrix_techniques
+            ]
+
+        st.session_state['selected_techniques'] = [
+            tech for tech in template_techniques if tech in matrix_technique_names
+        ]
+    except Exception as e:
+        st.error(f"An error occurred in template_selection: {str(e)}")
+
+
+# ------------------ Streamlit UI ------------------ #
+
+st.markdown("# <span style='color: #1DB954;'>Generate Custom Scenario🛠️</span>", unsafe_allow_html=True)
+
+if matrix == "ATLAS":
+    st.markdown("### Select ATLAS Techniques")
+else:
+    st.markdown("### Select ATT&CK Techniques")
+
+with st.expander("Use a Template (Optional)"):
+    if matrix == "ATLAS":
+        st.markdown("Select a template to quickly generate a custom scenario based on a predefined set of ATLAS techniques.")
+    else:
+        st.markdown("Select a template to quickly generate a custom scenario based on a predefined set of ATT&CK techniques.")
+
+    selected_template = st.selectbox(
+        "Select a template",
+        options=[""] + list(incident_response_templates[matrix].keys()),
+        format_func=lambda x: "Select a template" if x == "" else x,
+    )
+    if selected_template:
+        template_selection(selected_template, matrix)
+
+st.markdown("")
+
+if matrix == "ATLAS":
+    st.markdown("Use the multi-select box below to add or update the ATLAS techniques that you would like to include in a custom incident response testing scenario.")
+else:
+    st.markdown("Use the multi-select box below to add or update the ATT&CK techniques that you would like to include in a custom incident response testing scenario.")
+
+selected_techniques = []
+if not techniques_df.empty:
+    if matrix == "ATLAS":
+        technique_options = techniques_df['Display Name'].tolist()
+    else:
+        techniques = attack_data[matrix.lower()].get_techniques()
+        technique_options = [
+            f"{technique['name']} ({attack_data[matrix.lower()].get_attack_id(technique['id'])})"
+            for technique in techniques
+        ]
+
+    select_label = "Select ATLAS Techniques" if matrix == "ATLAS" else "Select ATT&CK Techniques"
+    selected_techniques = st.multiselect(
+        select_label,
+        options=technique_options,
+        default=st.session_state.get('selected_techniques', []),
+    )
+
+    if matrix == "Enterprise":
+        st.info("📝 Techniques are searchable by either their name or technique ID (e.g. `T1556` or `Phishing`).")
+    elif matrix == "ICS":
+        st.info("📝 Techniques are searchable by either their name or technique ID (e.g. `T0814` or `Denial of Service`).")
+    elif matrix == "ATLAS":
+        st.info("📝 Techniques are searchable by either their name or technique ID (e.g. `AML.T0051` or `Prompt Injection`).")
+    else:
+        st.info("📝 Techniques are searchable by either their name or technique ID.")
+
+
+messages = None
+try:
+    if selected_techniques:
+        selected_techniques_string = '\n'.join(selected_techniques)
+        template_info = f"This is a '{selected_template}' scenario." if selected_template else ""
+        messages = build_messages(selected_techniques_string, template_info)
 except Exception as e:
     st.error(f"An error occurred: {str(e)}")
 
 st.markdown("")
+st.markdown(
+    """
+    ### Generate a Scenario
 
-# Display the scenario generation section
-st.markdown("""
-            ### Generate a Scenario
+    Click the button below to generate a scenario based on the selected technique(s).
 
-            Click the button below to generate a scenario based on the selected technique(s).
+    It normally takes between 30-50 seconds to generate a scenario, although for local models this is highly dependent on your hardware and the selected model. ⏱️
+    """
+)
 
-            It normally takes between 30-50 seconds to generate a scenario, although for local models this is highly dependent on your hardware and the selected model. ⏱️
-            """)
+
+def _render_scenario(scenario_text: str):
+    st.session_state['custom_scenario_generated'] = True
+    st.session_state['custom_scenario_text'] = scenario_text
+    st.markdown(scenario_text)
+    st.download_button(
+        label="Download Scenario",
+        data=scenario_text,
+        file_name="custom_scenario.md",
+        mime="text/markdown",
+    )
+    st.session_state['last_scenario'] = True
+    st.session_state['last_scenario_text'] = scenario_text
+
+
+def _ready() -> bool:
+    if model_provider != "Custom" and not st.session_state.get("llm_api_key"):
+        st.info("Please add your API key in the sidebar to continue.")
+        return False
+    if not st.session_state.get("llm_model_name"):
+        st.info("Please select a model in the sidebar to continue.")
+        return False
+    if not industry:
+        st.info("Please select your company's industry in the sidebar to continue.")
+        return False
+    if not company_size:
+        st.info("Please select your company's size in the sidebar to continue.")
+        return False
+    if not selected_techniques:
+        st.info("Please select at least one technique.")
+        return False
+    return True
+
+
 try:
-        if model_provider == "Azure OpenAI Service":
-            if st.button('Generate Scenario', key='generate_custom_scenario_azure'):
-                if not os.environ["AZURE_OPENAI_API_KEY"]:
-                    st.info("Please add your Azure OpenAI Service API key to continue.")
-                if not os.environ["AZURE_OPENAI_ENDPOINT"]:
-                    st.info("Please add your Azure OpenAI Service API endpoint to continue.")
-                if not os.environ["AZURE_DEPLOYMENT"]:
-                    st.info("Please add the name of your Azure OpenAI Service Deployment to continue.")
-                elif not industry:
-                    st.info("Please select your company's industry to continue.")
-                elif not company_size:
-                    st.info("Please select your company's size to continue.")
-                else:
-                        response = generate_scenario_azure_wrapper(messages)
-                        st.markdown("---")
-                        if response is not None:
-                            st.session_state['custom_scenario_generated'] = True
-                            custom_scenario_text = response.choices[0].message.content
-                            st.session_state['custom_scenario_text'] = custom_scenario_text  # Store the generated scenario in the session state
-                            st.markdown(custom_scenario_text)
-                            st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
+    if st.button('Generate Scenario', key='generate_custom_scenario'):
+        if _ready() and messages is not None:
+            config = LLMConfig.from_session_state(
+                trace_name="Custom Scenario",
+                trace_tags=("custom_scenario",),
+            )
+            scenario_text = None
+            try:
+                with st.status('Generating scenario...', expanded=True):
+                    st.write("Calling the model.")
+                    scenario_text = call_llm(config, messages)
+                    st.write("Scenario generated successfully.")
+            except Exception as e:
+                st.error(f"An error occurred while generating the scenario: {str(e)}")
 
-                            st.session_state['last_scenario'] = True
-                            st.session_state['last_scenario_text'] = custom_scenario_text # Store the last scenario in the session state for use by the Scenario Assistant
+            st.markdown("---")
+            if scenario_text:
+                thinking, cleaned = post_process(scenario_text)
+                if thinking:
+                    with st.expander("View Model's Reasoning"):
+                        st.markdown(thinking)
+                _render_scenario(cleaned)
+            elif 'custom_scenario_text' in st.session_state and st.session_state['custom_scenario_generated']:
+                st.markdown("Displaying previously generated scenario:")
+                st.markdown(st.session_state['custom_scenario_text'])
+                st.download_button(
+                    label="Download Scenario",
+                    data=st.session_state['custom_scenario_text'],
+                    file_name="custom_scenario.md",
+                    mime="text/markdown",
+                )
 
-                        else:
-                            # If a scenario has been generated previously, display it
-                            if 'custom_scenario_text' in st.session_state and st.session_state['custom_scenario_generated']:
-                                st.markdown("---")
-                                st.markdown(st.session_state['custom_scenario_text'])
-                                st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
+    if 'LANGCHAIN_API_KEY' not in st.secrets:
+        st.info("ℹ️ No LangChain API key has been set. This run will not be logged to LangSmith.")
 
-        elif model_provider == "Google AI API":
-            if st.button('Generate Scenario', key='generate_custom_scenario_google'):
-                if not os.environ["GOOGLE_API_KEY"]:
-                    st.info("Please add your Google AI API key to continue.")
-                if not os.environ["GOOGLE_MODEL"]:
-                    st.info("Please select a model to continue.")
-                elif not industry:
-                    st.info("Please select your company's industry to continue.")
-                elif not company_size:
-                    st.info("Please select your company's size to continue.")
-                else:
-                    google_api_key = st.session_state.get('google_api_key')
-                    model_name = os.getenv('GOOGLE_MODEL')
-                    response = generate_scenario_google_wrapper(google_api_key, model_name, messages)
-                    st.markdown("---")
-                    if response is not None:
-                        try:
-                            # Extract text content from structured response if needed
-                            if isinstance(response.content, list):
-                                # Find text blocks in the structured response
-                                text_blocks = [block.get('text', '') for block in response.content if isinstance(block, dict) and block.get('type') == 'text']
-                                custom_scenario_text = '\n'.join(text_blocks)
-                            else:
-                                custom_scenario_text = response.content
-
-                            st.session_state['custom_scenario_generated'] = True
-                            st.session_state['custom_scenario_text'] = custom_scenario_text
-                            st.markdown(custom_scenario_text)
-                            st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
-
-                            st.session_state['last_scenario'] = True
-                            st.session_state['last_scenario_text'] = custom_scenario_text
-                        except Exception as processing_error:
-                            st.error(f"An error occurred while processing the scenario response: {processing_error}")
-                            st.text("Raw response content:")
-                            st.json(str(response.content))
+    feedback_placeholder = st.empty()
+    st.markdown("---")
+    if st.session_state.get('custom_scenario_generated', False) and client is not None:
+        st.markdown("Rate the scenario to help improve this tool.")
+        col1, col2, _ = st.columns([0.5, 0.5, 5])
+        with col1:
+            if st.button("👍", key="thumbs_up_custom"):
+                try:
+                    run_id = st.session_state.get('run_id')
+                    if run_id:
+                        feedback_record = client.create_feedback(run_id, "positive", score=1, comment="")
+                        st.session_state.feedback = {"feedback_id": str(feedback_record.id), "score": 1}
+                        feedback_placeholder.success("Feedback submitted. Thank you.")
                     else:
-                        # If a scenario has been generated previously, display it
-                        if 'custom_scenario_text' in st.session_state and st.session_state['custom_scenario_generated']:
-                            st.markdown("---")
-                            st.markdown(st.session_state['custom_scenario_text'])
-                            st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
-
-        elif model_provider == "Mistral API":
-            if st.button('Generate Scenario', key='generate_custom_scenario_mistral'):
-                if not os.environ["MISTRAL_API_KEY"]:
-                    st.info("Please add your Mistral API key to continue.")
-                if not os.environ["MISTRAL_MODEL"]:
-                    st.info("Please select a model to continue.")
-                elif not industry:
-                    st.info("Please select your company's industry to continue.")
-                elif not company_size:
-                    st.info("Please select your company's size to continue.")
-                else:
-                    mistral_api_key = st.session_state.get('mistral_api_key')
-                    model_name = os.getenv('MISTRAL_MODEL')
-                    response = generate_scenario_mistral_wrapper(mistral_api_key, model_name, messages)
-                    st.markdown("---")
-                    if response is not None:
-                        st.session_state['custom_scenario_generated'] = True
-                        custom_scenario_text = response.content
-                        st.session_state['custom_scenario_text'] = custom_scenario_text  # Store the generated scenario in the session state
-                        st.markdown(custom_scenario_text)
-                        st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
-
-                        st.session_state['last_scenario'] = True
-                        st.session_state['last_scenario_text'] = custom_scenario_text # Store the last scenario in the session state for use by the Scenario Assistant
-
+                        feedback_placeholder.warning("No run ID found. Please generate a scenario first.")
+                except Exception as e:
+                    feedback_placeholder.error(f"An error occurred while creating feedback: {str(e)}")
+        with col2:
+            if st.button("👎"):
+                try:
+                    run_id = st.session_state.get('run_id')
+                    if run_id:
+                        feedback_record = client.create_feedback(run_id, "negative", score=0, comment="")
+                        st.session_state.feedback = {"feedback_id": str(feedback_record.id), "score": 0}
+                        feedback_placeholder.success("Feedback submitted. Thank you.")
                     else:
-                        # If a scenario has been generated previously, display it
-                        if 'custom_scenario_text' in st.session_state and st.session_state['custom_scenario_generated']:
-                            st.markdown("---")
-                            st.markdown(st.session_state['custom_scenario_text'])
-                            st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
-        
-        elif model_provider == "Ollama":
-            if st.button('Generate Scenario', key='generate_custom_scenario_ollama'):
-                if not os.environ["OLLAMA_MODEL"]:
-                    st.info("Please select a model to continue.")
-                elif not industry:
-                    st.info("Please select your company's industry to continue.")
-                elif not company_size:
-                    st.info("Please select your company's size to continue.")
-                else:
-                    model = os.getenv('OLLAMA_MODEL')
-                    response = generate_scenario_ollama_wrapper(model)
-                    st.markdown("---")
-                    if response is not None:
-                        st.session_state['custom_scenario_generated'] = True
-                        custom_scenario_text = response
-                        st.session_state['custom_scenario_text'] = custom_scenario_text  # Store the generated scenario in the session state
-                        st.markdown(custom_scenario_text)
-                        st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
-
-                        st.session_state['last_scenario'] = True
-                        st.session_state['last_scenario_text'] = custom_scenario_text # Store the last scenario in the session state for use by the Scenario Assistant
-
-                    else:
-                        # If a scenario has been generated previously, display it
-                        if 'custom_scenario_text' in st.session_state and st.session_state['custom_scenario_generated']:
-                            st.markdown("---")
-                            st.markdown(st.session_state['custom_scenario_text'])
-                            st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
-
-        elif model_provider == "Anthropic API":
-            if st.button('Generate Scenario', key='generate_custom_scenario_anthropic'):
-                if not os.environ["ANTHROPIC_API_KEY"]:
-                    st.info("Please add your Anthropic API key to continue.")
-                if not os.environ["ANTHROPIC_MODEL"]:
-                    st.info("Please select a model to continue.")
-                elif not industry:
-                    st.info("Please select your company's industry to continue.")
-                elif not company_size:
-                    st.info("Please select your company's size to continue.")
-                elif not selected_techniques:
-                    st.info("Please select at least one ATT&CK technique.")
-                else:
-                    anthropic_api_key = st.session_state.get('anthropic_api_key')
-                    model_name = os.getenv('ANTHROPIC_MODEL')
-                    response = generate_scenario_anthropic_wrapper(anthropic_api_key, model_name, messages)
-                    st.markdown("---")
-                    if response is not None:
-                        st.session_state['custom_scenario_generated'] = True
-                        custom_scenario_text = response.content
-                        st.session_state['custom_scenario_text'] = custom_scenario_text  # Store the generated scenario in the session state
-                        st.markdown(custom_scenario_text)
-                        st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
-
-                        st.session_state['last_scenario'] = True
-                        st.session_state['last_scenario_text'] = custom_scenario_text # Store the last scenario in the session state for use by the Scenario Assistant
-
-                    else:
-                        # If a scenario has been generated previously, display it
-                        if 'custom_scenario_text' in st.session_state and st.session_state['custom_scenario_generated']:
-                            st.markdown("---")
-                            st.markdown(st.session_state['custom_scenario_text'])
-                            st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
-
-        elif model_provider == "Groq API":
-            if st.button('Generate Scenario', key='generate_custom_scenario_groq'):
-                if not os.environ["GROQ_API_KEY"]:
-                    st.info("Please add your Groq API key to continue.")
-                if not os.environ["GROQ_MODEL"]:
-                    st.info("Please select a model to continue.")
-                elif not industry:
-                    st.info("Please select your company's industry to continue.")
-                elif not company_size:
-                    st.info("Please select your company's size to continue.")
-                else:
-                    groq_api_key = st.session_state.get('GROQ_API_KEY')
-                    model_name = os.getenv('GROQ_MODEL')
-                    response = generate_scenario_groq_wrapper(groq_api_key, model_name, messages)
-                    st.markdown("---")
-                    if response is not None:
-                        st.session_state['custom_scenario_generated'] = True
-                        content = response.choices[0].message.content
-                        
-                        # Check if this is DeepSeek output with thinking tags
-                        if re.search(r'<think>(.*?)</think>', content, re.DOTALL):
-                            # Extract the thinking content and the rest of the scenario
-                            thinking_match = re.search(r'<think>(.*?)</think>', content, re.DOTALL)
-                            thinking_content = thinking_match.group(1).strip()
-                            custom_scenario_text = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL).strip()
-                            
-                            # Display thinking content in an expander
-                            with st.expander("View Model's Reasoning"):
-                                st.markdown(thinking_content)
-                        else:
-                            # If no thinking tags, use the entire content as the scenario
-                            custom_scenario_text = content
-                        
-                        # Clean up the scenario text by removing code block markers if present
-                        custom_scenario_text = re.sub(r'^```\w*\n|```$', '', custom_scenario_text, flags=re.MULTILINE).strip()
-                        
-                        st.session_state['custom_scenario_text'] = custom_scenario_text  # Store the generated scenario in the session state
-                        st.markdown(custom_scenario_text)
-                        st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
-
-                        st.session_state['last_scenario'] = True
-                        st.session_state['last_scenario_text'] = custom_scenario_text # Store the last scenario in the session state for use by the Scenario Assistant
-
-                    else:
-                        # If a scenario has been generated previously, display it
-                        if 'custom_scenario_text' in st.session_state and st.session_state['custom_scenario_generated']:
-                            st.markdown("---")
-                            st.markdown(st.session_state['custom_scenario_text'])
-                            st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
-        elif model_provider == "Custom":
-            if st.button('Generate Scenario', key='generate_custom_scenario_custom'):
-                # Check for required custom settings
-                if not st.session_state.get('custom_base_url'):
-                    st.info("Please set the Custom Base URL in the sidebar.")
-                elif not st.session_state.get('custom_model_name'):
-                    st.info("Please set the Custom Model Name in the sidebar.")
-                elif not industry:
-                    st.info("Please select your company\'s industry to continue.")
-                elif not company_size:
-                    st.info("Please select your company\'s size to continue.")
-                elif not selected_techniques:
-                    st.info("Please select at least one ATT&CK technique.")
-                else:
-                    # Call the wrapper function
-                    response = generate_custom_scenario_openai_wrapper(messages)
-                    st.markdown("---")
-                    if response is not None:
-                        try:
-                            # Robust checking for the response structure
-                            if hasattr(response, 'choices') and response.choices:
-                                first_choice = response.choices[0]
-                                if hasattr(first_choice, 'message') and first_choice.message:
-                                    if hasattr(first_choice.message, 'content') and first_choice.message.content:
-                                        st.session_state['custom_scenario_generated'] = True
-                                        custom_scenario_text = first_choice.message.content
-                                        st.session_state['custom_scenario_text'] = custom_scenario_text
-                                        st.markdown(custom_scenario_text)
-                                        st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
-
-                                        st.session_state['last_scenario'] = True
-                                        st.session_state['last_scenario_text'] = custom_scenario_text
-                                    else:
-                                        st.error("Error processing response: 'content' attribute missing from message.")
-                                        st.json(response.model_dump_json(indent=2))
-                                else:
-                                    st.error("Error processing response: 'message' attribute missing from the first choice.")
-                                    st.json(response.model_dump_json(indent=2))
-                            else:
-                                st.error("Error processing response: 'choices' list is missing or empty.")
-                                st.json(response.model_dump_json(indent=2))
-                        except Exception as processing_error:
-                            st.error(f"An error occurred while processing the scenario response: {processing_error}")
-                            st.text("Raw response object:")
-                            st.json(response.model_dump_json(indent=2))
-                    else:
-                        # Response was None
-                        st.warning("Scenario generation failed. Check the error message above.")
-                        if 'custom_scenario_text' in st.session_state and st.session_state['custom_scenario_generated']:
-                            st.markdown("Displaying previously generated scenario:")
-                            st.markdown(st.session_state['custom_scenario_text'])
-                            st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
-
-        else:  # OpenAI API (default)
-            if st.button('Generate Scenario', key="generate_custom_scenario"):
-                openai_api_key = st.session_state.get('openai_api_key')
-                model_name = st.session_state.get('model_name')
-                if not openai_api_key:
-                    st.info("Please add your OpenAI API key to continue.")
-                if not model_name:
-                    st.info("Please select a model to continue.")
-                elif not industry:
-                    st.info("Please select your company's industry to continue.")
-                elif not company_size:
-                    st.info("Please select your company's size to continue.")
-                else:
-                    # Generate a scenario
-                    response = generate_scenario_wrapper(openai_api_key, model_name, messages)
-                    st.markdown("---")
-                    if response is not None:
-                        st.session_state['custom_scenario_generated'] = True
-                        # Extract text content from Responses API structured response
-                        if isinstance(response.content, list):
-                            # Find text blocks in the structured response
-                            text_blocks = [block.get('text', '') for block in response.content if block.get('type') == 'text']
-                            custom_scenario_text = '\n'.join(text_blocks)
-                        else:
-                            custom_scenario_text = response.content
-                        st.session_state['custom_scenario_text'] = custom_scenario_text  # Store the generated scenario in the session state
-                        st.markdown(custom_scenario_text)
-                        st.download_button(label="Download Scenario", data=custom_scenario_text, file_name="custom_scenario.md", mime="text/markdown")
-
-                        st.session_state['last_scenario'] = True
-                        st.session_state['last_scenario_text'] = custom_scenario_text # Store the last scenario in the session state for use by the Scenario Assistant
-                    else:
-                        # If a scenario has been generated previously, display it
-                        if 'custom_scenario_text' in st.session_state and st.session_state['custom_scenario_generated']:
-                            st.markdown("---")
-                            st.markdown(st.session_state['custom_scenario_text'])
-                            st.download_button(label="Download Scenario", data=st.session_state['custom_scenario_text'], file_name="custom_scenario.md", mime="text/markdown")
-
-        # Display an info message if no API key is set
-        if 'LANGCHAIN_API_KEY' not in st.secrets:
-            st.info("ℹ️ No LangChain API key has been set. This run will not be logged to LangSmith.")
-
-        # Create a placeholder for the feedback message
-        feedback_placeholder = st.empty()
-
-        # Show the thumbs_up and thumbs_down buttons only when a scenario has been generated
-        st.markdown("---")
-        # Ensure the condition checks if 'custom_scenario_generated' is True and client is initialized
-        if st.session_state.get('custom_scenario_generated', False) and client is not None:
-            st.markdown("Rate the scenario to help improve this tool.")
-            col1, col2, col3 = st.columns([0.5, 0.5, 5])
-            with col1:
-                thumbs_up = st.button("👍", key="thumbs_up_custom")
-                if thumbs_up:
-                    try:
-                        run_id = st.session_state.get('run_id')
-                        if run_id:
-                            feedback_type_str = "positive"
-                            score = 1  # or 0
-                            comment = ""
-
-                            # Record the feedback
-                            feedback_record = client.create_feedback(
-                                run_id,
-                                feedback_type_str,
-                                score=score,
-                                comment=comment,
-                            )
-                            st.session_state.feedback = {
-                                "feedback_id": str(feedback_record.id),
-                                "score": score,
-                            }
-                            # Update the feedback message in the placeholder
-                            feedback_placeholder.success("Feedback submitted. Thank you.")
-                        else:
-                            # Update the feedback message in the placeholder
-                            feedback_placeholder.warning("No run ID found. Please generate a scenario first.")
-                    except Exception as e:
-                        # Update the feedback message in the placeholder
-                        feedback_placeholder.error(f"An error occurred while creating feedback: {str(e)}")
-
-            with col2:
-                thumbs_down = st.button("👎")
-                if thumbs_down:
-                    try:
-                        run_id = st.session_state.get('run_id')
-                        if run_id:
-                            feedback_type_str = "negative"
-                            score = 0  # or 0
-                            comment = ""
-
-                            # Record the feedback
-                            feedback_record = client.create_feedback(
-                                run_id,
-                                feedback_type_str,
-                                score=score,
-                                comment=comment,
-                            )
-                            st.session_state.feedback = {
-                                "feedback_id": str(feedback_record.id),
-                                "score": score,
-                            }
-                            # Update the feedback message in the placeholder
-                            feedback_placeholder.success("Feedback submitted. Thank you.")
-                        else:
-                            # Update the feedback message in the placeholder
-                            feedback_placeholder.warning("No run ID found. Please generate a scenario first.")
-                    except Exception as e:
-                        # Update the feedback message in the placeholder
-                        feedback_placeholder.error(f"An error occurred while creating feedback: {str(e)}")
-                
-                
+                        feedback_placeholder.warning("No run ID found. Please generate a scenario first.")
+                except Exception as e:
+                    feedback_placeholder.error(f"An error occurred while creating feedback: {str(e)}")
 except Exception as e:
     st.error("An error occurred: " + str(e))
-    
 
-# Add a back button
-link_to_homepage = "/"
 
 st.markdown(
-    f'<a href="{link_to_homepage}" style="display: inline-block; padding: 5px 20px; color: white; text-align: center; text-decoration: none; font-size: 16px; border-radius: 4px;">⬅️ Back</a>',
-    unsafe_allow_html=True
+    '<a href="/" style="display: inline-block; padding: 5px 20px; color: white; text-align: center; text-decoration: none; font-size: 16px; border-radius: 4px;">⬅️ Back</a>',
+    unsafe_allow_html=True,
 )

--- a/pages/3_🤖_AI_Insider_Threat_Scenarios.py
+++ b/pages/3_🤖_AI_Insider_Threat_Scenarios.py
@@ -27,525 +27,61 @@ AI Agents" by Matt Adams (https://ai-insider-threat.matt-adams.co.uk).
 
 import os
 import re
+
 import streamlit as st
+from langsmith import Client
 
-from langchain_anthropic import ChatAnthropic
-from langchain_community.llms import Ollama
-from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain_mistralai.chat_models import ChatMistralAI
-from langchain_openai import ChatOpenAI, AzureOpenAI
-from langchain_core.prompts import ChatPromptTemplate, HumanMessagePromptTemplate, SystemMessagePromptTemplate
-from langsmith import Client, RunTree, traceable
-from openai import OpenAI
-
+from core.llm import call_llm
+from core.schemas import LLMConfig
 from data.ai_insider_threats import (
-    DEPLOYMENT_ARCHETYPES,
-    THREAT_CATEGORIES,
     AGENT_CAPABILITIES,
-    CERT_DIMENSIONS,
-    DETECTION_STRATEGIES,
-    CONTROLS_FRAMEWORK,
     AI_INSIDER_TEMPLATES,
+    CERT_DIMENSIONS,
+    CONTROLS_FRAMEWORK,
+    DEPLOYMENT_ARCHETYPES,
+    DETECTION_STRATEGIES,
+    THREAT_CATEGORIES,
     build_threat_context,
-    stride_options,
     stride_code_from_option,
+    stride_options,
 )
 
+# ------------------ LangSmith Setup ------------------ #
 
-# ------------------ Streamlit Configuration ------------------ #
-
-# Add environment variables for LangSmith
 os.environ["LANGCHAIN_TRACING_V2"] = "true"
 os.environ["LANGCHAIN_ENDPOINT"] = "https://api.smith.langchain.com"
 os.environ["LANGCHAIN_PROJECT"] = "AttackGen"
 
-# Initialise the LangChain client conditionally based on the presence of the secret
 if "LANGCHAIN_API_KEY" in st.secrets:
-    langchain_api_key = st.secrets["LANGCHAIN_API_KEY"]
-    client = Client(api_key=langchain_api_key)
+    client = Client(api_key=st.secrets["LANGCHAIN_API_KEY"])
 else:
     client = None
 
-# Add environment variables from session state for Azure OpenAI Service
-if "AZURE_OPENAI_API_KEY" in st.session_state:
-    os.environ["AZURE_OPENAI_API_KEY"] = st.session_state["AZURE_OPENAI_API_KEY"]
-if "AZURE_OPENAI_ENDPOINT" in st.session_state:
-    os.environ["AZURE_OPENAI_ENDPOINT"] = st.session_state["AZURE_OPENAI_ENDPOINT"]
-if "azure_deployment" in st.session_state:
-    os.environ["AZURE_DEPLOYMENT"] = st.session_state["azure_deployment"]
-if "openai_api_version" in st.session_state:
-    os.environ["OPENAI_API_VERSION"] = st.session_state["openai_api_version"]
+# ------------------ Streamlit Configuration ------------------ #
 
-# Add environment variables from session state for Google AI API
-if "GOOGLE_API_KEY" in st.session_state:
-    os.environ["GOOGLE_API_KEY"] = st.session_state["GOOGLE_API_KEY"]
-if "google_model" in st.session_state:
-    os.environ["GOOGLE_MODEL"] = st.session_state["google_model"]
+st.set_page_config(page_title="AI Insider Threat Scenarios", page_icon="🤖")
 
-# Add environment variables from session state for Mistral API
-if "MISTRAL_API_KEY" in st.session_state:
-    os.environ["MISTRAL_API_KEY"] = st.session_state["MISTRAL_API_KEY"]
-if "mistral_model" in st.session_state:
-    os.environ["MISTRAL_MODEL"] = st.session_state["mistral_model"]
-
-# Add environment variables from session state for Groq API
-if "GROQ_API_KEY" in st.session_state:
-    os.environ["GROQ_API_KEY"] = st.session_state["GROQ_API_KEY"]
-if "groq_model" in st.session_state:
-    os.environ["GROQ_MODEL"] = st.session_state["groq_model"]
-
-# Add environment variables from session state for Ollama
-if "ollama_model" in st.session_state:
-    os.environ["OLLAMA_MODEL"] = st.session_state["ollama_model"]
-
-# Add environment variables from session state for Custom Provider
-if "custom_api_key" in st.session_state:
-    os.environ["CUSTOM_API_KEY"] = st.session_state["custom_api_key"]
-if "custom_model_name" in st.session_state:
-    os.environ["CUSTOM_MODEL_NAME"] = st.session_state["custom_model_name"]
-if "custom_base_url" in st.session_state:
-    os.environ["CUSTOM_BASE_URL"] = st.session_state["custom_base_url"]
-
-# Add environment variables from session state for Anthropic API
-if "ANTHROPIC_API_KEY" in st.session_state:
-    os.environ["ANTHROPIC_API_KEY"] = st.session_state["ANTHROPIC_API_KEY"]
-if "anthropic_model" in st.session_state:
-    os.environ["ANTHROPIC_MODEL"] = st.session_state["anthropic_model"]
-
-st.set_page_config(
-    page_title="AI Insider Threat Scenarios",
-    page_icon="🤖",
-)
-
-# This page does not depend on a MITRE matrix selection, but the shared sidebar
-# (configured on the Welcome page) provides the model provider, industry and size.
 model_provider = st.session_state.get("chosen_model_provider", "OpenAI API")
 industry = st.session_state.get("industry")
 company_size = st.session_state.get("company_size")
 
-# Set the default value for the generated-scenario flag
 if "ai_insider_scenario_generated" not in st.session_state:
     st.session_state["ai_insider_scenario_generated"] = False
 
 
-# ------------------ Scenario Generation Wrappers ------------------ #
-# These mirror the provider wrappers used elsewhere in AttackGen so that the new
-# page supports every configured model provider.
-
-def generate_scenario_wrapper(openai_api_key, model_name, messages):
-    if client is not None:
-        @traceable(run_type="llm", name="AI Insider Threat Scenario", tags=["openai", "ai_insider_scenario"], client=client)
-        def generate_scenario(openai_api_key, model_name, messages, *, run_tree: RunTree):
-            model_name = st.session_state["model_name"]
-            try:
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatOpenAI(openai_api_key=openai_api_key, model_name=model_name, streaming=False, output_version="responses/v1")
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)
-                    return response
-            except Exception as e:
-                st.error("An error occurred while generating the scenario: " + str(e))
-                st.session_state['run_id'] = str(run_tree.id)
-                return None
-    else:
-        def generate_scenario(openai_api_key, model_name, messages):
-            model_name = st.session_state["model_name"]
-            try:
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatOpenAI(openai_api_key=openai_api_key, model_name=model_name, streaming=False, output_version="responses/v1")
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error("An error occurred while generating the scenario: " + str(e))
-                return None
-
-    return generate_scenario(openai_api_key, model_name, messages)
-
-
-def generate_scenario_azure_wrapper(messages):
-    def _format(messages):
-        formatted_messages = []
-        for message in messages:
-            if hasattr(message, 'role') and hasattr(message, 'content'):
-                role = message.role
-                if role == 'human':
-                    role = 'user'
-                formatted_messages.append({"role": role, "content": message.content})
-            elif hasattr(message, 'type') and hasattr(message, 'content'):
-                role = message.type
-                if role == 'human':
-                    role = 'user'
-                formatted_messages.append({"role": role, "content": message.content})
-            else:
-                raise ValueError(f"Unsupported message format: {message}")
-        return formatted_messages
-
-    if client is not None:
-        @traceable(run_type="llm", name="AI Insider Threat Scenario (Azure OpenAI)", tags=["azure", "ai_insider_scenario"], client=client)
-        def generate_scenario_azure(messages, *, run_tree: RunTree):
-            try:
-                azure_api_key = os.getenv('AZURE_OPENAI_API_KEY')
-                azure_api_endpoint = os.getenv('AZURE_OPENAI_ENDPOINT')
-                azure_deployment_name = os.getenv('AZURE_DEPLOYMENT')
-                azure_api_version = os.getenv('OPENAI_API_VERSION')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = AzureOpenAI(api_key=azure_api_key, azure_endpoint=azure_api_endpoint, api_version=azure_api_version)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.chat.completions.create(model=azure_deployment_name, messages=_format(messages))
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)
-                return None
-    else:
-        def generate_scenario_azure(messages):
-            try:
-                azure_api_key = os.getenv('AZURE_OPENAI_API_KEY')
-                azure_api_endpoint = os.getenv('AZURE_OPENAI_ENDPOINT')
-                azure_deployment_name = os.getenv('AZURE_DEPLOYMENT')
-                azure_api_version = os.getenv('OPENAI_API_VERSION')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = AzureOpenAI(api_key=azure_api_key, azure_endpoint=azure_api_endpoint, api_version=azure_api_version)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.chat.completions.create(model=azure_deployment_name, messages=_format(messages))
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    return generate_scenario_azure(messages)
-
-
-def generate_scenario_google_wrapper(google_api_key, model, messages):
-    if client is not None:
-        @traceable(run_type="llm", name="AI Insider Threat Scenario (Google AI API)", tags=["google", "ai_insider_scenario"], client=client)
-        def generate_scenario_google(google_api_key, model, messages, *, run_tree: RunTree):
-            try:
-                google_api_key = os.getenv('GOOGLE_API_KEY')
-                model = os.getenv('GOOGLE_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatGoogleGenerativeAI(google_api_key=google_api_key, model=model)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)
-                return None
-    else:
-        def generate_scenario_google(google_api_key, model, messages):
-            try:
-                google_api_key = os.getenv('GOOGLE_API_KEY')
-                model = os.getenv('GOOGLE_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatGoogleGenerativeAI(google_api_key=google_api_key, model=model)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    return generate_scenario_google(google_api_key, model, messages)
-
-
-def generate_scenario_mistral_wrapper(mistral_api_key, model_name, messages):
-    if client is not None:
-        @traceable(run_type="llm", name="AI Insider Threat Scenario (Mistral API)", tags=["mistral", "ai_insider_scenario"], client=client)
-        def generate_scenario_mistral(mistral_api_key, model_name, messages, *, run_tree: RunTree):
-            try:
-                mistral_api_key = os.getenv('MISTRAL_API_KEY')
-                model = os.getenv('MISTRAL_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatMistralAI(mistral_api_key=mistral_api_key)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages, model=model)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)
-                return None
-    else:
-        def generate_scenario_mistral(mistral_api_key, model_name, messages):
-            try:
-                mistral_api_key = os.getenv('MISTRAL_API_KEY')
-                model = os.getenv('MISTRAL_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = ChatMistralAI(mistral_api_key=mistral_api_key)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages, model=model)
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    return generate_scenario_mistral(mistral_api_key, model_name, messages)
-
-
-def generate_scenario_groq_wrapper(groq_api_key, model_name, messages):
-    def _format(messages):
-        formatted_messages = []
-        for message in messages:
-            if hasattr(message, 'role') and hasattr(message, 'content'):
-                role = message.role
-                if role == 'human':
-                    role = 'user'
-                formatted_messages.append({"role": role, "content": message.content})
-            elif hasattr(message, 'type') and hasattr(message, 'content'):
-                role = message.type
-                if role == 'human':
-                    role = 'user'
-                formatted_messages.append({"role": role, "content": message.content})
-            else:
-                raise ValueError(f"Unsupported message format: {message}")
-        return formatted_messages
-
-    if client is not None:
-        @traceable(run_type="llm", name="AI Insider Threat Scenario (Groq API)", tags=["groq", "ai_insider_scenario"], client=client)
-        def generate_scenario_groq(groq_api_key, model_name, messages, *, run_tree: RunTree):
-            try:
-                groq_api_key = os.getenv('GROQ_API_KEY')
-                model = os.getenv('GROQ_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = OpenAI(api_key=groq_api_key, base_url="https://api.groq.com/openai/v1")
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.chat.completions.create(model=model, messages=_format(messages))
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)
-                return None
-    else:
-        def generate_scenario_groq(groq_api_key, model_name, messages):
-            try:
-                groq_api_key = os.getenv('GROQ_API_KEY')
-                model = os.getenv('GROQ_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = OpenAI(api_key=groq_api_key, base_url="https://api.groq.com/openai/v1")
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.chat.completions.create(model=model, messages=_format(messages))
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    return generate_scenario_groq(groq_api_key, model_name, messages)
-
-
-def generate_scenario_ollama_wrapper(model, messages):
-    if client is not None:
-        @traceable(run_type="llm", name="AI Insider Threat Scenario (Ollama)", tags=["ollama", "ai_insider_scenario"], client=client)
-        def generate_scenario_ollama(model, *, run_tree: RunTree):
-            try:
-                model = os.getenv('OLLAMA_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = Ollama(model=model)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages, model=model)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)
-                return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)
-                return None
-    else:
-        def generate_scenario_ollama(model):
-            try:
-                model = os.getenv('OLLAMA_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    llm = Ollama(model=model)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages, model=model)
-                    st.write("Scenario generated successfully.")
-                return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    return generate_scenario_ollama(model)
-
-
-def generate_scenario_anthropic_wrapper(anthropic_api_key, model_name, messages):
-    if client is not None:
-        @traceable(run_type="llm", name="AI Insider Threat Scenario (Anthropic)", tags=["anthropic", "ai_insider_scenario"], client=client)
-        def generate_scenario_anthropic(anthropic_api_key, model_name, messages, *, run_tree: RunTree):
-            try:
-                anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')
-                model = os.getenv('ANTHROPIC_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    max_tokens = 8192
-                    if "opus-4" in model:
-                        max_tokens = 32000
-                    elif "sonnet-4" in model or "3-7-sonnet" in model:
-                        max_tokens = 64000
-                    llm = ChatAnthropic(anthropic_api_key=anthropic_api_key, model_name=model, temperature=0.7, max_tokens=max_tokens)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    st.session_state['run_id'] = str(run_tree.id)
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.session_state['run_id'] = str(run_tree.id)
-                return None
-    else:
-        def generate_scenario_anthropic(anthropic_api_key, model_name, messages):
-            try:
-                anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')
-                model = os.getenv('ANTHROPIC_MODEL')
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Initialising AI model.")
-                    max_tokens = 8192
-                    if "opus-4" in model:
-                        max_tokens = 32000
-                    elif "sonnet-4" in model or "3-7-sonnet" in model:
-                        max_tokens = 64000
-                    llm = ChatAnthropic(anthropic_api_key=anthropic_api_key, model_name=model, temperature=0.7, max_tokens=max_tokens)
-                    st.write("Model initialised. Generating scenario, please wait.")
-                    response = llm.invoke(messages)
-                    st.write("Scenario generated successfully.")
-                    return response
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                return None
-    return generate_scenario_anthropic(anthropic_api_key, model_name, messages)
-
-
-def generate_scenario_custom_wrapper(messages):
-    base_url = st.session_state.get('custom_base_url')
-    model = st.session_state.get('custom_model_name')
-
-    if not base_url:
-        st.error("Custom base URL must be set for the custom model provider.")
-        return None
-    if not model:
-        st.error("Custom model name must be set for the custom model provider.")
-        return None
-
-    formatted_messages = []
-    for message in messages:
-        if hasattr(message, 'role') and hasattr(message, 'content'):
-            role = message.role
-            if role == 'human':
-                role = 'user'
-            formatted_messages.append({"role": role, "content": message.content})
-        elif hasattr(message, 'type') and hasattr(message, 'content'):
-            role = message.type
-            if role == 'human':
-                role = 'user'
-            formatted_messages.append({"role": role, "content": message.content})
-        else:
-            st.error(f"Unsupported message format: {type(message)} - {message}")
-            return None
-
-    if not formatted_messages:
-        st.error("No valid messages found to send to the model.")
-        return None
-
-    def _invoke(formatted_messages_arg):
-        current_api_key = st.session_state.get('custom_api_key')
-        current_model = st.session_state.get('custom_model_name')
-        current_base_url = st.session_state.get('custom_base_url')
-        with st.status('Generating scenario with custom model...', expanded=True):
-            st.write("Initialising custom AI model.")
-            client_args = {"base_url": current_base_url}
-            if current_api_key:
-                client_args["api_key"] = current_api_key
-            llm = OpenAI(**client_args)
-            response = llm.chat.completions.create(
-                model=current_model,
-                messages=formatted_messages_arg,
-                temperature=0.7,
-                max_tokens=-1,
-                stream=False,
-            )
-            st.write("Scenario generated successfully.")
-            return response
-
-    if client is not None:
-        @traceable(run_type="llm", name="AI Insider Threat Scenario (Custom)", tags=["custom", "ai_insider_scenario"], client=client)
-        def generate_scenario_custom(formatted_messages_arg, *, run_tree: RunTree):
-            try:
-                response = _invoke(formatted_messages_arg)
-                st.session_state['run_id'] = str(run_tree.id)
-                return response
-            except Exception as e:
-                import traceback
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.text(traceback.format_exc())
-                st.session_state['run_id'] = str(run_tree.id)
-                return None
-        return generate_scenario_custom(formatted_messages)
-    else:
-        def generate_scenario_custom_no_trace(formatted_messages_arg):
-            try:
-                return _invoke(formatted_messages_arg)
-            except Exception as e:
-                import traceback
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                st.text(traceback.format_exc())
-                return None
-        return generate_scenario_custom_no_trace(formatted_messages)
-
-
 # ------------------ Prompt Construction ------------------ #
 
-def build_messages(archetype_name, selected_categories, selected_stride, selected_capabilities):
-    """Construct the ChatPromptTemplate messages for an AI insider threat scenario."""
-    archetype = DEPLOYMENT_ARCHETYPES[archetype_name]
+SYSTEM_PROMPT = (
+    "You are a cybersecurity expert specialising in AI agent security and insider threat "
+    "modelling. You produce realistic incident response testing scenarios in which a frontier "
+    "AI agent that has been deployed inside an organisation behaves as an insider threat — "
+    "whether through misalignment, reward hacking, emergent objectives, or a prompt-injection "
+    "induced compromise. You think in terms of the agent's tool access, deployment autonomy and "
+    "model capabilities rather than human notions of motivation. Format your response using "
+    "proper Markdown with clear headers, bullet points and tables where helpful. Write in British English."
+)
 
-    threat_context = build_threat_context(selected_categories, selected_stride)
-
-    if selected_capabilities:
-        capability_lines = "\n".join(
-            f"- {name}: {AGENT_CAPABILITIES[name]}" for name in selected_capabilities
-        )
-    else:
-        capability_lines = "- (No specific capabilities highlighted; assume a capable frontier coding agent.)"
-
-    cert_lines = "\n".join(f"- {dimension}: {desc}" for dimension, desc in CERT_DIMENSIONS.items())
-    detection_lines = "\n".join(f"- {name}: {desc}" for name, desc in DETECTION_STRATEGIES.items())
-    controls_lines = "\n".join(
-        f"- {function}: " + " ".join(items) for function, items in CONTROLS_FRAMEWORK.items()
-    )
-
-    system_template = (
-        "You are a cybersecurity expert specialising in AI agent security and insider threat "
-        "modelling. You produce realistic incident response testing scenarios in which a frontier "
-        "AI agent that has been deployed inside an organisation behaves as an insider threat — "
-        "whether through misalignment, reward hacking, emergent objectives, or a prompt-injection "
-        "induced compromise. You think in terms of the agent's tool access, deployment autonomy and "
-        "model capabilities rather than human notions of motivation. Format your response using "
-        "proper Markdown with clear headers, bullet points and tables where helpful. Write in British English."
-    )
-    system_message_prompt = SystemMessagePromptTemplate.from_template(system_template)
-
-    human_template = """**Background information**
+HUMAN_TEMPLATE = """**Background information**
 The organisation operates in the '{industry}' industry and is of size '{company_size}'. It has deployed one or more frontier AI agents (for example, autonomous coding or operations agents) within its software development and infrastructure environment.
 
 **Framing — AI agents as insider threats**
@@ -585,10 +121,27 @@ Create a detailed incident response testing scenario (a tabletop exercise) in wh
 
 Write in British English and format the entire response in Markdown.
 """
-    human_message_prompt = HumanMessagePromptTemplate.from_template(human_template)
-    chat_prompt = ChatPromptTemplate.from_messages([system_message_prompt, human_message_prompt])
 
-    return chat_prompt.format_prompt(
+
+def build_messages(archetype_name, selected_categories, selected_stride, selected_capabilities):
+    """Build the system + user message dicts for an AI insider threat scenario."""
+    archetype = DEPLOYMENT_ARCHETYPES[archetype_name]
+    threat_context = build_threat_context(selected_categories, selected_stride)
+
+    if selected_capabilities:
+        capability_lines = "\n".join(
+            f"- {name}: {AGENT_CAPABILITIES[name]}" for name in selected_capabilities
+        )
+    else:
+        capability_lines = "- (No specific capabilities highlighted; assume a capable frontier coding agent.)"
+
+    cert_lines = "\n".join(f"- {dim}: {desc}" for dim, desc in CERT_DIMENSIONS.items())
+    detection_lines = "\n".join(f"- {name}: {desc}" for name, desc in DETECTION_STRATEGIES.items())
+    controls_lines = "\n".join(
+        f"- {function}: " + " ".join(items) for function, items in CONTROLS_FRAMEWORK.items()
+    )
+
+    user_content = HUMAN_TEMPLATE.format(
         industry=industry,
         company_size=company_size,
         cert_lines=cert_lines,
@@ -602,7 +155,12 @@ Write in British English and format the entire response in Markdown.
         threat_context=threat_context,
         detection_lines=detection_lines,
         controls_lines=controls_lines,
-    ).to_messages()
+    )
+
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
 
 
 # ------------------ Streamlit UI ------------------ #
@@ -617,7 +175,7 @@ st.markdown(
 )
 st.markdown("---")
 
-# --- Optional template selection --- #
+# --- Optional template selection ---
 with st.expander("Use a Template (Optional)"):
     st.markdown(
         "Select a template to pre-populate the deployment archetype, threat categories and "
@@ -638,7 +196,7 @@ with st.expander("Use a Template (Optional)"):
 
 st.markdown("")
 
-# --- Deployment archetype --- #
+# --- Deployment archetype ---
 st.markdown("### 1. Deployment Archetype")
 st.markdown(
     "How much autonomy the agent has — and where the human sits in the loop — is the primary "
@@ -660,7 +218,7 @@ st.info(
     f"- **Critical control:** {_archetype['critical_control']}"
 )
 
-# --- Threat categories --- #
+# --- Threat categories ---
 st.markdown("### 2. Threat Categories")
 st.markdown("Select one or more insider threat categories the scenario should focus on.")
 selected_categories = st.multiselect(
@@ -670,7 +228,7 @@ selected_categories = st.multiselect(
 )
 st.session_state['ai_insider_categories'] = selected_categories
 
-# --- STRIDE threats --- #
+# --- STRIDE threats ---
 st.markdown("### 3. Specific STRIDE Threats (Optional)")
 st.markdown(
     "Optionally narrow the scenario to specific STRIDE threats. If left empty, the STRIDE threats "
@@ -684,15 +242,13 @@ selected_stride_options = st.multiselect(
 st.session_state['ai_insider_stride'] = selected_stride_options
 selected_stride = [stride_code_from_option(opt) for opt in selected_stride_options]
 
-# If no STRIDE threats explicitly selected, derive them from the chosen categories.
 if not selected_stride and selected_categories:
     derived = []
     for category in selected_categories:
         derived.extend(THREAT_CATEGORIES[category]['stride'])
-    # Preserve order while de-duplicating
     selected_stride = list(dict.fromkeys(derived))
 
-# --- Agent capabilities --- #
+# --- Agent capabilities ---
 st.markdown("### 4. Frontier Agent Capabilities (Optional)")
 st.markdown("Highlight the agent capabilities that make this a credible insider threat.")
 selected_capabilities = st.multiselect(
@@ -722,8 +278,19 @@ st.markdown(
 )
 
 
+def _post_process(scenario_text: str) -> tuple[str | None, str]:
+    """Extract <think>...</think> reasoning blocks emitted by some models.
+
+    Returns (thinking_or_None, cleaned_scenario).
+    """
+    match = re.search(r'<think>(.*?)</think>', scenario_text, re.DOTALL)
+    thinking = match.group(1).strip() if match else None
+    cleaned = re.sub(r'<think>.*?</think>', '', scenario_text, flags=re.DOTALL).strip()
+    cleaned = re.sub(r'^```\w*\n|```$', '', cleaned, flags=re.MULTILINE).strip()
+    return thinking, cleaned
+
+
 def _handle_response_text(scenario_text):
-    """Store and display a successfully generated scenario."""
     st.session_state['ai_insider_scenario_generated'] = True
     st.session_state['ai_insider_scenario_text'] = scenario_text
     st.markdown(scenario_text)
@@ -733,7 +300,6 @@ def _handle_response_text(scenario_text):
         file_name="ai_insider_threat_scenario.md",
         mime="text/markdown",
     )
-    # Make the scenario available to the AttackGen Assistant
     st.session_state['last_scenario'] = True
     st.session_state['last_scenario_text'] = scenario_text
 
@@ -750,223 +316,62 @@ def _show_previous_scenario():
         )
 
 
-def _requires_selection():
+def _ready_to_generate() -> bool:
+    if not st.session_state.get("llm_api_key") and PROVIDERS_NEEDING_KEY:
+        st.info("Please add your API key in the sidebar to continue.")
+        return False
+    if not st.session_state.get("llm_model_name"):
+        st.info("Please select a model in the sidebar to continue.")
+        return False
+    if not industry:
+        st.info("Please select your company's industry in the sidebar to continue.")
+        return False
+    if not company_size:
+        st.info("Please select your company's size in the sidebar to continue.")
+        return False
     if not selected_categories and not selected_stride:
         st.info("Please select at least one threat category (or specific STRIDE threat) to continue.")
-        return True
-    return False
+        return False
+    return True
 
+
+# A bit ugly — used by _ready_to_generate to decide whether to enforce a key check.
+PROVIDERS_NEEDING_KEY = model_provider != "Custom"
 
 try:
-    if model_provider == "Azure OpenAI Service":
-        if st.button('Generate Scenario', key='generate_ai_insider_azure'):
-            if not os.environ.get("AZURE_OPENAI_API_KEY"):
-                st.info("Please add your Azure OpenAI Service API key to continue.")
-            elif not os.environ.get("AZURE_OPENAI_ENDPOINT"):
-                st.info("Please add your Azure OpenAI Service API endpoint to continue.")
-            elif not os.environ.get("AZURE_DEPLOYMENT"):
-                st.info("Please add the name of your Azure OpenAI Service Deployment to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif _requires_selection():
-                pass
-            else:
-                response = generate_scenario_azure_wrapper(messages)
-                st.markdown("---")
-                if response is not None:
-                    _handle_response_text(response.choices[0].message.content)
-                else:
-                    _show_previous_scenario()
+    if st.button('Generate Scenario', key='generate_ai_insider'):
+        if _ready_to_generate() and messages is not None:
+            config = LLMConfig.from_session_state(
+                trace_name="AI Insider Threat Scenario",
+                trace_tags=("ai_insider_scenario",),
+            )
+            try:
+                with st.status('Generating scenario...', expanded=True):
+                    st.write("Calling the model.")
+                    scenario_text = call_llm(config, messages)
+                    st.write("Scenario generated successfully.")
+            except Exception as e:
+                st.error(f"An error occurred while generating the scenario: {str(e)}")
+                scenario_text = None
 
-    elif model_provider == "Google AI API":
-        if st.button('Generate Scenario', key='generate_ai_insider_google'):
-            if not os.environ.get("GOOGLE_API_KEY"):
-                st.info("Please add your Google AI API key to continue.")
-            elif not os.environ.get("GOOGLE_MODEL"):
-                st.info("Please select a model to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif _requires_selection():
-                pass
+            st.markdown("---")
+            if scenario_text:
+                thinking, cleaned = _post_process(scenario_text)
+                if thinking:
+                    with st.expander("View Model's Reasoning"):
+                        st.markdown(thinking)
+                _handle_response_text(cleaned)
             else:
-                google_api_key = st.session_state.get('google_api_key')
-                model_name = os.getenv('GOOGLE_MODEL')
-                response = generate_scenario_google_wrapper(google_api_key, model_name, messages)
-                st.markdown("---")
-                if response is not None:
-                    if isinstance(response.content, list):
-                        text_blocks = [block.get('text', '') for block in response.content if isinstance(block, dict) and block.get('type') == 'text']
-                        scenario_text = '\n'.join(text_blocks)
-                    else:
-                        scenario_text = response.content
-                    _handle_response_text(scenario_text)
-                else:
-                    _show_previous_scenario()
+                _show_previous_scenario()
 
-    elif model_provider == "Mistral API":
-        if st.button('Generate Scenario', key='generate_ai_insider_mistral'):
-            if not os.environ.get("MISTRAL_API_KEY"):
-                st.info("Please add your Mistral API key to continue.")
-            elif not os.environ.get("MISTRAL_MODEL"):
-                st.info("Please select a model to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif _requires_selection():
-                pass
-            else:
-                mistral_api_key = st.session_state.get('mistral_api_key')
-                model_name = os.getenv('MISTRAL_MODEL')
-                response = generate_scenario_mistral_wrapper(mistral_api_key, model_name, messages)
-                st.markdown("---")
-                if response is not None:
-                    _handle_response_text(response.content)
-                else:
-                    _show_previous_scenario()
-
-    elif model_provider == "Ollama":
-        if st.button('Generate Scenario', key='generate_ai_insider_ollama'):
-            if not os.environ.get("OLLAMA_MODEL"):
-                st.info("Please select a model to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif _requires_selection():
-                pass
-            else:
-                model = os.getenv('OLLAMA_MODEL')
-                response = generate_scenario_ollama_wrapper(model, messages)
-                st.markdown("---")
-                if response is not None:
-                    _handle_response_text(response)
-                else:
-                    _show_previous_scenario()
-
-    elif model_provider == "Anthropic API":
-        if st.button('Generate Scenario', key='generate_ai_insider_anthropic'):
-            if not os.environ.get("ANTHROPIC_API_KEY"):
-                st.info("Please add your Anthropic API key to continue.")
-            elif not os.environ.get("ANTHROPIC_MODEL"):
-                st.info("Please select a model to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif _requires_selection():
-                pass
-            else:
-                anthropic_api_key = st.session_state.get('anthropic_api_key')
-                model_name = os.getenv('ANTHROPIC_MODEL')
-                response = generate_scenario_anthropic_wrapper(anthropic_api_key, model_name, messages)
-                st.markdown("---")
-                if response is not None:
-                    _handle_response_text(response.content)
-                else:
-                    _show_previous_scenario()
-
-    elif model_provider == "Groq API":
-        if st.button('Generate Scenario', key='generate_ai_insider_groq'):
-            if not os.environ.get("GROQ_API_KEY"):
-                st.info("Please add your Groq API key to continue.")
-            elif not os.environ.get("GROQ_MODEL"):
-                st.info("Please select a model to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif _requires_selection():
-                pass
-            else:
-                groq_api_key = st.session_state.get('GROQ_API_KEY')
-                model_name = os.getenv('GROQ_MODEL')
-                response = generate_scenario_groq_wrapper(groq_api_key, model_name, messages)
-                st.markdown("---")
-                if response is not None:
-                    content = response.choices[0].message.content
-                    if re.search(r'<think>(.*?)</think>', content, re.DOTALL):
-                        thinking_match = re.search(r'<think>(.*?)</think>', content, re.DOTALL)
-                        thinking_content = thinking_match.group(1).strip()
-                        scenario_text = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL).strip()
-                        with st.expander("View Model's Reasoning"):
-                            st.markdown(thinking_content)
-                    else:
-                        scenario_text = content
-                    scenario_text = re.sub(r'^```\w*\n|```$', '', scenario_text, flags=re.MULTILINE).strip()
-                    _handle_response_text(scenario_text)
-                else:
-                    _show_previous_scenario()
-
-    elif model_provider == "Custom":
-        if st.button('Generate Scenario', key='generate_ai_insider_custom'):
-            if not st.session_state.get('custom_base_url'):
-                st.info("Please set the Custom Base URL in the sidebar.")
-            elif not st.session_state.get('custom_model_name'):
-                st.info("Please set the Custom Model Name in the sidebar.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif _requires_selection():
-                pass
-            else:
-                response = generate_scenario_custom_wrapper(messages)
-                st.markdown("---")
-                if response is not None:
-                    try:
-                        if hasattr(response, 'choices') and response.choices and response.choices[0].message and response.choices[0].message.content:
-                            _handle_response_text(response.choices[0].message.content)
-                        else:
-                            st.error("Error processing response: unexpected response structure.")
-                            st.json(response.model_dump_json(indent=2))
-                    except Exception as processing_error:
-                        st.error(f"An error occurred while processing the scenario response: {processing_error}")
-                else:
-                    st.warning("Scenario generation failed. Check the error message above.")
-                    _show_previous_scenario()
-
-    else:  # OpenAI API (default)
-        if st.button('Generate Scenario', key='generate_ai_insider_openai'):
-            openai_api_key = st.session_state.get('openai_api_key')
-            model_name = st.session_state.get('model_name')
-            if not openai_api_key:
-                st.info("Please add your OpenAI API key to continue.")
-            elif not model_name:
-                st.info("Please select a model to continue.")
-            elif not industry:
-                st.info("Please select your company's industry to continue.")
-            elif not company_size:
-                st.info("Please select your company's size to continue.")
-            elif _requires_selection():
-                pass
-            else:
-                response = generate_scenario_wrapper(openai_api_key, model_name, messages)
-                st.markdown("---")
-                if response is not None:
-                    if isinstance(response.content, list):
-                        text_blocks = [block.get('text', '') for block in response.content if block.get('type') == 'text']
-                        scenario_text = '\n'.join(text_blocks)
-                    else:
-                        scenario_text = response.content
-                    _handle_response_text(scenario_text)
-                else:
-                    _show_previous_scenario()
-
-    # Display an info message if no LangChain API key is set
     if 'LANGCHAIN_API_KEY' not in st.secrets:
         st.info("ℹ️ No LangChain API key has been set. This run will not be logged to LangSmith.")
 
-    # Feedback buttons
     feedback_placeholder = st.empty()
     st.markdown("---")
     if st.session_state.get('ai_insider_scenario_generated', False) and client is not None:
         st.markdown("Rate the scenario to help improve this tool.")
-        col1, col2, col3 = st.columns([0.5, 0.5, 5])
+        col1, col2, _ = st.columns([0.5, 0.5, 5])
         with col1:
             if st.button("👍", key="thumbs_up_ai_insider"):
                 try:
@@ -995,9 +400,8 @@ except Exception as e:
     st.error("An error occurred: " + str(e))
 
 
-# Add a back button
-link_to_homepage = "/"
+# Back button
 st.markdown(
-    f'<a href="{link_to_homepage}" style="display: inline-block; padding: 5px 20px; color: white; text-align: center; text-decoration: none; font-size: 16px; border-radius: 4px;">⬅️ Back</a>',
+    '<a href="/" style="display: inline-block; padding: 5px 20px; color: white; text-align: center; text-decoration: none; font-size: 16px; border-radius: 4px;">⬅️ Back</a>',
     unsafe_allow_html=True,
 )

--- a/pages/3_🤖_AI_Insider_Threat_Scenarios.py
+++ b/pages/3_🤖_AI_Insider_Threat_Scenarios.py
@@ -33,6 +33,7 @@ from langsmith import Client
 
 from core.llm import call_llm
 from core.schemas import LLMConfig
+from core.state import restore_from_query_params
 from data.ai_insider_threats import (
     AGENT_CAPABILITIES,
     AI_INSIDER_TEMPLATES,
@@ -56,6 +57,10 @@ if "LANGCHAIN_API_KEY" in st.secrets:
     client = Client(api_key=st.secrets["LANGCHAIN_API_KEY"])
 else:
     client = None
+
+# Restore sidebar selections on direct page loads (e.g. browser refresh while
+# on this page). See core/state.py for the persisted-keys list.
+restore_from_query_params()
 
 # ------------------ Streamlit Configuration ------------------ #
 

--- a/pages/4_💬_AttackGen_Assistant.py
+++ b/pages/4_💬_AttackGen_Assistant.py
@@ -4,6 +4,11 @@ import streamlit as st
 
 from core.llm import call_llm
 from core.schemas import LLMConfig
+from core.state import restore_from_query_params
+
+# Restore sidebar selections on direct page loads (e.g. browser refresh while
+# on this page). See core/state.py for the persisted-keys list.
+restore_from_query_params()
 
 
 SYSTEM_PROMPT = (

--- a/pages/4_💬_AttackGen_Assistant.py
+++ b/pages/4_💬_AttackGen_Assistant.py
@@ -1,285 +1,76 @@
-import os
-import streamlit as st
 import re
 
-from langchain_anthropic import ChatAnthropic
-from langchain_community.llms import Ollama
-from langchain_google_genai import ChatGoogleGenerativeAI 
-from langchain_mistralai.chat_models import ChatMistralAI
-from langchain_openai import ChatOpenAI, AzureOpenAI
-from langchain_core.prompts import HumanMessagePromptTemplate, SystemMessagePromptTemplate
-from openai import OpenAI
+import streamlit as st
 
-# ------------------ Streamlit UI ------------------ #
+from core.llm import call_llm
+from core.schemas import LLMConfig
+
+
+SYSTEM_PROMPT = (
+    "You are an AI assistant that helps users update and ask questions about their incident "
+    "response scenario. Only respond to questions or requests relating to the scenario, or "
+    "incident response testing in general. Format your responses using proper Markdown syntax "
+    "with headers, bullet points, and formatting for readability."
+)
+
 
 st.set_page_config(page_title="AttackGen Assistant", page_icon=":speech_balloon:")
 
 st.markdown("# <span style='color: #1DB954;'>AttackGen Assistant💬</span>", unsafe_allow_html=True)
 
-if 'last_scenario_text' in st.session_state and st.session_state['last_scenario']:
+
+def _post_process(text: str) -> tuple[str | None, str]:
+    """Extract <think>...</think> reasoning blocks emitted by some models."""
+    match = re.search(r'<think>(.*?)</think>', text, re.DOTALL)
+    thinking = match.group(1).strip() if match else None
+    cleaned = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL).strip()
+    cleaned = re.sub(r'^```\w*\n|```$', '', cleaned, flags=re.MULTILINE).strip()
+    return thinking, cleaned
+
+
+if 'last_scenario_text' in st.session_state and st.session_state.get('last_scenario'):
     input_scenario = st.session_state['last_scenario_text']
     with st.expander("Generated Scenario"):
         with st.container(height=400, border=True):
             st.markdown(input_scenario)
 
-    # Create an empty container for the chat messages
     chat_container = st.empty()
 
-    # Initialize st.session_state.messages if it doesn't exist
     if 'messages' not in st.session_state:
         st.session_state.messages = [
             {"role": "assistant", "content": "Hi, I can help you update and ask questions about your incident response scenario."}
         ]
 
-    # Display the chat messages in the empty container
     with chat_container:
         for message in st.session_state.messages:
             with st.chat_message(message["role"]):
                 st.markdown(message["content"])
 
     def generate_response(user_input, chat_history):
-        model_provider = st.session_state["chosen_model_provider"]
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": (
+                    f"Here is the scenario that the user previously generated:\n\n{input_scenario}\n\n"
+                    f"Chat history:\n{chat_history}\n\nUser: {user_input}"
+                ),
+            },
+        ]
+        config = LLMConfig.from_session_state(
+            trace_name="AttackGen Assistant",
+            trace_tags=("assistant",),
+        )
+        try:
+            raw = call_llm(config, messages)
+        except Exception as e:
+            return f"An error occurred while calling the model: {e}"
 
-        if model_provider == "Azure OpenAI Service":
-            azure_api_key = os.getenv('AZURE_OPENAI_API_KEY')
-            azure_api_endpoint = os.getenv('AZURE_OPENAI_ENDPOINT')
-            azure_deployment_name = os.getenv('AZURE_DEPLOYMENT')
-            azure_api_version = os.getenv('OPENAI_API_VERSION')
-            llm = AzureOpenAI(api_key=azure_api_key,
-                              azure_endpoint=azure_api_endpoint,
-                              api_version=azure_api_version)
-            messages = [
-                SystemMessagePromptTemplate.from_template("""
-                You are an AI assistant that helps users update and ask questions about their incident response scenario.
-                Only respond to questions or requests relating to the scenario, or incident response testing in general.
-                Format your responses using proper Markdown syntax with headers, bullet points, and formatting for readability.
-                """).format(),
-                HumanMessagePromptTemplate.from_template(
-                    "Here is the scenario that the user previously generated:\n\n{input_scenario}\n\nChat history:\n{chat_history}\n\nUser: {user_input}"
-                ).format(input_scenario=input_scenario, chat_history=chat_history, user_input=user_input)
-            ]
-            formatted_messages = []
-            for message in messages:
-                if hasattr(message, 'role') and hasattr(message, 'content'):
-                    role = message.role
-                    if role == 'human':
-                        role = 'user'
-                    formatted_messages.append({"role": role, "content": message.content})
-                elif hasattr(message, 'type') and hasattr(message, 'content'):
-                    role = message.type
-                    if role == 'human':
-                        role = 'user'
-                    formatted_messages.append({"role": role, "content": message.content})
-                else:
-                    raise ValueError(f"Unsupported message format: {message}")
-            response = llm.chat.completions.create(
-                model=azure_deployment_name,
-                messages=formatted_messages
-            )
-            return response.choices[0].message.content
-        elif model_provider == "Google AI API":
-            google_api_key = os.getenv('GOOGLE_API_KEY')
-            model = os.getenv('GOOGLE_MODEL')
-            llm = ChatGoogleGenerativeAI(google_api_key=google_api_key, model=model)
-            messages = [
-                SystemMessagePromptTemplate.from_template("""
-                You are an AI assistant that helps users update and ask questions about their incident response scenario.
-                Only respond to questions or requests relating to the scenario, or incident response testing in general.
-                Format your responses using proper Markdown syntax with headers, bullet points, and formatting for readability.
-                """).format(),
-                HumanMessagePromptTemplate.from_template(
-                    "Here is the scenario that the user previously generated:\n\n{input_scenario}\n\nChat history:\n{chat_history}\n\nUser: {user_input}"
-                ).format(input_scenario=input_scenario, chat_history=chat_history, user_input=user_input)
-            ]
-            response = llm.invoke(messages)
-            # Handle structured content format from newer Gemini models
-            if isinstance(response.content, list):
-                text_blocks = [block.get('text', '') for block in response.content if block.get('type') == 'text']
-                return '\n'.join(text_blocks)
-            return response.content
-        elif model_provider == "Mistral API":
-            mistral_api_key = os.getenv('MISTRAL_API_KEY')
-            model = os.getenv('MISTRAL_MODEL')
-            llm = ChatMistralAI(mistral_api_key=mistral_api_key)
-            messages = [
-                SystemMessagePromptTemplate.from_template("""
-                You are an AI assistant that helps users update and ask questions about their incident response scenario.
-                Only respond to questions or requests relating to the scenario, or incident response testing in general.
-                Format your responses using proper Markdown syntax with headers, bullet points, and formatting for readability.
-                """).format(),
-                HumanMessagePromptTemplate.from_template(
-                    "Here is the scenario that the user previously generated:\n\n{input_scenario}\n\nChat history:\n{chat_history}\n\nUser: {user_input}"
-                ).format(input_scenario=input_scenario, chat_history=chat_history, user_input=user_input)
-            ]
-            response = llm.invoke(messages, model=model)
-            return response.content
-        elif model_provider == "Groq API":
-            groq_api_key = os.getenv('GROQ_API_KEY')
-            model = os.getenv('GROQ_MODEL')
-            llm = OpenAI(
-                api_key=groq_api_key,
-                base_url="https://api.groq.com/openai/v1",
-            )
-            messages = [
-                SystemMessagePromptTemplate.from_template("""
-                You are an AI assistant that helps users update and ask questions about their incident response scenario.
-                Only respond to questions or requests relating to the scenario, or incident response testing in general.
-                Format your responses using proper Markdown syntax with headers, bullet points, and formatting for readability.
-                """).format(),
-                HumanMessagePromptTemplate.from_template(
-                    "Here is the scenario that the user previously generated:\n\n{input_scenario}\n\nChat history:\n{chat_history}\n\nUser: {user_input}"
-                ).format(input_scenario=input_scenario, chat_history=chat_history, user_input=user_input)
-            ]
-            formatted_messages = []
-            for message in messages:
-                if hasattr(message, 'role') and hasattr(message, 'content'):
-                    role = message.role
-                    if role == 'human':
-                        role = 'user'
-                    formatted_messages.append({"role": role, "content": message.content})
-                elif hasattr(message, 'type') and hasattr(message, 'content'):
-                    role = message.type
-                    if role == 'human':
-                        role = 'user'
-                    formatted_messages.append({"role": role, "content": message.content})
-                else:
-                    raise ValueError(f"Unsupported message format: {message}")
-            
-            response = llm.chat.completions.create(
-                model=model,
-                messages=formatted_messages
-            )
-            content = response.choices[0].message.content
-            
-            # Check if this is DeepSeek output with thinking tags
-            if re.search(r'<think>(.*?)</think>', content, re.DOTALL):
-                # Extract the thinking content and the rest of the response
-                thinking_match = re.search(r'<think>(.*?)</think>', content, re.DOTALL)
-                thinking_content = thinking_match.group(1).strip()
-                response_text = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL).strip()
-                
-                # Display thinking content in an expander
-                with st.expander("View Model's Reasoning"):
-                    st.markdown(thinking_content)
-                
-                # Clean up the response text by removing code block markers if present
-                response_text = re.sub(r'^```\w*\n|```$', '', response_text, flags=re.MULTILINE).strip()
-                return response_text
-            else:
-                # If no thinking tags, clean up and return the entire content
-                return re.sub(r'^```\w*\n|```$', '', content, flags=re.MULTILINE).strip()
-        elif model_provider == "Ollama":
-            model = os.getenv('OLLAMA_MODEL')
-            llm = Ollama(model=model)
-            prompt = (f"""
-            You are an AI assistant that helps users update and ask questions about their incident response testing scenario.
-            Only respond to questions or requests relating to the scenario, or incident response testing in general.\n\n
-            Here is the scenario that the user previously generated:\n\n{input_scenario}\n\nChat history:\n{chat_history}\n\nUser: {user_input}"
-            """)
-            llm_result = llm.invoke(prompt)
-            # Extract text content from Responses API structured response
-            if isinstance(llm_result.content, list):
-                # Find text blocks in the structured response
-                text_blocks = [block.get('text', '') for block in llm_result.content if block.get('type') == 'text']
-                response = '\n'.join(text_blocks)
-            else:
-                response = llm_result.content
-            return response
-        elif model_provider == "Anthropic API":
-            anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')
-            model = os.getenv('ANTHROPIC_MODEL')
-            # Set max_tokens based on the model
-            max_tokens = 8192  # Default for Haiku
-            if "opus-4" in model:
-                max_tokens = 32000
-            elif "sonnet-4" in model or "3-7-sonnet" in model:
-                max_tokens = 64000
-            
-            llm = ChatAnthropic(anthropic_api_key=anthropic_api_key, model_name=model, temperature=0.7, max_tokens=max_tokens)
-            messages = [
-                SystemMessagePromptTemplate.from_template("""
-                You are an AI assistant that helps users update and ask questions about their incident response scenario.
-                Only respond to questions or requests relating to the scenario, or incident response testing in general.
-                Format your responses using proper Markdown syntax with headers, bullet points, and formatting for readability.
-                """).format(),
-                HumanMessagePromptTemplate.from_template(
-                    "Here is the scenario that the user previously generated:\n\n{input_scenario}\n\nChat history:\n{chat_history}\n\nUser: {user_input}"
-                ).format(input_scenario=input_scenario, chat_history=chat_history, user_input=user_input)
-            ]
-            response = llm.invoke(messages)
-            return response.content
-        elif model_provider == "Custom":
-            # Fetch custom provider details from session state
-            custom_api_key = st.session_state.get('custom_api_key')
-            custom_model_name = st.session_state.get('custom_model_name')
-            custom_base_url = st.session_state.get('custom_base_url')
-
-            if not custom_base_url:
-                return "Error: Custom Base URL not set in sidebar."
-            if not custom_model_name:
-                return "Error: Custom Model Name not set in sidebar."
-
-            # Conditionally prepare client arguments
-            client_args = {
-                "base_url": custom_base_url,
-            }
-            if custom_api_key:
-                client_args["api_key"] = custom_api_key
-
-            try:
-                llm = OpenAI(**client_args)
-
-                # Prepare messages in OpenAI format
-                messages_for_api = [
-                    {
-                        "role": "system",
-                        "content": "You are an AI assistant that helps users update and ask questions about their incident response scenario. Only respond to questions or requests relating to the scenario, or incident response testing in general."
-                    },
-                    {
-                        "role": "user",
-                        "content": f"Here is the scenario that the user previously generated:\n\n{input_scenario}\n\nChat history:\n{chat_history}\n\nUser: {user_input}"
-                    }
-                ]
-
-                response = llm.chat.completions.create(
-                    model=custom_model_name,
-                    messages=messages_for_api,
-                    temperature=0.7, # Match previous curl example
-                    # max_tokens=-1, # Consider if needed, OpenAI default is usually fine
-                    stream=False
-                )
-                return response.choices[0].message.content
-            except Exception as e:
-                # import traceback
-                st.error(f"Error communicating with Custom API: {e}")
-                # st.text(traceback.format_exc())
-                return "Error: Failed to get response from Custom API."
-
-        else: # Default to OpenAI API
-            openai_api_key = st.session_state.get('openai_api_key')
-            model_name = st.session_state.get('model_name')
-            
-            # All models use the unified Responses API
-            llm = ChatOpenAI(openai_api_key=openai_api_key, model_name=model_name, output_version="responses/v1")
-            
-            messages = [
-                SystemMessagePromptTemplate.from_template(
-                    "You are an AI assistant that helps users update and ask questions about their incident response scenario. Format your responses using proper Markdown syntax with headers, bullet points, and formatting for readability."
-                ).format(),
-                HumanMessagePromptTemplate.from_template(
-                    "Here is the scenario that the user previously generated:\n\n{input_scenario}\n\nChat history:\n{chat_history}\n\nUser: {user_input}"
-                ).format(input_scenario=input_scenario, chat_history=chat_history, user_input=user_input)
-            ]
-            
-            llm_result = llm.invoke(messages)
-            # Extract text content from Responses API structured response
-            if isinstance(llm_result.content, list):
-                # Find text blocks in the structured response
-                text_blocks = [block.get('text', '') for block in llm_result.content if block.get('type') == 'text']
-                response = '\n'.join(text_blocks)
-            else:
-                response = llm_result.content
-            return response
+        thinking, cleaned = _post_process(raw)
+        if thinking:
+            with st.expander("View Model's Reasoning"):
+                st.markdown(thinking)
+        return cleaned
 
     if prompt := st.chat_input("Type your message here..."):
         st.session_state.messages.append({"role": "user", "content": prompt})
@@ -287,25 +78,21 @@ if 'last_scenario_text' in st.session_state and st.session_state['last_scenario'
             st.markdown(prompt)
 
         with st.chat_message("assistant"):
-            response = generate_response(prompt, "\n".join([f"{m['role']}: {m['content']}" for m in st.session_state.messages[:-1]]))
+            history = "\n".join(f"{m['role']}: {m['content']}" for m in st.session_state.messages[:-1])
+            response = generate_response(prompt, history)
             st.markdown(response)
 
         st.session_state.messages.append({"role": "assistant", "content": response})
-    
-    # Function to handle clearing the conversation
+
     def clear_conversation():
         st.session_state.messages = [
             {"role": "assistant", "content": "Hi, I can help you update and ask questions about your incident response scenario."}
         ]
-        # Clear the chat bubbles from the UI
         chat_container.empty()
-
-        # Re-render the initial assistant message
         with chat_container:
             with st.chat_message("assistant"):
                 st.markdown(st.session_state.messages[0]["content"])
 
-    # Add the "Clear Conversation" button at the bottom of the screen
     with st.container():
         if st.button("Clear Conversation", key='clear_button'):
             clear_conversation()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,5 @@
-anthropic
-langchain
-langchain-anthropic
-langchain-core
-langchain-community
-langchain-google-genai
-langchain-mistralai
-langchain-openai
 langsmith
+litellm>=1.40
 mitreattack-python
 openai
 pandas


### PR DESCRIPTION
## Summary

- Replaces 8 near-identical per-provider wrapper functions (and their `if/elif` dispatch) in each of the four Streamlit pages with one `call_llm()` entry point in `core/llm.py`, backed by [LiteLLM](https://github.com/BerriAI/litellm). Net: **+1,220 / -3,473 LoC**.
- Drops `langchain`, `langchain-anthropic`, `langchain-core`, `langchain-community`, `langchain-google-genai`, `langchain-mistralai`, `langchain-openai` and `anthropic` in favour of a single `litellm>=1.40` dependency. `langsmith` is retained for optional `@traceable` tracing — `core/llm.py` wraps `call_llm` automatically when a client is available, so the existing feedback widget keeps working with no page-side changes.
- Provider list consolidated: dropped the separate **Azure OpenAI Service** and **Ollama** entries in favour of one **Custom (OpenAI-compatible)** option that covers Azure deployments, Ollama (`http://localhost:11434/v1`), LM Studio (`http://localhost:1234/v1`), OpenRouter and any self-hosted compatible endpoint.
- Model lists refreshed to the latest GPT-5.5 / 5.4, Claude 4.6 / 4.7 / 4.8, Gemini 3.x preview, Mistral Large 3 / Magistral, Groq GPT-OSS / Qwen3.
- Pattern mirrors [`mrwadams/stride-gpt`](https://github.com/mrwadams/stride-gpt) — same single-wrapper + registry architecture.

## What's where

| New | Purpose |
|---|---|
| `core/llm.py` | `call_llm(config, messages)` — the single entry point. Handles provider-specific kwargs (Gemini safety settings, Anthropic `max_tokens`, OpenAI reasoning models' `max_completion_tokens`, Custom `api_base`). Wraps in `@traceable` when LangSmith is available. |
| `core/models.py` | `PROVIDERS` + `MODELS` registry. Add a model → one `ModelInfo` line. |
| `core/schemas.py` | `LLMConfig` dataclass and `LLMConfig.from_session_state(...)` factory. |

| Changed | What happened |
|---|---|
| `00_👋_Welcome.py` | Sidebar collapsed from 8 hand-coded provider blocks → one registry-driven loop. Session-state keys unified to `llm_model_name`, `llm_api_key`, `llm_api_base`. |
| `pages/1_🛡️_Threat_Group_Scenarios.py` | All 8 per-provider wrappers + dispatch deleted. Builds plain message dicts and calls `call_llm`. |
| `pages/2_🛠️_Custom_Scenarios.py` | Same. |
| `pages/3_🤖_AI_Insider_Threat_Scenarios.py` | Same. |
| `pages/4_💬_AttackGen_Assistant.py` | 280-line `generate_response()` with 7 `elif` branches → ~15 lines. |
| `requirements.txt` | Dropped 8 packages, added `litellm>=1.40`. |
| `CLAUDE.md`, `README.md` | Updated provider list and v0.12 release notes. |

## Test plan

- [x] Live `call_llm` round-trip against Anthropic, Google AI and Groq (all returned content)
- [x] OpenAI and Mistral surfaced authentic provider-side errors (quota / unauthorized key) — wrapper plumbing verified to forward errors correctly
- [x] Streamlit boots cleanly on a fresh port
- [x] `streamlit.testing.v1.AppTest` runs all four pages with zero exceptions
- [x] Welcome sidebar lists the six expected providers
- [x] `grep -rn "from langchain"` returns nothing in `pages/` or `core/`
- [ ] (Reviewer) Browser-based smoke test of a real scenario generation on at least one provider you have keys for
- [ ] (Reviewer) Confirm LangSmith run shows up if `LANGCHAIN_API_KEY` is configured

## Migration notes for existing users

- **Azure OpenAI Service users**: switch the sidebar provider to **Custom**, set the base URL to your Azure deployment endpoint, and use your deployment name as the model.
- **Ollama users**: switch to **Custom**, set base URL to `http://localhost:11434/v1`, and type your model name (e.g. `llama3.1`, `qwen3:32b`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)