### PR TITLE
test: cover high-value untested logic (streaming filter, ATLAS parser, state, registry)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__/
 
 # Local notes
 TODO.md
+
+# Test audit report (local only)
+test-optimization.html

--- a/tests/test_ai_uplift.py
+++ b/tests/test_ai_uplift.py
@@ -1,0 +1,48 @@
+"""Tests for `core.ai_uplift` — the AI-enhanced adversary toggle.
+
+The toggle reframes a scenario's prompt and adds an `ai_enhanced` LangSmith tag
+when on, and is namespaced per page so two scenario pages keep independent
+state. These cover the on/off branches and the namespacing.
+"""
+
+from __future__ import annotations
+
+from core.ai_uplift import (
+    AI_UPLIFT_PROMPT,
+    apply_ai_uplift,
+    is_ai_uplift_on,
+    uplift_trace_tags,
+)
+
+
+def test_defaults_to_off_before_toggle_rendered(fake_session_state) -> None:
+    assert is_ai_uplift_on("threat_group") is False
+    assert apply_ai_uplift("base content", "threat_group") == "base content"
+    assert uplift_trace_tags(("threat_group_scenario",), "threat_group") == (
+        "threat_group_scenario",
+    )
+
+
+def test_apply_appends_prompt_when_on(fake_session_state) -> None:
+    fake_session_state["threat_group_ai_uplift"] = True
+
+    result = apply_ai_uplift("base content", "threat_group")
+
+    assert result == "base content" + AI_UPLIFT_PROMPT
+
+
+def test_trace_tags_gains_ai_enhanced_when_on(fake_session_state) -> None:
+    fake_session_state["custom_ai_uplift"] = True
+
+    tags = uplift_trace_tags(("custom_scenario",), "custom")
+
+    assert tags == ("custom_scenario", "ai_enhanced")
+
+
+def test_toggle_state_is_namespaced_per_page(fake_session_state) -> None:
+    fake_session_state["threat_group_ai_uplift"] = True
+
+    # The "custom" page must not inherit the threat-group page's toggle.
+    assert is_ai_uplift_on("threat_group") is True
+    assert is_ai_uplift_on("custom") is False
+    assert apply_ai_uplift("x", "custom") == "x"

--- a/tests/test_atlas_parser.py
+++ b/tests/test_atlas_parser.py
@@ -1,0 +1,225 @@
+"""Tests for `atlas_parser` — the custom MITRE ATLAS STIX parser.
+
+The parser turns on-disk STIX JSON into the technique/tactic rows that feed the
+Threat Group and Custom scenario pages. These tests drive it from a small
+in-memory STIX document written to a temp file, so they assert the indexing,
+ordering and fallback contracts without depending on the full ATLAS matrix.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from atlas_parser import ATLASData, get_techniques_from_case_study_procedure
+
+
+def _atlas(source_name: str = "mitre-atlas") -> dict:
+    """A minimal STIX document exercising every indexing branch.
+
+    Tactics are intentionally given out of kill-chain order (Initial Access
+    before Reconnaissance) so a test can prove `get_tactics` re-orders them.
+    """
+    return {
+        "objects": [
+            # Tactics — only two of the sixteen ordered IDs are present.
+            {
+                "type": "x-mitre-tactic",
+                "id": "x-mitre-tactic--ia",
+                "name": "Initial Access",
+                "x_mitre_shortname": "initial-access",
+                "external_references": [
+                    {"source_name": "mitre-atlas", "external_id": "AML.TA0004"}
+                ],
+            },
+            {
+                "type": "x-mitre-tactic",
+                "id": "x-mitre-tactic--recon",
+                "name": "Reconnaissance",
+                "x_mitre_shortname": "reconnaissance",
+                "external_references": [
+                    {"source_name": "mitre-atlas", "external_id": "AML.TA0002"}
+                ],
+            },
+            # A parent technique under Reconnaissance.
+            {
+                "type": "attack-pattern",
+                "id": "attack-pattern--t1",
+                "name": "Tech One",
+                "description": "desc one",
+                "x_mitre_is_subtechnique": False,
+                "kill_chain_phases": [
+                    {"kill_chain_name": "atlas", "phase_name": "reconnaissance"}
+                ],
+                "external_references": [
+                    {"source_name": "mitre-atlas", "external_id": "AML.T0001"}
+                ],
+            },
+            # A subtechnique under Initial Access.
+            {
+                "type": "attack-pattern",
+                "id": "attack-pattern--t2",
+                "name": "Sub Tech",
+                "description": "sub desc",
+                "x_mitre_is_subtechnique": True,
+                "kill_chain_phases": [
+                    {"kill_chain_name": "atlas", "phase_name": "initial-access"}
+                ],
+                "external_references": [
+                    {"source_name": "mitre-atlas", "external_id": "AML.T0001.001"}
+                ],
+            },
+            # A technique with no kill-chain phases (drives the "Unknown" fallback).
+            {
+                "type": "attack-pattern",
+                "id": "attack-pattern--t3",
+                "name": "No Phase Tech",
+                "description": "no phase desc",
+                "x_mitre_is_subtechnique": False,
+                "external_references": [
+                    {"source_name": "mitre-atlas", "external_id": "AML.T0009"}
+                ],
+            },
+            # An attack-pattern lacking a mitre-atlas external id — must be skipped.
+            {
+                "type": "attack-pattern",
+                "id": "attack-pattern--noid",
+                "name": "Unindexed Tech",
+                "external_references": [
+                    {"source_name": "other-source", "external_id": "X1"}
+                ],
+            },
+            # A mitigation and a relationship, to confirm they are indexed/collected.
+            {
+                "type": "course-of-action",
+                "id": "course-of-action--m1",
+                "name": "Mitigation One",
+                "external_references": [
+                    {"source_name": "mitre-atlas", "external_id": "AML.M0001"}
+                ],
+            },
+            {
+                "type": "relationship",
+                "id": "relationship--r1",
+                "relationship_type": "mitigates",
+                "source_ref": "course-of-action--m1",
+                "target_ref": "attack-pattern--t1",
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def atlas_data(tmp_path: Path) -> ATLASData:
+    path = tmp_path / "stix-atlas.json"
+    path.write_text(json.dumps(_atlas()))
+    return ATLASData(str(path))
+
+
+# ---------------------------------------------------------------------------
+# Indexing
+# ---------------------------------------------------------------------------
+
+
+def test_indexes_only_objects_with_mitre_atlas_external_id(atlas_data: ATLASData) -> None:
+    # The three techniques carrying an ATLAS id are indexed; the one without is not.
+    assert set(atlas_data.techniques) == {"AML.T0001", "AML.T0001.001", "AML.T0009"}
+    assert atlas_data.get_technique_by_id("X1") is None
+    assert set(atlas_data.tactics) == {"AML.TA0004", "AML.TA0002"}
+    assert set(atlas_data.mitigations) == {"AML.M0001"}
+    assert len(atlas_data.relationships) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tactics
+# ---------------------------------------------------------------------------
+
+
+def test_get_tactics_returns_kill_chain_order_skipping_absent_ids(
+    atlas_data: ATLASData,
+) -> None:
+    # Reconnaissance (AML.TA0002) precedes Initial Access (AML.TA0004) in the
+    # canonical order, even though the document lists them the other way round.
+    assert atlas_data.get_tactic_names_ordered() == ["Reconnaissance", "Initial Access"]
+
+
+def test_get_tactic_name_by_shortname_echoes_unknown(atlas_data: ATLASData) -> None:
+    assert atlas_data.get_tactic_name_by_shortname("reconnaissance") == "Reconnaissance"
+    assert atlas_data.get_tactic_name_by_shortname("no-such-tactic") == "no-such-tactic"
+
+
+def test_get_tactic_name_by_id_echoes_unknown(atlas_data: ATLASData) -> None:
+    assert atlas_data.get_tactic_name_by_id("AML.TA0002") == "Reconnaissance"
+    assert atlas_data.get_tactic_name_by_id("AML.TA9999") == "AML.TA9999"
+
+
+# ---------------------------------------------------------------------------
+# Techniques
+# ---------------------------------------------------------------------------
+
+
+def test_get_techniques_can_exclude_subtechniques(atlas_data: ATLASData) -> None:
+    with_subs = {t["external_id"] for t in atlas_data.get_techniques(include_subtechniques=True)}
+    without_subs = {t["external_id"] for t in atlas_data.get_techniques(include_subtechniques=False)}
+
+    assert "AML.T0001.001" in with_subs
+    assert "AML.T0001.001" not in without_subs
+    assert "AML.T0001" in without_subs
+
+
+def test_get_techniques_for_tactic_matches_by_phase_name(atlas_data: ATLASData) -> None:
+    recon = atlas_data.get_techniques_for_tactic("reconnaissance")
+    assert [t["external_id"] for t in recon] == ["AML.T0001"]
+
+
+def test_get_atlas_id_maps_stix_id_back_to_external_id(atlas_data: ATLASData) -> None:
+    assert atlas_data.get_atlas_id("attack-pattern--t1") == "AML.T0001"
+    assert atlas_data.get_atlas_id("attack-pattern--missing") is None
+
+
+# ---------------------------------------------------------------------------
+# Case-study procedure extraction — the three-way tactic-name fallback.
+# ---------------------------------------------------------------------------
+
+
+def test_procedure_uses_step_tactic_id_when_present(atlas_data: ATLASData) -> None:
+    procedure = [{"technique": "AML.T0001", "tactic": "AML.TA0002", "description": "step desc"}]
+    rows = get_techniques_from_case_study_procedure(procedure, atlas_data)
+
+    assert rows == [
+        {
+            "Technique Name": "Tech One",
+            "ATT&CK ID": "AML.T0001",
+            "Phase Name": "Reconnaissance",
+            "Description": "step desc",
+        }
+    ]
+
+
+def test_procedure_falls_back_to_technique_kill_chain_phase(atlas_data: ATLASData) -> None:
+    # No tactic on the step → resolve via the technique's first kill-chain phase.
+    procedure = [{"technique": "AML.T0001"}]
+    rows = get_techniques_from_case_study_procedure(procedure, atlas_data)
+
+    assert rows[0]["Phase Name"] == "Reconnaissance"
+    # Description falls back to the technique's own description.
+    assert rows[0]["Description"] == "desc one"
+
+
+def test_procedure_phase_is_unknown_without_tactic_or_phases(atlas_data: ATLASData) -> None:
+    procedure = [{"technique": "AML.T0009"}]
+    rows = get_techniques_from_case_study_procedure(procedure, atlas_data)
+
+    assert rows[0]["Phase Name"] == "Unknown"
+
+
+def test_procedure_drops_steps_with_unknown_technique(atlas_data: ATLASData) -> None:
+    procedure = [
+        {"technique": "AML.T0001", "tactic": "AML.TA0002"},
+        {"technique": "AML.T9999", "tactic": "AML.TA0002"},  # not indexed → dropped
+    ]
+    rows = get_techniques_from_case_study_procedure(procedure, atlas_data)
+
+    assert [r["ATT&CK ID"] for r in rows] == ["AML.T0001"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,12 +9,32 @@ from __future__ import annotations
 
 from core.models import (
     MODELS,
+    PROVIDERS,
     get_litellm_prefix,
     get_model,
     get_models_for_provider,
     get_provider,
     model_uses_completion_tokens,
 )
+
+
+def test_every_model_references_a_known_provider() -> None:
+    """Adding a model is a one-line edit to MODELS; a typo'd provider_key would
+    otherwise route to an empty prefix and misfire only at call time."""
+    for m in MODELS:
+        assert m.provider_key in PROVIDERS, m.model_id
+
+
+def test_custom_provider_has_no_static_models() -> None:
+    # Custom is free-text: the user types the model name in the sidebar.
+    assert get_models_for_provider("Custom") == []
+
+
+def test_model_provider_pairs_are_unique() -> None:
+    """A duplicate (provider, model) pair would be silently shadowed in the
+    lookup table built in core.models."""
+    pairs = [(m.provider_key, m.model_id) for m in MODELS]
+    assert len(pairs) == len(set(pairs))
 
 
 def test_get_provider_unknown_returns_none() -> None:

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,8 +1,13 @@
-"""Tests for `core.response.clean_model_response`."""
+"""Tests for `core.response.clean_model_response` and `stream_filter_thinking`."""
 
 from __future__ import annotations
 
-from core.response import clean_model_response
+from core.response import clean_model_response, stream_filter_thinking
+
+
+def _filter(*deltas: str) -> str:
+    """Run the streaming filter over the given deltas and join the output."""
+    return "".join(stream_filter_thinking(deltas))
 
 
 def test_returns_text_unchanged_when_no_think_or_fences() -> None:
@@ -53,3 +58,42 @@ def test_returns_empty_cleaned_for_only_think_block() -> None:
     thinking, cleaned = clean_model_response(text)
     assert thinking == "only thinking, no answer"
     assert cleaned == ""
+
+
+# ---------------------------------------------------------------------------
+# stream_filter_thinking — the streaming counterpart that suppresses
+# <think>...</think> regions across chunk boundaries.
+# ---------------------------------------------------------------------------
+
+
+def test_stream_passes_plain_text_unchanged() -> None:
+    assert _filter("# Scenario\n\nA tabletop exercise.") == "# Scenario\n\nA tabletop exercise."
+
+
+def test_stream_suppresses_think_block_with_surrounding_content() -> None:
+    assert _filter("before<think>secret</think>after") == "beforeafter"
+
+
+def test_stream_suppresses_tag_split_across_chunks() -> None:
+    # The opening tag straddles two deltas; nothing inside it may leak.
+    assert _filter("<thi", "nk>secret</think>visible") == "visible"
+
+
+def test_stream_suppresses_close_tag_split_across_chunks() -> None:
+    assert _filter("<think>secret</thi", "nk>visible") == "visible"
+
+
+def test_stream_suppresses_multiple_think_blocks() -> None:
+    assert _filter("<think>a</think>mid<think>b</think>end") == "midend"
+
+
+def test_stream_does_not_swallow_stray_lessthan() -> None:
+    # A literal "<" that never becomes a <think> tag must survive, even when
+    # the buffer is long enough to trigger the partial-tag tail retention.
+    text = "this is a < sign embedded in a reasonably long line of output"
+    assert _filter(text) == text
+
+
+def test_stream_drops_unterminated_think_block() -> None:
+    # An opened-but-never-closed block emits nothing after the open tag.
+    assert _filter("visible<think>secret never closed") == "visible"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -7,8 +7,6 @@ security invariant that API keys are never mirrored into the URL.
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 import streamlit as st
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,127 @@
+"""Tests for `core.state` — URL query-param persistence of sidebar selections.
+
+These assert the validation rules (stale provider/matrix values are dropped),
+the precedence rule (an existing session_state value wins over the URL), and the
+security invariant that API keys are never mirrored into the URL.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import streamlit as st
+
+from core.state import restore_from_query_params, sync_to_query_params
+
+
+@pytest.fixture
+def fake_query_params(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Replace `st.query_params` with a plain dict.
+
+    A dict is interface-compatible with the access patterns `core.state` uses:
+    `in`, `[]`, `.items()`, `.keys()`, `del`, and item assignment.
+    """
+    qp: dict[str, str] = {}
+    monkeypatch.setattr(st, "query_params", qp)
+    return qp
+
+
+# ---------------------------------------------------------------------------
+# restore_from_query_params
+# ---------------------------------------------------------------------------
+
+
+def test_restore_loads_valid_values(fake_session_state, fake_query_params) -> None:
+    fake_query_params.update({"p": "Anthropic API", "x": "ICS", "i": "Finance"})
+
+    restore_from_query_params()
+
+    assert fake_session_state["chosen_model_provider"] == "Anthropic API"
+    assert fake_session_state["matrix"] == "ICS"
+    assert fake_session_state["industry"] == "Finance"
+
+
+def test_restore_drops_unknown_provider(fake_session_state, fake_query_params) -> None:
+    fake_query_params["p"] = "BogusProvider"
+
+    restore_from_query_params()
+
+    assert "chosen_model_provider" not in fake_session_state
+
+
+def test_restore_drops_invalid_matrix(fake_session_state, fake_query_params) -> None:
+    fake_query_params["x"] = "Bogus"
+
+    restore_from_query_params()
+
+    assert "matrix" not in fake_session_state
+
+
+def test_restore_does_not_overwrite_existing_session_value(
+    fake_session_state, fake_query_params
+) -> None:
+    fake_session_state["industry"] = "Healthcare"
+    fake_query_params["i"] = "Technology"
+
+    restore_from_query_params()
+
+    # A user-driven selection already in session_state wins over the URL.
+    assert fake_session_state["industry"] == "Healthcare"
+
+
+# ---------------------------------------------------------------------------
+# sync_to_query_params
+# ---------------------------------------------------------------------------
+
+
+def test_sync_writes_only_the_persisted_shadow_keys(
+    fake_session_state, fake_query_params
+) -> None:
+    fake_session_state.update(
+        {
+            "chosen_model_provider": "OpenAI API",
+            "llm_model_name": "gpt-5.5",
+            "llm_api_base": "https://example.invalid/v1",
+            "matrix": "Enterprise",
+            "industry": "Finance",
+            "company_size": "Large",
+            # Noise that must not be mirrored:
+            "run_id": "abc",
+            "feedback": {"score": 1},
+        }
+    )
+
+    sync_to_query_params()
+
+    assert set(fake_query_params) == {"p", "m", "b", "x", "i", "s"}
+    assert fake_query_params["p"] == "OpenAI API"
+    assert fake_query_params["m"] == "gpt-5.5"
+
+
+def test_sync_never_writes_api_key_to_url(fake_session_state, fake_query_params) -> None:
+    """Security invariant: secrets must never reach the URL/history/logs."""
+    fake_session_state.update(
+        {
+            "chosen_model_provider": "OpenAI API",
+            "llm_model_name": "gpt-5.5",
+            "llm_api_key": "sk-super-secret",
+        }
+    )
+
+    sync_to_query_params()
+
+    assert "sk-super-secret" not in fake_query_params.values()
+    assert "llm_api_key" not in fake_query_params
+
+
+def test_sync_skips_falsy_values(fake_session_state, fake_query_params) -> None:
+    fake_session_state.update(
+        {"chosen_model_provider": "OpenAI API", "industry": "", "company_size": None}
+    )
+
+    sync_to_query_params()
+
+    assert "p" in fake_query_params
+    assert "i" not in fake_query_params
+    assert "s" not in fake_query_params


### PR DESCRIPTION
## Summary

Fills the highest-value coverage gaps surfaced by a test-suite audit. The existing 35-test suite was high quality but breadth-limited, so this **adds** tests for risky untested logic rather than reworking what exists. **67 passed (was 35).**

## What's covered (high-confidence findings)

| Area | What's now pinned |
|---|---|
| **`stream_filter_thinking`** (`core/response.py`) | The stateful streaming filter that strips `<think>…</think>` across chunk boundaries — runs on *every* streamed scenario and chat reply, previously untested while its whole-string sibling was well covered. Cases: tag split across chunks, multiple blocks, stray `<`, unterminated block. |
| **`atlas_parser`** | `ATLASData` indexing (skips objects with no ATLAS id), kill-chain tactic ordering, subtechnique filtering, name-lookup fallbacks, and the three-way tactic-name resolution + step-dropping in `get_techniques_from_case_study_procedure`. Driven from a small in-memory STIX fixture. |
| **`core/state.py`** | Query-param restore validation (drops unknown provider/invalid matrix), session-wins-over-URL precedence, and the **security invariant that API keys never reach the URL**. |
| **`core/models.py`** | Registry-integrity invariants: every model's `provider_key` exists in `PROVIDERS`, Custom carries no static models, `(provider, model)` pairs are unique. |
| **`core/ai_uplift.py`** | The AI-enhanced toggle's prompt/tag injection on/off branches and per-page namespacing. |

## Scope notes

Medium-confidence and borderline findings from the audit (extra `_build_litellm_kwargs` provider cases, scenario-page error branches, and a partly-redundant existing test) were intentionally left out of this PR.

## Test plan

- `pytest -q` → **67 passed**
- New tests use only in-memory fixtures (temp STIX file, dict-backed `session_state`/`query_params`); no network or live LLM calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)