### PR TITLE
test(core): seed pytest suite for LLM wrapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+"""Shared pytest fixtures for the AttackGen test suite."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import streamlit as st
+
+
+@pytest.fixture
+def fake_session_state(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace `st.session_state` with a plain dict for the duration of a test.
+
+    Streamlit's real SessionState requires a running ScriptRunContext. A dict
+    is interface-compatible for the .get() / [] access patterns used by
+    `LLMConfig.from_session_state` and the LangSmith run_id stash.
+    """
+    state: dict[str, Any] = {}
+    monkeypatch.setattr(st, "session_state", state)
+    return state
+
+
+@pytest.fixture
+def mock_litellm_completion(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    """Patch `litellm.completion` to capture kwargs and return a stub response.
+
+    Returns a SimpleNamespace with:
+      - calls: list of (args, kwargs) tuples for every invocation
+      - set_content(s): change the stub response content for the next call
+    """
+    captured = SimpleNamespace(calls=[], content="stub response")
+
+    def _fake_completion(*args, **kwargs):
+        captured.calls.append((args, kwargs))
+        message = SimpleNamespace(content=captured.content)
+        choice = SimpleNamespace(message=message)
+        return SimpleNamespace(choices=[choice])
+
+    # Patch on the litellm module *and* on core.llm (which imported the symbol
+    # via `import litellm` — same module object, so one patch suffices).
+    import litellm
+
+    monkeypatch.setattr(litellm, "completion", _fake_completion)
+    return captured

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import pytest
 
 import core.llm as llm_module
-from core.llm import GEMINI_SAFETY_SETTINGS, _build_litellm_kwargs, call_llm
 from core.schemas import LLMConfig
+
+_build_litellm_kwargs = llm_module._build_litellm_kwargs
+call_llm = llm_module.call_llm
+GEMINI_SAFETY_SETTINGS = llm_module.GEMINI_SAFETY_SETTINGS
 
 
 def test_kwargs_always_set_num_retries_to_three() -> None:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,133 @@
+"""Tests for `core.llm._build_litellm_kwargs` and `call_llm`."""
+
+from __future__ import annotations
+
+import pytest
+
+import core.llm as llm_module
+from core.llm import GEMINI_SAFETY_SETTINGS, _build_litellm_kwargs, call_llm
+from core.schemas import LLMConfig
+
+
+def test_kwargs_always_set_num_retries_to_three() -> None:
+    config = LLMConfig(provider="OpenAI API", model_name="gpt-5.5", api_key="k")
+    kwargs = _build_litellm_kwargs(config)
+    assert kwargs["num_retries"] == 3
+
+
+def test_openai_reasoning_model_uses_max_completion_tokens() -> None:
+    config = LLMConfig(
+        provider="OpenAI API",
+        model_name="gpt-5.5",
+        api_key="k",
+        max_tokens=4096,
+    )
+    kwargs = _build_litellm_kwargs(config)
+    assert kwargs["max_completion_tokens"] == 4096
+    assert "max_tokens" not in kwargs
+    # OpenAI keeps the empty litellm_prefix, so the model string is bare.
+    assert kwargs["model"] == "gpt-5.5"
+
+
+def test_openai_reasoning_model_without_max_tokens_omits_completion_tokens() -> None:
+    config = LLMConfig(provider="OpenAI API", model_name="gpt-5.5", api_key="k")
+    kwargs = _build_litellm_kwargs(config)
+    assert "max_completion_tokens" not in kwargs
+    assert "max_tokens" not in kwargs
+
+
+def test_anthropic_defaults_max_tokens_to_16000_when_unset() -> None:
+    config = LLMConfig(
+        provider="Anthropic API", model_name="claude-sonnet-4-6", api_key="k"
+    )
+    kwargs = _build_litellm_kwargs(config)
+    assert kwargs["max_tokens"] == 16000
+    assert kwargs["model"] == "anthropic/claude-sonnet-4-6"
+
+
+def test_anthropic_respects_explicit_max_tokens() -> None:
+    config = LLMConfig(
+        provider="Anthropic API",
+        model_name="claude-sonnet-4-6",
+        api_key="k",
+        max_tokens=8000,
+    )
+    kwargs = _build_litellm_kwargs(config)
+    assert kwargs["max_tokens"] == 8000
+
+
+def test_google_ai_attaches_safety_settings() -> None:
+    config = LLMConfig(
+        provider="Google AI API", model_name="gemini-3.1-pro-preview", api_key="k"
+    )
+    kwargs = _build_litellm_kwargs(config)
+    assert kwargs["safety_settings"] == GEMINI_SAFETY_SETTINGS
+    assert kwargs["model"] == "gemini/gemini-3.1-pro-preview"
+
+
+def test_custom_provider_strips_prefix_and_forces_openai_routing() -> None:
+    config = LLMConfig(
+        provider="Custom",
+        model_name="my-local-model",
+        api_base="http://127.0.0.1:1234/v1",
+    )
+    kwargs = _build_litellm_kwargs(config)
+    # Bare model name — no openai/ prefix even though the provider has one.
+    assert kwargs["model"] == "my-local-model"
+    assert kwargs["custom_llm_provider"] == "openai"
+    assert kwargs["api_base"] == "http://127.0.0.1:1234/v1"
+    # Falls back to a placeholder when none provided.
+    assert kwargs["api_key"] == "not-required"
+
+
+def test_custom_provider_with_slash_in_model_name_regression() -> None:
+    """Regression test: LiteLLM's auto-detection misroutes "qwen/qwen3-32b"
+    by reading "qwen" as a provider. Setting custom_llm_provider="openai" and
+    sending the bare model name bypasses that. Fixed in commit 479d578."""
+    config = LLMConfig(
+        provider="Custom",
+        model_name="qwen/qwen3-32b",
+        api_base="http://127.0.0.1:1234/v1",
+        api_key="actual-key",
+    )
+    kwargs = _build_litellm_kwargs(config)
+    assert kwargs["model"] == "qwen/qwen3-32b"
+    assert kwargs["custom_llm_provider"] == "openai"
+    # User-provided key wins over the "not-required" fallback.
+    assert kwargs["api_key"] == "actual-key"
+
+
+@pytest.fixture
+def disable_langsmith(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the LangSmith-bypass path so call_llm hits _raw_call directly."""
+    monkeypatch.setattr(llm_module, "_langsmith_client", None)
+
+
+def test_call_llm_returns_completion_content(
+    disable_langsmith, mock_litellm_completion
+) -> None:
+    mock_litellm_completion.content = "hello world"
+    config = LLMConfig(provider="OpenAI API", model_name="gpt-5.5", api_key="k")
+
+    result = call_llm(config, [{"role": "user", "content": "hi"}])
+
+    assert result == "hello world"
+    assert len(mock_litellm_completion.calls) == 1
+
+
+def test_call_llm_passes_built_kwargs_to_litellm(
+    disable_langsmith, mock_litellm_completion
+) -> None:
+    config = LLMConfig(
+        provider="Anthropic API", model_name="claude-sonnet-4-6", api_key="k"
+    )
+    messages = [{"role": "user", "content": "hi"}]
+
+    call_llm(config, messages)
+
+    _args, kwargs = mock_litellm_completion.calls[0]
+    assert kwargs["messages"] == messages
+    assert kwargs["model"] == "anthropic/claude-sonnet-4-6"
+    assert kwargs["max_tokens"] == 16000
+    assert kwargs["api_key"] == "k"
+    assert kwargs["num_retries"] == 3

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,48 @@
+"""Tests for the provider/model registry in `core.models`.
+
+Scope: only behaviour that's specific to this project's registry decisions
+(fallback shapes, the OpenAI gpt-5 invariant). Tautological lookups that just
+re-derive expected values from MODELS/PROVIDERS are intentionally omitted.
+"""
+
+from __future__ import annotations
+
+from core.models import (
+    MODELS,
+    get_litellm_prefix,
+    get_model,
+    get_models_for_provider,
+    get_provider,
+    model_uses_completion_tokens,
+)
+
+
+def test_get_provider_unknown_returns_none() -> None:
+    assert get_provider("Nope") is None
+
+
+def test_get_litellm_prefix_unknown_returns_empty_string() -> None:
+    assert get_litellm_prefix("Nope") == ""
+
+
+def test_get_models_for_provider_unknown_returns_empty() -> None:
+    assert get_models_for_provider("Nope") == []
+
+
+def test_get_model_unknown_returns_none() -> None:
+    assert get_model("OpenAI API", "no-such-model") is None
+    assert get_model("Nope", "gpt-5.5") is None
+
+
+def test_model_uses_completion_tokens_true_only_for_openai_gpt5() -> None:
+    """Today only OpenAI gpt-5.x entries should set the flag. Adding a new
+    model that flips this requires updating the assertion, which is the point —
+    it's an intentional choice, not an accident."""
+    for m in MODELS:
+        if m.uses_max_completion_tokens:
+            assert m.provider_key == "OpenAI API"
+            assert m.model_id.startswith("gpt-5.")
+
+
+def test_model_uses_completion_tokens_unknown_model_is_false() -> None:
+    assert model_uses_completion_tokens("OpenAI API", "no-such-model") is False

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,45 @@
+"""Tests for `core.schemas.LLMConfig`."""
+
+from __future__ import annotations
+
+from core.schemas import LLMConfig
+
+
+def test_from_session_state_defaults_when_empty(fake_session_state) -> None:
+    config = LLMConfig.from_session_state()
+    assert config.provider == "OpenAI API"
+    assert config.model_name == ""
+    assert config.api_key is None
+    assert config.api_base is None
+    assert config.trace_name == "AttackGen LLM call"
+    assert config.trace_tags == ()
+
+
+def test_from_session_state_reads_populated_keys(fake_session_state) -> None:
+    fake_session_state.update(
+        {
+            "chosen_model_provider": "Anthropic API",
+            "llm_model_name": "claude-sonnet-4-6",
+            "llm_api_key": "sk-test",
+            "llm_api_base": "https://example.invalid/v1",
+        }
+    )
+
+    config = LLMConfig.from_session_state()
+
+    assert config.provider == "Anthropic API"
+    assert config.model_name == "claude-sonnet-4-6"
+    assert config.api_key == "sk-test"
+    assert config.api_base == "https://example.invalid/v1"
+
+
+def test_from_session_state_empty_string_api_key_collapses_to_none(
+    fake_session_state,
+) -> None:
+    fake_session_state["llm_api_key"] = ""
+    fake_session_state["llm_api_base"] = ""
+
+    config = LLMConfig.from_session_state()
+
+    assert config.api_key is None
+    assert config.api_base is None


### PR DESCRIPTION
## Summary
- Adds `pytest` (via `requirements-dev.txt`) and a `tests/` package with shared fixtures in `conftest.py` (`fake_session_state`, `mock_litellm_completion`).
- Covers the project-specific surface in `core/`: provider routing in `_build_litellm_kwargs` (Anthropic `max_tokens=16000` default, OpenAI gpt-5.x → `max_completion_tokens`, Gemini safety settings, Custom-provider override including the `qwen/qwen3-32b` regression), `LLMConfig.from_session_state` mapping + empty-string coercion, registry fallback shapes, and the OpenAI gpt-5 invariant.
- Intentionally narrow: no Streamlit-page tests, no live LiteLLM calls (everything mocked), no CI workflow. Tautological lookups that just re-derive expected values from `MODELS`/`PROVIDERS` were left out.

## Test plan
- [x] `pip install -r requirements-dev.txt`
- [x] `pytest` from the repo root — 19 tests pass in ~1.5s
- [ ] Reviewer: confirm the parametrize-free `test_model_uses_completion_tokens_true_only_for_openai_gpt5` is the right shape for catching accidental new-model flag changes
- [ ] Reviewer: spot-check the `_build_litellm_kwargs` test list against current provider quirks

🤖 Generated with [Claude Code](https://claude.com/claude-code)