### PR TITLE
feat(core): stream LLM output for scenarios and chat

### DIFF
--- a/core/llm.py
+++ b/core/llm.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterator
 
 # Silence LiteLLM's import-time WARNINGs about optional AWS deps (Bedrock /
 # SageMaker pre-load) — we don't use them, and they fire before
@@ -129,6 +130,14 @@ def _raw_call(config: LLMConfig, messages: list[dict]) -> str:
     return response.choices[0].message.content or ""
 
 
+def _raw_stream(config: LLMConfig, messages: list[dict]) -> Iterator[str]:
+    kwargs = _build_litellm_kwargs(config)
+    for chunk in litellm.completion(messages=messages, stream=True, **kwargs):
+        delta = chunk.choices[0].delta.content
+        if delta:
+            yield delta
+
+
 def call_llm(config: LLMConfig, messages: list[dict]) -> str:
     """Generate a single text response from any supported provider.
 
@@ -151,3 +160,26 @@ def call_llm(config: LLMConfig, messages: list[dict]) -> str:
         return _traced(messages)
 
     return _raw_call(config, messages)
+
+
+def call_llm_stream(config: LLMConfig, messages: list[dict]) -> Iterator[str]:
+    """Stream text deltas from any supported provider.
+
+    Yields raw assistant content as it arrives. The run_id is published into
+    session_state at the start so the LangSmith feedback widget can pick it
+    up even if the user clicks thumbs-up mid-stream.
+    """
+    if _langsmith_client is not None and traceable is not None:
+        @traceable(
+            run_type="llm",
+            name=config.trace_name,
+            tags=list(config.trace_tags),
+            client=_langsmith_client,
+        )
+        def _traced(messages: list[dict], *, run_tree) -> Iterator[str]:
+            st.session_state["run_id"] = str(run_tree.id)
+            yield from _raw_stream(config, messages)
+
+        return _traced(messages)
+
+    return _raw_stream(config, messages)

--- a/core/response.py
+++ b/core/response.py
@@ -3,6 +3,50 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable, Iterator
+
+_OPEN_TAG = "<think>"
+_CLOSE_TAG = "</think>"
+_MAX_PARTIAL = max(len(_OPEN_TAG), len(_CLOSE_TAG)) - 1
+
+
+def stream_filter_thinking(deltas: Iterable[str]) -> Iterator[str]:
+    """Yield text deltas with ``<think>...</think>`` regions suppressed.
+
+    Holds back up to ``len("</think>")-1`` trailing characters at any time so
+    that a tag prefix spanning two chunks doesn't leak before we can decide
+    whether it's the start of a tag. The caller is responsible for capturing
+    the raw stream separately if it needs the unfiltered text (e.g. to run
+    ``clean_model_response`` for the final cleaned + thinking pair).
+    """
+    buf = ""
+    inside = False
+    for delta in deltas:
+        buf += delta
+        while True:
+            if inside:
+                close_at = buf.find(_CLOSE_TAG)
+                if close_at == -1:
+                    # Keep enough tail to recognise a future "</think>".
+                    if len(buf) > _MAX_PARTIAL:
+                        buf = buf[-_MAX_PARTIAL:]
+                    break
+                buf = buf[close_at + len(_CLOSE_TAG):]
+                inside = False
+                continue
+            open_at = buf.find(_OPEN_TAG)
+            if open_at == -1:
+                # Yield everything except a possible partial-tag tail.
+                if len(buf) > _MAX_PARTIAL:
+                    yield buf[:-_MAX_PARTIAL]
+                    buf = buf[-_MAX_PARTIAL:]
+                break
+            if open_at > 0:
+                yield buf[:open_at]
+            buf = buf[open_at + len(_OPEN_TAG):]
+            inside = True
+    if not inside and buf:
+        yield buf
 
 
 def clean_model_response(text: str) -> tuple[str | None, str]:

--- a/core/scenario_page.py
+++ b/core/scenario_page.py
@@ -17,8 +17,8 @@ from collections.abc import Callable
 import streamlit as st
 
 from core.feedback import render_feedback_widget
-from core.llm import call_llm
-from core.response import clean_model_response
+from core.llm import call_llm_stream
+from core.response import clean_model_response, stream_filter_thinking
 from core.schemas import LLMConfig
 
 Message = dict
@@ -86,17 +86,32 @@ def _generate_and_render(
         trace_tags=trace_tags,
     )
     scenario_text: str | None = None
+    stream_placeholder = st.empty()
+    raw_chunks: list[str] = []
+
+    def _tee(chunks):
+        for chunk in chunks:
+            raw_chunks.append(chunk)
+            yield chunk
+
     try:
-        with st.status(status_text, expanded=True):
-            st.write("Calling the model.")
-            scenario_text = call_llm(config, messages)
-            st.write("Scenario generated successfully.")
+        with st.status(status_text, expanded=True) as status:
+            st.write("Streaming response from the model.")
+            with stream_placeholder.container():
+                st.write_stream(
+                    stream_filter_thinking(_tee(call_llm_stream(config, messages)))
+                )
+            scenario_text = "".join(raw_chunks)
+            status.update(label="Scenario generated.", state="complete")
     except Exception as e:
         st.error(f"An error occurred while generating the scenario: {e}")
 
     st.markdown("---")
     if scenario_text:
         thinking, cleaned = clean_model_response(scenario_text)
+        # Replace the live-streamed view with the canonical cleaned render so
+        # any code-fence stripping (or other tidy-ups) takes effect.
+        stream_placeholder.empty()
         if thinking:
             with st.expander("View Model's Reasoning"):
                 st.markdown(thinking)

--- a/pages/4_💬_AttackGen_Assistant.py
+++ b/pages/4_💬_AttackGen_Assistant.py
@@ -1,7 +1,7 @@
 import streamlit as st
 
-from core.llm import call_llm
-from core.response import clean_model_response
+from core.llm import call_llm_stream
+from core.response import clean_model_response, stream_filter_thinking
 from core.schemas import LLMConfig
 from core.state import restore_from_query_params
 
@@ -56,16 +56,28 @@ if 'last_scenario_text' in st.session_state and st.session_state.get('last_scena
             trace_name="AttackGen Assistant",
             trace_tags=("assistant",),
         )
-        try:
-            raw = call_llm(config, messages)
-        except Exception as e:
-            return f"An error occurred while calling the model: {e}"
+        raw_chunks: list[str] = []
 
+        def _tee(chunks):
+            for chunk in chunks:
+                raw_chunks.append(chunk)
+                yield chunk
+
+        try:
+            yield from stream_filter_thinking(_tee(call_llm_stream(config, messages)))
+        except Exception as e:
+            yield f"\n\nAn error occurred while calling the model: {e}"
+            st.session_state["_last_assistant_cleaned"] = (
+                f"An error occurred while calling the model: {e}"
+            )
+            return
+
+        raw = "".join(raw_chunks)
         thinking, cleaned = clean_model_response(raw)
         if thinking:
             with st.expander("View Model's Reasoning"):
                 st.markdown(thinking)
-        return cleaned
+        st.session_state["_last_assistant_cleaned"] = cleaned
 
     if prompt := st.chat_input("Type your message here..."):
         st.session_state.messages.append({"role": "user", "content": prompt})
@@ -74,10 +86,11 @@ if 'last_scenario_text' in st.session_state and st.session_state.get('last_scena
 
         with st.chat_message("assistant"):
             history = "\n".join(f"{m['role']}: {m['content']}" for m in st.session_state.messages[:-1])
-            response = generate_response(prompt, history)
-            st.markdown(response)
+            st.write_stream(generate_response(prompt, history))
 
-        st.session_state.messages.append({"role": "assistant", "content": response})
+        st.session_state.messages.append(
+            {"role": "assistant", "content": st.session_state.pop("_last_assistant_cleaned", "")}
+        )
 
     def clear_conversation():
         st.session_state.messages = [


### PR DESCRIPTION
## Summary
- Add `call_llm_stream` alongside `call_llm` in `core/llm.py` — LangSmith-traced generator that publishes `run_id` to `st.session_state` at the start of the stream so the feedback widget keeps working.
- Add `stream_filter_thinking` in `core/response.py` — stateful filter that suppresses `<think>...</think>` regions in the live view with cross-chunk tag holdback. `clean_model_response` is unchanged and still extracts thinking from the accumulated raw text for the reasoning expander.
- Wire scenario generation in `core/scenario_page.py` and the AttackGen Assistant chat in `pages/4_💬_AttackGen_Assistant.py` through `st.write_stream`. Scenario pages stream into an `st.empty()` placeholder inside the existing `st.status` box and replace it with the cleaned canonical render after completion; chat replies stream directly into the chat bubble and the cleaned text is appended to history for subsequent reruns.

No provider-specific changes — kwargs continue to flow through `_build_litellm_kwargs`, so Gemini `safety_settings`, Anthropic `max_tokens`, OpenAI reasoning `max_completion_tokens`, and Custom `custom_llm_provider="openai"` all apply unchanged.

## Test plan
- [ ] Anthropic (Claude Sonnet 4.6) on page 1 — tokens stream progressively, final cleaned markdown matches today's output, LangSmith thumbs-up/down submits successfully.
- [ ] Gemini 3.1 Flash on page 2 — safety settings don't block, stream flows.
- [ ] OpenAI gpt-5.4-mini on page 3 — streaming works. Confirm a clean `st.error` if a reasoning model rejects `stream=True`.
- [ ] Custom OpenAI-compatible endpoint (LM Studio at `http://127.0.0.1:1234/v1`) — local model streams.
- [ ] Reasoning model that emits `<think>...</think>` (e.g. Qwen on Groq) — live stream never shows raw `<think>` tags; "View Model's Reasoning" expander appears after completion.
- [ ] AttackGen Assistant chat — reply streams into the chat bubble; on the next user turn the prior assistant reply is preserved in history.
- [ ] Download button still produces the cleaned markdown; cross-page handoff to the chat page's "Generated Scenario" expander still works.