### PR TITLE
Collapse scenario pages onto a shared run_scenario_page

### DIFF
--- a/core/feedback.py
+++ b/core/feedback.py
@@ -1,0 +1,71 @@
+"""LangSmith feedback widget for scenario pages.
+
+Pages don't see the LangSmith client — `render_feedback_widget` initialises one
+lazily from ``st.secrets['LANGCHAIN_API_KEY']`` and reads the active run id
+from ``st.session_state['run_id']`` (set by ``core.llm.call_llm`` when a
+LangSmith client is configured for tracing).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import streamlit as st
+
+
+def _get_client() -> Any | None:
+    if "LANGCHAIN_API_KEY" not in st.secrets:
+        return None
+    try:
+        from langsmith import Client
+
+        return Client(api_key=st.secrets["LANGCHAIN_API_KEY"])
+    except Exception:
+        return None
+
+
+def render_feedback_widget(*, key_prefix: str, scenario_generated: bool) -> None:
+    """Render the thumbs-up/down feedback widget for the last scenario run.
+
+    The notice + horizontal rule render unconditionally so the page layout
+    matches the pre-refactor look even before any scenario has been generated.
+    `key_prefix` namespaces the Streamlit button keys so the widget can render
+    on multiple pages within one app session without collision.
+    """
+    if "LANGCHAIN_API_KEY" not in st.secrets:
+        st.info(
+            "ℹ️ No LangChain API key has been set. "
+            "This run will not be logged to LangSmith."
+        )
+
+    placeholder = st.empty()
+    st.markdown("---")
+
+    if not scenario_generated:
+        return
+
+    client = _get_client()
+    if client is None:
+        return
+
+    st.markdown("Rate the scenario to help improve this tool.")
+    col1, col2, _ = st.columns([0.5, 0.5, 5])
+    with col1:
+        if st.button("👍", key=f"thumbs_up_{key_prefix}"):
+            _submit(client, placeholder, kind="positive", score=1)
+    with col2:
+        if st.button("👎", key=f"thumbs_down_{key_prefix}"):
+            _submit(client, placeholder, kind="negative", score=0)
+
+
+def _submit(client: Any, placeholder: Any, *, kind: str, score: int) -> None:
+    run_id = st.session_state.get("run_id")
+    if not run_id:
+        placeholder.warning("No run ID found. Please generate a scenario first.")
+        return
+    try:
+        record = client.create_feedback(run_id, kind, score=score, comment="")
+        st.session_state["feedback"] = {"feedback_id": str(record.id), "score": score}
+        placeholder.success("Feedback submitted. Thank you.")
+    except Exception as e:
+        placeholder.error(f"An error occurred while creating feedback: {e}")

--- a/core/llm.py
+++ b/core/llm.py
@@ -48,6 +48,14 @@ GEMINI_SAFETY_SETTINGS = [
 # LangSmith setup — optional. Kept for the existing feedback widget.
 # ---------------------------------------------------------------------------
 
+# Configure LangSmith for any page that calls `call_llm`. Previously each page
+# set these at the top of its script; we centralise so a page can't forget to
+# (page 4 didn't), and so adding a fifth page doesn't mean copying the block
+# again.
+os.environ.setdefault("LANGCHAIN_TRACING_V2", "true")
+os.environ.setdefault("LANGCHAIN_ENDPOINT", "https://api.smith.langchain.com")
+os.environ.setdefault("LANGCHAIN_PROJECT", "AttackGen")
+
 try:
     from langsmith import Client
     from langsmith.run_helpers import traceable

--- a/core/response.py
+++ b/core/response.py
@@ -1,0 +1,22 @@
+"""Cleaning helpers for raw LLM responses."""
+
+from __future__ import annotations
+
+import re
+
+
+def clean_model_response(text: str) -> tuple[str | None, str]:
+    """Pull out ``<think>...</think>`` reasoning and strip surrounding code fences.
+
+    Some reasoning models wrap their chain-of-thought in ``<think>`` tags; we
+    surface that separately so pages can show it in an expander while keeping
+    the main scenario clean. The trailing fence strip handles models that wrap
+    a Markdown scenario in a single outer ```` ```markdown ```` block.
+
+    Returns ``(thinking_or_None, cleaned)``.
+    """
+    match = re.search(r"<think>(.*?)</think>", text, re.DOTALL)
+    thinking = match.group(1).strip() if match else None
+    cleaned = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+    cleaned = re.sub(r"^```\w*\n|```$", "", cleaned, flags=re.MULTILINE).strip()
+    return thinking, cleaned

--- a/core/scenario_page.py
+++ b/core/scenario_page.py
@@ -1,0 +1,157 @@
+"""Deepened entry-point for the three scenario-generating pages.
+
+Each scenario page owns its own widgets, prompt assembly and readiness check.
+The shared control flow — generate button, LLM call, response cleaning,
+download, render, feedback widget — lives here. Page-specific behaviour comes
+in via the ``build_messages`` and ``is_ready`` callbacks; identity (session
+state keys, widget keys) comes in via ``page_id``.
+
+Adding a new scenario page is now: write the widgets and prompt builder, then
+``run_scenario_page(page_id=..., build_messages=..., is_ready=..., ...)``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import streamlit as st
+
+from core.feedback import render_feedback_widget
+from core.llm import call_llm
+from core.response import clean_model_response
+from core.schemas import LLMConfig
+
+Message = dict
+"""A single chat message: ``{"role": "...", "content": "..."}``."""
+
+
+def run_scenario_page(
+    *,
+    page_id: str,
+    build_messages: Callable[[], list[Message] | None],
+    is_ready: Callable[[], bool],
+    download_name: str,
+    trace_name: str,
+    trace_tags: tuple[str, ...],
+    status_text: str = "Generating scenario...",
+    button_label: str = "Generate Scenario",
+) -> None:
+    """Render the generate-button + scenario lifecycle for one scenario page.
+
+    ``page_id`` namespaces the persisted scenario keys and Streamlit widget
+    keys so the three pages can coexist in one Streamlit session without
+    colliding. ``build_messages`` may return ``None`` to indicate "nothing to
+    send yet" — in that case ``is_ready`` should also be returning ``False``,
+    but we double-check before calling the model.
+    """
+    generated_key = f"{page_id}_scenario_generated"
+    text_key = f"{page_id}_scenario_text"
+
+    st.session_state.setdefault(generated_key, False)
+
+    if st.button(button_label, key=f"{page_id}_generate"):
+        if is_ready():
+            messages = build_messages()
+            if messages is not None:
+                _generate_and_render(
+                    messages=messages,
+                    page_id=page_id,
+                    trace_name=trace_name,
+                    trace_tags=trace_tags,
+                    status_text=status_text,
+                    download_name=download_name,
+                    generated_key=generated_key,
+                    text_key=text_key,
+                )
+
+    render_feedback_widget(
+        key_prefix=page_id,
+        scenario_generated=st.session_state.get(generated_key, False),
+    )
+
+
+def _generate_and_render(
+    *,
+    messages: list[Message],
+    page_id: str,
+    trace_name: str,
+    trace_tags: tuple[str, ...],
+    status_text: str,
+    download_name: str,
+    generated_key: str,
+    text_key: str,
+) -> None:
+    config = LLMConfig.from_session_state(
+        trace_name=trace_name,
+        trace_tags=trace_tags,
+    )
+    scenario_text: str | None = None
+    try:
+        with st.status(status_text, expanded=True):
+            st.write("Calling the model.")
+            scenario_text = call_llm(config, messages)
+            st.write("Scenario generated successfully.")
+    except Exception as e:
+        st.error(f"An error occurred while generating the scenario: {e}")
+
+    st.markdown("---")
+    if scenario_text:
+        thinking, cleaned = clean_model_response(scenario_text)
+        if thinking:
+            with st.expander("View Model's Reasoning"):
+                st.markdown(thinking)
+        _persist_and_render(
+            cleaned=cleaned,
+            page_id=page_id,
+            download_name=download_name,
+            generated_key=generated_key,
+            text_key=text_key,
+        )
+    elif st.session_state.get(generated_key) and st.session_state.get(text_key):
+        _render_previous(
+            page_id=page_id,
+            text_key=text_key,
+            download_name=download_name,
+        )
+
+
+def _persist_and_render(
+    *,
+    cleaned: str,
+    page_id: str,
+    download_name: str,
+    generated_key: str,
+    text_key: str,
+) -> None:
+    st.session_state[generated_key] = True
+    st.session_state[text_key] = cleaned
+    # Cross-page handoff for the AttackGen Assistant chat page.
+    st.session_state["last_scenario"] = True
+    st.session_state["last_scenario_text"] = cleaned
+
+    st.markdown(cleaned)
+    st.download_button(
+        label="Download Scenario",
+        data=cleaned,
+        file_name=download_name,
+        mime="text/markdown",
+        key=f"{page_id}_download",
+    )
+
+
+def _render_previous(
+    *,
+    page_id: str,
+    text_key: str,
+    download_name: str,
+) -> None:
+    text = st.session_state.get(text_key, "")
+    st.markdown("Displaying previously generated scenario:")
+    st.markdown(text)
+    st.download_button(
+        label="Download Scenario",
+        data=text,
+        file_name=download_name,
+        mime="text/markdown",
+        key=f"{page_id}_download_previous",
+    )

--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -1,31 +1,14 @@
-import os
-import re
-
 import pandas as pd
 import streamlit as st
-from langsmith import Client
 from mitreattack.stix20 import MitreAttackData
 
 from atlas_parser import ATLASData, get_techniques_from_case_study_procedure
-from core.llm import call_llm
-from core.schemas import LLMConfig
+from core.scenario_page import run_scenario_page
 from core.state import restore_from_query_params
 
 # Restore sidebar selections on direct page loads (e.g. browser refresh while
 # on this page). See core/state.py for the persisted-keys list.
 restore_from_query_params()
-
-
-# ------------------ LangSmith Setup ------------------ #
-
-os.environ["LANGCHAIN_TRACING_V2"] = "true"
-os.environ["LANGCHAIN_ENDPOINT"] = "https://api.smith.langchain.com"
-os.environ["LANGCHAIN_PROJECT"] = "AttackGen"
-
-if "LANGCHAIN_API_KEY" in st.secrets:
-    client = Client(api_key=st.secrets["LANGCHAIN_API_KEY"])
-else:
-    client = None
 
 
 # ------------------ Streamlit Configuration ------------------ #
@@ -35,9 +18,6 @@ st.set_page_config(page_title="Generate Scenario", page_icon="🛡️")
 model_provider = st.session_state.get("chosen_model_provider", "OpenAI API")
 industry = st.session_state.get("industry")
 company_size = st.session_state.get("company_size")
-
-if "scenario_generated" not in st.session_state:
-    st.session_state["scenario_generated"] = False
 
 
 # ------------------ Data Loading ------------------ #
@@ -117,15 +97,6 @@ def build_messages(matrix, selected_group_alias, kill_chain_string):
         {"role": "system", "content": SYSTEM_PROMPT},
         {"role": "user", "content": user_content},
     ]
-
-
-def post_process(scenario_text: str) -> tuple[str | None, str]:
-    """Pull out <think>...</think> reasoning blocks emitted by some models."""
-    match = re.search(r'<think>(.*?)</think>', scenario_text, re.DOTALL)
-    thinking = match.group(1).strip() if match else None
-    cleaned = re.sub(r'<think>.*?</think>', '', scenario_text, flags=re.DOTALL).strip()
-    cleaned = re.sub(r'^```\w*\n|```$', '', cleaned, flags=re.MULTILINE).strip()
-    return thinking, cleaned
 
 
 # ------------------ Streamlit UI ------------------ #
@@ -298,20 +269,6 @@ else:
     )
 
 
-def _render_scenario(scenario_text: str):
-    st.session_state['scenario_generated'] = True
-    st.session_state['scenario_text'] = scenario_text
-    st.markdown(scenario_text)
-    st.download_button(
-        label="Download Scenario",
-        data=scenario_text,
-        file_name="threat_group_scenario.md",
-        mime="text/markdown",
-    )
-    st.session_state['last_scenario'] = True
-    st.session_state['last_scenario_text'] = scenario_text
-
-
 def _ready() -> bool:
     if model_provider != "Custom" and not st.session_state.get("llm_api_key"):
         st.info("Please add your API key in the sidebar to continue.")
@@ -328,76 +285,19 @@ def _ready() -> bool:
     if techniques_df.empty:
         st.info(f"Please select a {entity_label} with associated techniques.")
         return False
+    if messages is None:
+        return False
     return True
 
 
-try:
-    if st.button('Generate Scenario', key='generate_scenario'):
-        if _ready() and messages is not None:
-            config = LLMConfig.from_session_state(
-                trace_name="Threat Group Scenario",
-                trace_tags=("threat_group_scenario",),
-            )
-            scenario_text = None
-            try:
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Calling the model.")
-                    scenario_text = call_llm(config, messages)
-                    st.write("Scenario generated successfully.")
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-
-            st.markdown("---")
-            if scenario_text:
-                thinking, cleaned = post_process(scenario_text)
-                if thinking:
-                    with st.expander("View Model's Reasoning"):
-                        st.markdown(thinking)
-                _render_scenario(cleaned)
-            elif 'scenario_text' in st.session_state and st.session_state['scenario_generated']:
-                st.markdown("Displaying previously generated scenario:")
-                st.markdown(st.session_state['scenario_text'])
-                st.download_button(
-                    label="Download Scenario",
-                    data=st.session_state['scenario_text'],
-                    file_name="threat_group_scenario.md",
-                    mime="text/markdown",
-                )
-
-    if 'LANGCHAIN_API_KEY' not in st.secrets:
-        st.info("ℹ️ No LangChain API key has been set. This run will not be logged to LangSmith.")
-
-    feedback_placeholder = st.empty()
-    st.markdown("---")
-    if st.session_state.get('scenario_generated', False) and client is not None:
-        st.markdown("Rate the scenario to help improve this tool.")
-        col1, col2, _ = st.columns([0.5, 0.5, 5])
-        with col1:
-            if st.button("👍"):
-                try:
-                    run_id = st.session_state.get('run_id')
-                    if run_id:
-                        feedback_record = client.create_feedback(run_id, "positive", score=1, comment="")
-                        st.session_state.feedback = {"feedback_id": str(feedback_record.id), "score": 1}
-                        feedback_placeholder.success("Feedback submitted. Thank you.")
-                    else:
-                        feedback_placeholder.warning("No run ID found. Please generate a scenario first.")
-                except Exception as e:
-                    feedback_placeholder.error(f"An error occurred while creating feedback: {str(e)}")
-        with col2:
-            if st.button("👎"):
-                try:
-                    run_id = st.session_state.get('run_id')
-                    if run_id:
-                        feedback_record = client.create_feedback(run_id, "negative", score=0, comment="")
-                        st.session_state.feedback = {"feedback_id": str(feedback_record.id), "score": 0}
-                        feedback_placeholder.success("Feedback submitted. Thank you.")
-                    else:
-                        feedback_placeholder.warning("No run ID found. Please generate a scenario first.")
-                except Exception as e:
-                    feedback_placeholder.error(f"An error occurred while creating feedback: {str(e)}")
-except Exception as e:
-    st.error("An error occurred: " + str(e))
+run_scenario_page(
+    page_id="threat_group",
+    build_messages=lambda: messages,
+    is_ready=_ready,
+    download_name="threat_group_scenario.md",
+    trace_name="Threat Group Scenario",
+    trace_tags=("threat_group_scenario",),
+)
 
 
 st.markdown(

--- a/pages/2_🛠️_Custom_Scenarios.py
+++ b/pages/2_🛠️_Custom_Scenarios.py
@@ -1,31 +1,14 @@
-import os
-import re
-
 import pandas as pd
 import streamlit as st
-from langsmith import Client
 from mitreattack.stix20 import MitreAttackData
 
 from atlas_parser import ATLASData
-from core.llm import call_llm
-from core.schemas import LLMConfig
+from core.scenario_page import run_scenario_page
 from core.state import restore_from_query_params
 
 # Restore sidebar selections on direct page loads (e.g. browser refresh while
 # on this page). See core/state.py for the persisted-keys list.
 restore_from_query_params()
-
-
-# ------------------ LangSmith Setup ------------------ #
-
-os.environ["LANGCHAIN_TRACING_V2"] = "true"
-os.environ["LANGCHAIN_ENDPOINT"] = "https://api.smith.langchain.com"
-os.environ["LANGCHAIN_PROJECT"] = "AttackGen"
-
-if "LANGCHAIN_API_KEY" in st.secrets:
-    client = Client(api_key=st.secrets["LANGCHAIN_API_KEY"])
-else:
-    client = None
 
 
 # ------------------ Streamlit Configuration ------------------ #
@@ -36,9 +19,6 @@ model_provider = st.session_state.get("chosen_model_provider", "OpenAI API")
 industry = st.session_state.get("industry")
 company_size = st.session_state.get("company_size")
 matrix = st.session_state.get("matrix", "Enterprise")
-
-if "custom_scenario_generated" not in st.session_state:
-    st.session_state["custom_scenario_generated"] = False
 
 
 # ------------------ Incident Response Templates ------------------ #
@@ -177,14 +157,6 @@ def build_messages(selected_techniques_string, template_info):
     ]
 
 
-def post_process(scenario_text: str) -> tuple[str | None, str]:
-    match = re.search(r'<think>(.*?)</think>', scenario_text, re.DOTALL)
-    thinking = match.group(1).strip() if match else None
-    cleaned = re.sub(r'<think>.*?</think>', '', scenario_text, flags=re.DOTALL).strip()
-    cleaned = re.sub(r'^```\w*\n|```$', '', cleaned, flags=re.MULTILINE).strip()
-    return thinking, cleaned
-
-
 def template_selection(template, current_matrix):
     try:
         if template not in incident_response_templates[current_matrix]:
@@ -288,20 +260,6 @@ st.markdown(
 )
 
 
-def _render_scenario(scenario_text: str):
-    st.session_state['custom_scenario_generated'] = True
-    st.session_state['custom_scenario_text'] = scenario_text
-    st.markdown(scenario_text)
-    st.download_button(
-        label="Download Scenario",
-        data=scenario_text,
-        file_name="custom_scenario.md",
-        mime="text/markdown",
-    )
-    st.session_state['last_scenario'] = True
-    st.session_state['last_scenario_text'] = scenario_text
-
-
 def _ready() -> bool:
     if model_provider != "Custom" and not st.session_state.get("llm_api_key"):
         st.info("Please add your API key in the sidebar to continue.")
@@ -318,76 +276,19 @@ def _ready() -> bool:
     if not selected_techniques:
         st.info("Please select at least one technique.")
         return False
+    if messages is None:
+        return False
     return True
 
 
-try:
-    if st.button('Generate Scenario', key='generate_custom_scenario'):
-        if _ready() and messages is not None:
-            config = LLMConfig.from_session_state(
-                trace_name="Custom Scenario",
-                trace_tags=("custom_scenario",),
-            )
-            scenario_text = None
-            try:
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Calling the model.")
-                    scenario_text = call_llm(config, messages)
-                    st.write("Scenario generated successfully.")
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-
-            st.markdown("---")
-            if scenario_text:
-                thinking, cleaned = post_process(scenario_text)
-                if thinking:
-                    with st.expander("View Model's Reasoning"):
-                        st.markdown(thinking)
-                _render_scenario(cleaned)
-            elif 'custom_scenario_text' in st.session_state and st.session_state['custom_scenario_generated']:
-                st.markdown("Displaying previously generated scenario:")
-                st.markdown(st.session_state['custom_scenario_text'])
-                st.download_button(
-                    label="Download Scenario",
-                    data=st.session_state['custom_scenario_text'],
-                    file_name="custom_scenario.md",
-                    mime="text/markdown",
-                )
-
-    if 'LANGCHAIN_API_KEY' not in st.secrets:
-        st.info("ℹ️ No LangChain API key has been set. This run will not be logged to LangSmith.")
-
-    feedback_placeholder = st.empty()
-    st.markdown("---")
-    if st.session_state.get('custom_scenario_generated', False) and client is not None:
-        st.markdown("Rate the scenario to help improve this tool.")
-        col1, col2, _ = st.columns([0.5, 0.5, 5])
-        with col1:
-            if st.button("👍", key="thumbs_up_custom"):
-                try:
-                    run_id = st.session_state.get('run_id')
-                    if run_id:
-                        feedback_record = client.create_feedback(run_id, "positive", score=1, comment="")
-                        st.session_state.feedback = {"feedback_id": str(feedback_record.id), "score": 1}
-                        feedback_placeholder.success("Feedback submitted. Thank you.")
-                    else:
-                        feedback_placeholder.warning("No run ID found. Please generate a scenario first.")
-                except Exception as e:
-                    feedback_placeholder.error(f"An error occurred while creating feedback: {str(e)}")
-        with col2:
-            if st.button("👎"):
-                try:
-                    run_id = st.session_state.get('run_id')
-                    if run_id:
-                        feedback_record = client.create_feedback(run_id, "negative", score=0, comment="")
-                        st.session_state.feedback = {"feedback_id": str(feedback_record.id), "score": 0}
-                        feedback_placeholder.success("Feedback submitted. Thank you.")
-                    else:
-                        feedback_placeholder.warning("No run ID found. Please generate a scenario first.")
-                except Exception as e:
-                    feedback_placeholder.error(f"An error occurred while creating feedback: {str(e)}")
-except Exception as e:
-    st.error("An error occurred: " + str(e))
+run_scenario_page(
+    page_id="custom",
+    build_messages=lambda: messages,
+    is_ready=_ready,
+    download_name="custom_scenario.md",
+    trace_name="Custom Scenario",
+    trace_tags=("custom_scenario",),
+)
 
 
 st.markdown(

--- a/pages/3_🤖_AI_Insider_Threat_Scenarios.py
+++ b/pages/3_🤖_AI_Insider_Threat_Scenarios.py
@@ -25,14 +25,9 @@ paper "Actions Speak Louder Than Tokens: An Insider Threat Model for Frontier
 AI Agents" by Matt Adams (https://ai-insider-threat.matt-adams.co.uk).
 """
 
-import os
-import re
-
 import streamlit as st
-from langsmith import Client
 
-from core.llm import call_llm
-from core.schemas import LLMConfig
+from core.scenario_page import run_scenario_page
 from core.state import restore_from_query_params
 from data.ai_insider_threats import (
     AGENT_CAPABILITIES,
@@ -47,17 +42,6 @@ from data.ai_insider_threats import (
     stride_options,
 )
 
-# ------------------ LangSmith Setup ------------------ #
-
-os.environ["LANGCHAIN_TRACING_V2"] = "true"
-os.environ["LANGCHAIN_ENDPOINT"] = "https://api.smith.langchain.com"
-os.environ["LANGCHAIN_PROJECT"] = "AttackGen"
-
-if "LANGCHAIN_API_KEY" in st.secrets:
-    client = Client(api_key=st.secrets["LANGCHAIN_API_KEY"])
-else:
-    client = None
-
 # Restore sidebar selections on direct page loads (e.g. browser refresh while
 # on this page). See core/state.py for the persisted-keys list.
 restore_from_query_params()
@@ -69,9 +53,6 @@ st.set_page_config(page_title="AI Insider Threat Scenarios", page_icon="🤖")
 model_provider = st.session_state.get("chosen_model_provider", "OpenAI API")
 industry = st.session_state.get("industry")
 company_size = st.session_state.get("company_size")
-
-if "ai_insider_scenario_generated" not in st.session_state:
-    st.session_state["ai_insider_scenario_generated"] = False
 
 
 # ------------------ Prompt Construction ------------------ #
@@ -283,46 +264,8 @@ st.markdown(
 )
 
 
-def _post_process(scenario_text: str) -> tuple[str | None, str]:
-    """Extract <think>...</think> reasoning blocks emitted by some models.
-
-    Returns (thinking_or_None, cleaned_scenario).
-    """
-    match = re.search(r'<think>(.*?)</think>', scenario_text, re.DOTALL)
-    thinking = match.group(1).strip() if match else None
-    cleaned = re.sub(r'<think>.*?</think>', '', scenario_text, flags=re.DOTALL).strip()
-    cleaned = re.sub(r'^```\w*\n|```$', '', cleaned, flags=re.MULTILINE).strip()
-    return thinking, cleaned
-
-
-def _handle_response_text(scenario_text):
-    st.session_state['ai_insider_scenario_generated'] = True
-    st.session_state['ai_insider_scenario_text'] = scenario_text
-    st.markdown(scenario_text)
-    st.download_button(
-        label="Download Scenario",
-        data=scenario_text,
-        file_name="ai_insider_threat_scenario.md",
-        mime="text/markdown",
-    )
-    st.session_state['last_scenario'] = True
-    st.session_state['last_scenario_text'] = scenario_text
-
-
-def _show_previous_scenario():
-    if 'ai_insider_scenario_text' in st.session_state and st.session_state['ai_insider_scenario_generated']:
-        st.markdown("---")
-        st.markdown(st.session_state['ai_insider_scenario_text'])
-        st.download_button(
-            label="Download Scenario",
-            data=st.session_state['ai_insider_scenario_text'],
-            file_name="ai_insider_threat_scenario.md",
-            mime="text/markdown",
-        )
-
-
-def _ready_to_generate() -> bool:
-    if not st.session_state.get("llm_api_key") and PROVIDERS_NEEDING_KEY:
+def _ready() -> bool:
+    if model_provider != "Custom" and not st.session_state.get("llm_api_key"):
         st.info("Please add your API key in the sidebar to continue.")
         return False
     if not st.session_state.get("llm_model_name"):
@@ -337,72 +280,19 @@ def _ready_to_generate() -> bool:
     if not selected_categories and not selected_stride:
         st.info("Please select at least one threat category (or specific STRIDE threat) to continue.")
         return False
+    if messages is None:
+        return False
     return True
 
 
-# A bit ugly — used by _ready_to_generate to decide whether to enforce a key check.
-PROVIDERS_NEEDING_KEY = model_provider != "Custom"
-
-try:
-    if st.button('Generate Scenario', key='generate_ai_insider'):
-        if _ready_to_generate() and messages is not None:
-            config = LLMConfig.from_session_state(
-                trace_name="AI Insider Threat Scenario",
-                trace_tags=("ai_insider_scenario",),
-            )
-            try:
-                with st.status('Generating scenario...', expanded=True):
-                    st.write("Calling the model.")
-                    scenario_text = call_llm(config, messages)
-                    st.write("Scenario generated successfully.")
-            except Exception as e:
-                st.error(f"An error occurred while generating the scenario: {str(e)}")
-                scenario_text = None
-
-            st.markdown("---")
-            if scenario_text:
-                thinking, cleaned = _post_process(scenario_text)
-                if thinking:
-                    with st.expander("View Model's Reasoning"):
-                        st.markdown(thinking)
-                _handle_response_text(cleaned)
-            else:
-                _show_previous_scenario()
-
-    if 'LANGCHAIN_API_KEY' not in st.secrets:
-        st.info("ℹ️ No LangChain API key has been set. This run will not be logged to LangSmith.")
-
-    feedback_placeholder = st.empty()
-    st.markdown("---")
-    if st.session_state.get('ai_insider_scenario_generated', False) and client is not None:
-        st.markdown("Rate the scenario to help improve this tool.")
-        col1, col2, _ = st.columns([0.5, 0.5, 5])
-        with col1:
-            if st.button("👍", key="thumbs_up_ai_insider"):
-                try:
-                    run_id = st.session_state.get('run_id')
-                    if run_id:
-                        feedback_record = client.create_feedback(run_id, "positive", score=1, comment="")
-                        st.session_state.feedback = {"feedback_id": str(feedback_record.id), "score": 1}
-                        feedback_placeholder.success("Feedback submitted. Thank you.")
-                    else:
-                        feedback_placeholder.warning("No run ID found. Please generate a scenario first.")
-                except Exception as e:
-                    feedback_placeholder.error(f"An error occurred while creating feedback: {str(e)}")
-        with col2:
-            if st.button("👎", key="thumbs_down_ai_insider"):
-                try:
-                    run_id = st.session_state.get('run_id')
-                    if run_id:
-                        feedback_record = client.create_feedback(run_id, "negative", score=0, comment="")
-                        st.session_state.feedback = {"feedback_id": str(feedback_record.id), "score": 0}
-                        feedback_placeholder.success("Feedback submitted. Thank you.")
-                    else:
-                        feedback_placeholder.warning("No run ID found. Please generate a scenario first.")
-                except Exception as e:
-                    feedback_placeholder.error(f"An error occurred while creating feedback: {str(e)}")
-except Exception as e:
-    st.error("An error occurred: " + str(e))
+run_scenario_page(
+    page_id="ai_insider",
+    build_messages=lambda: messages,
+    is_ready=_ready,
+    download_name="ai_insider_threat_scenario.md",
+    trace_name="AI Insider Threat Scenario",
+    trace_tags=("ai_insider_scenario",),
+)
 
 
 # Back button

--- a/pages/4_💬_AttackGen_Assistant.py
+++ b/pages/4_💬_AttackGen_Assistant.py
@@ -1,8 +1,7 @@
-import re
-
 import streamlit as st
 
 from core.llm import call_llm
+from core.response import clean_model_response
 from core.schemas import LLMConfig
 from core.state import restore_from_query_params
 
@@ -22,15 +21,6 @@ SYSTEM_PROMPT = (
 st.set_page_config(page_title="AttackGen Assistant", page_icon=":speech_balloon:")
 
 st.markdown("# <span style='color: #1DB954;'>AttackGen Assistant💬</span>", unsafe_allow_html=True)
-
-
-def _post_process(text: str) -> tuple[str | None, str]:
-    """Extract <think>...</think> reasoning blocks emitted by some models."""
-    match = re.search(r'<think>(.*?)</think>', text, re.DOTALL)
-    thinking = match.group(1).strip() if match else None
-    cleaned = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL).strip()
-    cleaned = re.sub(r'^```\w*\n|```$', '', cleaned, flags=re.MULTILINE).strip()
-    return thinking, cleaned
 
 
 if 'last_scenario_text' in st.session_state and st.session_state.get('last_scenario'):
@@ -71,7 +61,7 @@ if 'last_scenario_text' in st.session_state and st.session_state.get('last_scena
         except Exception as e:
             return f"An error occurred while calling the model: {e}"
 
-        thinking, cleaned = _post_process(raw)
+        thinking, cleaned = clean_model_response(raw)
         if thinking:
             with st.expander("View Model's Reasoning"):
                 st.markdown(thinking)

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,95 @@
+"""Tests for `core.feedback._submit`.
+
+The widget itself (`render_feedback_widget`) is exercised end-to-end by the
+scenario_page tests; here we cover the LangSmith POST + session-state
+side-effects directly because they're the failure modes worth asserting on.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from core.feedback import _submit
+
+
+class _FakePlaceholder:
+    """Captures the success/warning/error message a placeholder is told to render."""
+
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+
+    def success(self, msg: str) -> None:
+        self.messages.append(("success", msg))
+
+    def warning(self, msg: str) -> None:
+        self.messages.append(("warning", msg))
+
+    def error(self, msg: str) -> None:
+        self.messages.append(("error", msg))
+
+
+class _FakeClient:
+    def __init__(self, record_id: str = "feedback-123", raises: Exception | None = None) -> None:
+        self.calls: list[tuple[Any, str, dict[str, Any]]] = []
+        self._record_id = record_id
+        self._raises = raises
+
+    def create_feedback(self, run_id: Any, kind: str, **kwargs: Any) -> SimpleNamespace:
+        self.calls.append((run_id, kind, kwargs))
+        if self._raises is not None:
+            raise self._raises
+        return SimpleNamespace(id=self._record_id)
+
+
+def test_submit_warns_when_run_id_missing(fake_session_state: dict[str, Any]) -> None:
+    client = _FakeClient()
+    placeholder = _FakePlaceholder()
+
+    _submit(client, placeholder, kind="positive", score=1)
+
+    assert client.calls == []
+    assert placeholder.messages == [("warning", "No run ID found. Please generate a scenario first.")]
+
+
+def test_submit_posts_feedback_and_records_success(
+    fake_session_state: dict[str, Any],
+) -> None:
+    fake_session_state["run_id"] = "run-abc"
+    client = _FakeClient(record_id="fb-1")
+    placeholder = _FakePlaceholder()
+
+    _submit(client, placeholder, kind="positive", score=1)
+
+    assert client.calls == [("run-abc", "positive", {"score": 1, "comment": ""})]
+    assert fake_session_state["feedback"] == {"feedback_id": "fb-1", "score": 1}
+    assert placeholder.messages == [("success", "Feedback submitted. Thank you.")]
+
+
+def test_submit_records_negative_with_score_zero(
+    fake_session_state: dict[str, Any],
+) -> None:
+    fake_session_state["run_id"] = "run-abc"
+    client = _FakeClient(record_id="fb-2")
+    placeholder = _FakePlaceholder()
+
+    _submit(client, placeholder, kind="negative", score=0)
+
+    assert client.calls == [("run-abc", "negative", {"score": 0, "comment": ""})]
+    assert fake_session_state["feedback"] == {"feedback_id": "fb-2", "score": 0}
+
+
+def test_submit_surfaces_client_errors(
+    fake_session_state: dict[str, Any],
+) -> None:
+    fake_session_state["run_id"] = "run-abc"
+    client = _FakeClient(raises=RuntimeError("network down"))
+    placeholder = _FakePlaceholder()
+
+    _submit(client, placeholder, kind="positive", score=1)
+
+    assert "feedback" not in fake_session_state
+    assert len(placeholder.messages) == 1
+    level, msg = placeholder.messages[0]
+    assert level == "error"
+    assert "network down" in msg

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,55 @@
+"""Tests for `core.response.clean_model_response`."""
+
+from __future__ import annotations
+
+from core.response import clean_model_response
+
+
+def test_returns_text_unchanged_when_no_think_or_fences() -> None:
+    text = "# Scenario\n\nA tabletop exercise."
+    thinking, cleaned = clean_model_response(text)
+    assert thinking is None
+    assert cleaned == text
+
+
+def test_extracts_single_think_block() -> None:
+    text = "<think>plan the response</think>\n\n# Scenario\n\nBody."
+    thinking, cleaned = clean_model_response(text)
+    assert thinking == "plan the response"
+    assert cleaned == "# Scenario\n\nBody."
+
+
+def test_strips_multiline_think_block() -> None:
+    text = "<think>\nstep 1\nstep 2\n</think>\nfinal answer"
+    thinking, cleaned = clean_model_response(text)
+    assert thinking == "step 1\nstep 2"
+    assert cleaned == "final answer"
+
+
+def test_strips_outer_markdown_code_fence() -> None:
+    text = "```markdown\n# Scenario\n\nBody.\n```"
+    thinking, cleaned = clean_model_response(text)
+    assert thinking is None
+    assert "```" not in cleaned
+    assert cleaned.startswith("# Scenario")
+
+
+def test_strips_bare_code_fence() -> None:
+    text = "```\n# Scenario\n```"
+    _, cleaned = clean_model_response(text)
+    assert "```" not in cleaned
+
+
+def test_handles_think_block_and_fences_together() -> None:
+    text = "<think>reasoning</think>\n```markdown\n# Title\n```"
+    thinking, cleaned = clean_model_response(text)
+    assert thinking == "reasoning"
+    assert "```" not in cleaned
+    assert cleaned.startswith("# Title")
+
+
+def test_returns_empty_cleaned_for_only_think_block() -> None:
+    text = "<think>only thinking, no answer</think>"
+    thinking, cleaned = clean_model_response(text)
+    assert thinking == "only thinking, no answer"
+    assert cleaned == ""

--- a/tests/test_scenario_page.py
+++ b/tests/test_scenario_page.py
@@ -1,0 +1,221 @@
+"""Tests for `core.scenario_page.run_scenario_page`.
+
+The interface is the test surface: given a build_messages callback and a
+readiness predicate, we assert what reaches `call_llm` and what lands in
+session_state. Streamlit's UI calls are stubbed to no-ops; we don't render
+anything — we only care about the control flow at the seam.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+import streamlit as st
+
+import core.llm as llm_module
+from core.scenario_page import run_scenario_page
+
+
+@pytest.fixture
+def stub_streamlit(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """No-op out the Streamlit UI surface that `run_scenario_page` touches.
+
+    Returns a dict the test can mutate to control widget return values:
+      - `button_returns`: bool returned by `st.button`
+    """
+    controls: dict[str, Any] = {"button_returns": False}
+
+    def _button(*_args, **_kwargs):
+        return controls["button_returns"]
+
+    @contextmanager
+    def _status(*_args, **_kwargs):
+        yield None
+
+    @contextmanager
+    def _expander(*_args, **_kwargs):
+        yield None
+
+    def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(st, "button", _button)
+    monkeypatch.setattr(st, "status", _status)
+    monkeypatch.setattr(st, "expander", _expander)
+    monkeypatch.setattr(st, "markdown", _noop)
+    monkeypatch.setattr(st, "write", _noop)
+    monkeypatch.setattr(st, "download_button", _noop)
+    monkeypatch.setattr(st, "info", _noop)
+    monkeypatch.setattr(st, "warning", _noop)
+    monkeypatch.setattr(st, "error", _noop)
+    # `render_feedback_widget` calls `st.empty()` then `st.markdown('---')`.
+    monkeypatch.setattr(st, "empty", lambda: _FakePlaceholder())
+    # `st.secrets` membership tests — pretend no LangSmith key is configured
+    # so the feedback widget short-circuits cleanly during tests.
+    monkeypatch.setattr(st, "secrets", {})
+
+    return controls
+
+
+class _FakePlaceholder:
+    def success(self, *_a, **_k): pass
+    def warning(self, *_a, **_k): pass
+    def error(self, *_a, **_k): pass
+
+
+@pytest.fixture
+def disable_langsmith_tracing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force call_llm to hit `_raw_call` directly so litellm sees the messages."""
+    monkeypatch.setattr(llm_module, "_langsmith_client", None)
+
+
+def test_does_nothing_when_button_not_pressed(
+    stub_streamlit, fake_session_state, mock_litellm_completion
+) -> None:
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+    fake_session_state["llm_api_key"] = "k"
+
+    run_scenario_page(
+        page_id="threat_group",
+        build_messages=lambda: [{"role": "user", "content": "x"}],
+        is_ready=lambda: True,
+        download_name="threat_group_scenario.md",
+        trace_name="Threat Group Scenario",
+        trace_tags=("threat_group_scenario",),
+    )
+
+    assert mock_litellm_completion.calls == []
+    assert "threat_group_scenario_generated" in fake_session_state
+    assert fake_session_state["threat_group_scenario_generated"] is False
+
+
+def test_skips_llm_when_not_ready(
+    stub_streamlit, fake_session_state, mock_litellm_completion
+) -> None:
+    stub_streamlit["button_returns"] = True
+    build_calls: list[None] = []
+
+    def build():
+        build_calls.append(None)
+        return [{"role": "user", "content": "x"}]
+
+    run_scenario_page(
+        page_id="threat_group",
+        build_messages=build,
+        is_ready=lambda: False,
+        download_name="threat_group_scenario.md",
+        trace_name="Threat Group Scenario",
+        trace_tags=("threat_group_scenario",),
+    )
+
+    assert mock_litellm_completion.calls == []
+    assert build_calls == []
+    assert fake_session_state["threat_group_scenario_generated"] is False
+
+
+def test_happy_path_calls_llm_cleans_response_and_persists(
+    stub_streamlit,
+    fake_session_state,
+    mock_litellm_completion,
+    disable_langsmith_tracing,
+) -> None:
+    stub_streamlit["button_returns"] = True
+    mock_litellm_completion.content = "<think>plan</think>\n# Scenario\n\nBody."
+
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+    fake_session_state["llm_api_key"] = "k"
+
+    messages = [{"role": "user", "content": "build me a scenario"}]
+
+    run_scenario_page(
+        page_id="threat_group",
+        build_messages=lambda: messages,
+        is_ready=lambda: True,
+        download_name="threat_group_scenario.md",
+        trace_name="Threat Group Scenario",
+        trace_tags=("threat_group_scenario",),
+    )
+
+    # The seam: call_llm got the page's messages.
+    assert len(mock_litellm_completion.calls) == 1
+    _args, kwargs = mock_litellm_completion.calls[0]
+    assert kwargs["messages"] == messages
+    assert kwargs["model"] == "gpt-5.5"
+
+    # The cleaned response — not the raw one — is what gets persisted.
+    cleaned = fake_session_state["threat_group_scenario_text"]
+    assert "<think>" not in cleaned
+    assert cleaned.startswith("# Scenario")
+
+    # Cross-page handoff for the Assistant page.
+    assert fake_session_state["last_scenario"] is True
+    assert fake_session_state["last_scenario_text"] == cleaned
+
+    # The artifact flag is set.
+    assert fake_session_state["threat_group_scenario_generated"] is True
+
+
+def test_page_id_namespaces_session_state(
+    stub_streamlit,
+    fake_session_state,
+    mock_litellm_completion,
+    disable_langsmith_tracing,
+) -> None:
+    stub_streamlit["button_returns"] = True
+    mock_litellm_completion.content = "scenario A"
+
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+    fake_session_state["llm_api_key"] = "k"
+
+    run_scenario_page(
+        page_id="custom",
+        build_messages=lambda: [{"role": "user", "content": "x"}],
+        is_ready=lambda: True,
+        download_name="custom_scenario.md",
+        trace_name="Custom Scenario",
+        trace_tags=("custom_scenario",),
+    )
+
+    assert "custom_scenario_text" in fake_session_state
+    assert "custom_scenario_generated" in fake_session_state
+    # The "threat_group_*" namespace is untouched by a "custom" page invocation.
+    assert "threat_group_scenario_text" not in fake_session_state
+
+
+def test_trace_name_and_tags_reach_llm_config(
+    stub_streamlit,
+    fake_session_state,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_streamlit["button_returns"] = True
+
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+    fake_session_state["llm_api_key"] = "k"
+
+    captured: dict[str, Any] = {}
+
+    def _fake_call_llm(config, msgs):
+        captured["config"] = config
+        captured["messages"] = msgs
+        return "ok"
+
+    monkeypatch.setattr("core.scenario_page.call_llm", _fake_call_llm)
+
+    run_scenario_page(
+        page_id="ai_insider",
+        build_messages=lambda: [{"role": "user", "content": "x"}],
+        is_ready=lambda: True,
+        download_name="ai_insider_threat_scenario.md",
+        trace_name="AI Insider Threat Scenario",
+        trace_tags=("ai_insider_scenario",),
+    )
+
+    cfg = captured["config"]
+    assert cfg.trace_name == "AI Insider Threat Scenario"
+    assert cfg.trace_tags == ("ai_insider_scenario",)


### PR DESCRIPTION
## Summary

- Three deepenings, one branch — the three scenario-generating pages now share their LLM-call lifecycle (readiness gate, call_llm, response cleaning, render + download, feedback widget) through a single `core.scenario_page.run_scenario_page` entry point. Each page keeps only its widgets, prompt builder, and readiness predicate.
- Extracts two helpers that were duplicated 4× and 3× across the pages: `core.response.clean_model_response` (the `<think>`/fence stripper) and `core.feedback.render_feedback_widget` (the LangSmith thumbs widget). Pages no longer import `langsmith` or set `LANGCHAIN_*` env vars — those move into `core/llm.py`.
- Net diff across the three scenario pages: roughly **-355 / +45**. The Assistant page (page 4) also drops its local copy of `post_process` and uses the new shared helper.

## Side effects worth knowing

- Thumbs up/down button keys are now consistently namespaced by `page_id`; previously they were inconsistent across pages with a key-collision risk if two were rendered together.
- Page 3's `_ready_to_generate` referenced `PROVIDERS_NEEDING_KEY` before its definition; the shared readiness pattern doesn't need that variable.
- Page 4 was never setting `LANGCHAIN_TRACING_V2` / `LANGCHAIN_ENDPOINT` / `LANGCHAIN_PROJECT`; now does, via `core/llm.py`.
- One small change in `core/feedback.py`: `st.session_state.feedback = ...` (attribute access) became `st.session_state[\"feedback\"] = ...` (item access). Real Streamlit `SessionState` supports both; the dict-based test fixture only supports item access.

## How to review

The branch is split into four commits, each independently sensible:

1. `973bbb8` extract `clean_model_response` — only page 4 uses it yet
2. `5f175e8` extract feedback widget — module + tests, no consumers
3. `9c430d4` add `run_scenario_page` + fold LangSmith env-var setup into `core/llm.py` — no consumers
4. `eb3acd1` collapse pages 1-3 onto `run_scenario_page`

Tests at each step: all 35 pass.

## Test plan

- [ ] \`pytest\` — 35 pass (16 new across `test_response.py`, `test_feedback.py`, `test_scenario_page.py`)
- [ ] Run \`streamlit run 00_👋_Welcome.py\` and on each scenario page: confirm the existing happy path (select inputs → Generate → scenario renders → download button works → thumbs widget renders when LangSmith key is configured)
- [ ] Page 4: confirm the chat refines the most recent scenario as before
- [ ] LangSmith (if you have a key set): confirm runs show up in the AttackGen project for all three scenario pages and the Assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)