### PR TITLE
fix: GPT-5.x temperature bug + refresh model registry (v0.13.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ If you find AttackGen useful, please consider starring the repository on GitHub.
 
 ## Releases
 
+### v0.13.1
+| What's new? | Why is it useful? |
+| ----------- | ----------------- |
+| Fix: OpenAI GPT-5.x scenario generation | - Correct Reasoning-Model Handling: OpenAI's GPT-5.x reasoning models reject any sampling `temperature` other than their default, so every GPT-5.x generation was failing with `BadRequestError: 'temperature' does not support 0.7 with this model`. AttackGen no longer sends a custom temperature to these models, while other providers keep the configured value. |
+| Model registry refresh | - Latest Models: Refreshed the model list against each provider's current docs — **OpenAI GPT-5.6** (Sol / Terra / Luna tiers), **Claude Fable 5** and **Claude Sonnet 5**, with one prior generation kept per provider for continuity.<br><br>- Removed Stale Entries: Dropped models that providers have superseded or are retiring — notably Groq's `qwen3-32b` (shut down 17 Jul 2026) and Mistral's Magistral Medium — so the sidebar can't offer a model that errors on selection.<br><br>- Added a fast/cheap Groq tier (`llama-3.1-8b-instant`). |
+
 ### v0.13
 | What's new? | Why is it useful? |
 | ----------- | ----------------- |

--- a/core/llm.py
+++ b/core/llm.py
@@ -78,13 +78,21 @@ def _build_litellm_kwargs(config: LLMConfig) -> dict:
     prefix = get_litellm_prefix(config.provider)
     model = prefix + config.model_name
 
+    # OpenAI reasoning models (gpt-5.x) use max_completion_tokens instead of
+    # max_tokens, and reject any temperature other than the default (1) — sending
+    # temperature=0.7 to them is a 400 BadRequest. Detect once; drive both below.
+    is_openai_reasoning = model_uses_completion_tokens(config.provider, config.model_name)
+
     kwargs: dict = {
         "model": model,
-        "temperature": config.temperature,
         # Retry transient errors (429s, timeouts, 5xx). LiteLLM defers to the
         # provider SDK, which uses exponential backoff and respects Retry-After.
         "num_retries": 3,
     }
+
+    # Only send temperature to models that accept a custom value.
+    if not is_openai_reasoning:
+        kwargs["temperature"] = config.temperature
 
     if config.api_key:
         kwargs["api_key"] = config.api_key
@@ -92,8 +100,7 @@ def _build_litellm_kwargs(config: LLMConfig) -> dict:
     if config.api_base:
         kwargs["api_base"] = config.api_base
 
-    # OpenAI reasoning models (gpt-5.x) use max_completion_tokens
-    if model_uses_completion_tokens(config.provider, config.model_name):
+    if is_openai_reasoning:
         if config.max_tokens:
             kwargs["max_completion_tokens"] = config.max_tokens
     elif config.provider == "Anthropic API":

--- a/core/models.py
+++ b/core/models.py
@@ -1,11 +1,11 @@
 """Unified model registry — single source of truth for providers and models.
 
 To add or update a model, edit the MODELS list below. Nothing else needs to change.
-Mirrored from mrwadams/stride-gpt:stride_gpt/models.py (reviewed 2026-05-30).
+Model list last refreshed against provider docs 2026-07-14.
 
 Provider model listing pages:
   - Anthropic: https://docs.anthropic.com/en/docs/about-claude/models
-  - OpenAI:    https://platform.openai.com/docs/models
+  - OpenAI:    https://developers.openai.com/api/docs/models
   - Google AI: https://ai.google.dev/gemini-api/docs/models
   - Mistral:   https://docs.mistral.ai/getting-started/models
   - Groq:      https://console.groq.com/docs/models
@@ -94,73 +94,74 @@ PROVIDERS: dict[str, ProviderInfo] = {
 # ---------------------------------------------------------------------------
 
 MODELS: list[ModelInfo] = [
-    # --- OpenAI ---
+    # --- OpenAI (all gpt-5.x are reasoning models: max_completion_tokens, and
+    #     they reject any temperature other than the default — see core/llm.py) ---
+    ModelInfo(
+        model_id="gpt-5.6-sol",
+        provider_key="OpenAI API",
+        uses_max_completion_tokens=True,
+        help_text="GPT-5.6 Sol is OpenAI's flagship frontier reasoning model for complex work.",
+    ),
+    ModelInfo(
+        model_id="gpt-5.6-terra",
+        provider_key="OpenAI API",
+        uses_max_completion_tokens=True,
+        help_text="GPT-5.6 Terra balances intelligence and cost for everyday work.",
+    ),
+    ModelInfo(
+        model_id="gpt-5.6-luna",
+        provider_key="OpenAI API",
+        uses_max_completion_tokens=True,
+        help_text="GPT-5.6 Luna is the fast, cost-efficient option for high-volume workloads.",
+    ),
     ModelInfo(
         model_id="gpt-5.5",
         provider_key="OpenAI API",
         uses_max_completion_tokens=True,
-        help_text="GPT-5.5 is OpenAI's latest flagship model.",
-    ),
-    ModelInfo(
-        model_id="gpt-5.4",
-        provider_key="OpenAI API",
-        uses_max_completion_tokens=True,
-        help_text="GPT-5.4 is OpenAI's previous flagship model with 1M+ context.",
-    ),
-    ModelInfo(
-        model_id="gpt-5.4-pro",
-        provider_key="OpenAI API",
-        uses_max_completion_tokens=True,
-        help_text="GPT-5.4 Pro produces smarter, more precise responses.",
-    ),
-    ModelInfo(
-        model_id="gpt-5.4-mini",
-        provider_key="OpenAI API",
-        uses_max_completion_tokens=True,
-        help_text="GPT-5.4 Mini is a fast, cost-efficient version.",
-    ),
-    ModelInfo(
-        model_id="gpt-5.4-nano",
-        provider_key="OpenAI API",
-        uses_max_completion_tokens=True,
-        help_text="GPT-5.4 Nano is the fastest and most affordable option.",
+        help_text="GPT-5.5 is OpenAI's previous-generation flagship model.",
     ),
     # --- Anthropic ---
     ModelInfo(
-        model_id="claude-sonnet-4-6",
+        model_id="claude-fable-5",
         provider_key="Anthropic API",
         supports_thinking=True,
-        help_text="Claude Sonnet 4.6 offers the best balance of performance and efficiency.",
+        help_text="Claude Fable 5 is Anthropic's most capable model for long-running agents and hard reasoning.",
     ),
     ModelInfo(
         model_id="claude-opus-4-8",
         provider_key="Anthropic API",
         supports_thinking=True,
-        help_text="Claude Opus 4.8 is the most capable Claude model.",
+        help_text="Claude Opus 4.8 excels at complex agentic coding and enterprise work.",
+    ),
+    ModelInfo(
+        model_id="claude-sonnet-5",
+        provider_key="Anthropic API",
+        supports_thinking=True,
+        help_text="Claude Sonnet 5 offers the best balance of speed and near-Opus intelligence.",
     ),
     ModelInfo(
         model_id="claude-opus-4-7",
         provider_key="Anthropic API",
         supports_thinking=True,
-        help_text="Claude Opus 4.7 is the previous-generation Opus.",
+        help_text="Claude Opus 4.7 is the previous-generation Opus, kept for continuity.",
     ),
     ModelInfo(
         model_id="claude-haiku-4-5-20251001",
         provider_key="Anthropic API",
         help_text="Claude Haiku 4.5 is the fastest and most cost-effective Claude model.",
     ),
-    # --- Google AI ---
+    # --- Google AI (all Gemini 3.x support extended thinking) ---
     ModelInfo(
         model_id="gemini-3.1-pro-preview",
         provider_key="Google AI API",
         supports_thinking=True,
-        help_text="Gemini 3.1 Pro is Google's most capable model with 1M context.",
+        help_text="Gemini 3.1 Pro is Google's highest-reasoning model with 1M context.",
     ),
     ModelInfo(
         model_id="gemini-3.5-flash",
         provider_key="Google AI API",
         supports_thinking=True,
-        help_text="Gemini 3.5 Flash is Google's latest fast model with 1M context.",
+        help_text="Gemini 3.5 Flash is Google's GA flagship fast model with 1M context.",
     ),
     ModelInfo(
         model_id="gemini-3.1-flash-lite",
@@ -168,48 +169,32 @@ MODELS: list[ModelInfo] = [
         supports_thinking=True,
         help_text="Gemini 3.1 Flash Lite is the most cost-efficient option with 1M context.",
     ),
-    ModelInfo(
-        model_id="gemini-3-flash-preview",
-        provider_key="Google AI API",
-        supports_thinking=True,
-        help_text="Gemini 3 Flash is optimized for speed with 1M context.",
-    ),
     # --- Mistral ---
     ModelInfo(
         model_id="mistral-large-2512",
         provider_key="Mistral API",
-        help_text="Mistral Large 3 offers premium capabilities.",
-    ),
-    ModelInfo(
-        model_id="mistral-small-2603",
-        provider_key="Mistral API",
-        help_text="Mistral Small 4 merges reasoning, vision, and coding in a 256k-context model.",
+        help_text="Mistral Large 3 offers premium, general-purpose capabilities.",
     ),
     ModelInfo(
         model_id="mistral-medium-3-5",
         provider_key="Mistral API",
-        help_text="Mistral Medium 3.5 provides balanced performance.",
+        help_text="Mistral Medium 3.5 is a frontier-class model tuned for agentic and coding use.",
     ),
     ModelInfo(
-        model_id="mistral-medium-2508",
+        model_id="mistral-small-2603",
         provider_key="Mistral API",
-        help_text="Mistral Medium 3.1 provides balanced performance.",
-    ),
-    ModelInfo(
-        model_id="magistral-medium-2509",
-        provider_key="Mistral API",
-        help_text="Magistral Medium is a reasoning-focused model.",
+        help_text="Mistral Small 4 unifies instruct, reasoning, and coding in an efficient model.",
     ),
     # --- Groq ---
     ModelInfo(
         model_id="openai/gpt-oss-120b",
         provider_key="Groq API",
-        help_text="GPT-OSS 120B is an open-source reasoning model on Groq.",
+        help_text="GPT-OSS 120B is an open-weight reasoning model on Groq.",
     ),
     ModelInfo(
         model_id="openai/gpt-oss-20b",
         provider_key="Groq API",
-        help_text="GPT-OSS 20B is a fast open-source model on Groq.",
+        help_text="GPT-OSS 20B is a fast open-weight model on Groq.",
     ),
     ModelInfo(
         model_id="llama-3.3-70b-versatile",
@@ -217,9 +202,9 @@ MODELS: list[ModelInfo] = [
         help_text="Llama 3.3 70B excels at general-purpose tasks.",
     ),
     ModelInfo(
-        model_id="qwen/qwen3-32b",
+        model_id="llama-3.1-8b-instant",
         provider_key="Groq API",
-        help_text="Qwen3 32B delivers balanced performance.",
+        help_text="Llama 3.1 8B is Groq's fastest, most cost-efficient tier.",
     ),
     # --- Custom: no static list; the user types the model name in the sidebar ---
 ]

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -52,7 +52,7 @@ def test_openai_reasoning_model_omits_temperature() -> None:
 def test_non_reasoning_models_still_send_temperature() -> None:
     config = LLMConfig(
         provider="Anthropic API",
-        model_name="claude-sonnet-4-6",
+        model_name="claude-sonnet-5",
         api_key="k",
         temperature=0.7,
     )
@@ -62,17 +62,17 @@ def test_non_reasoning_models_still_send_temperature() -> None:
 
 def test_anthropic_defaults_max_tokens_to_16000_when_unset() -> None:
     config = LLMConfig(
-        provider="Anthropic API", model_name="claude-sonnet-4-6", api_key="k"
+        provider="Anthropic API", model_name="claude-sonnet-5", api_key="k"
     )
     kwargs = _build_litellm_kwargs(config)
     assert kwargs["max_tokens"] == 16000
-    assert kwargs["model"] == "anthropic/claude-sonnet-4-6"
+    assert kwargs["model"] == "anthropic/claude-sonnet-5"
 
 
 def test_anthropic_respects_explicit_max_tokens() -> None:
     config = LLMConfig(
         provider="Anthropic API",
-        model_name="claude-sonnet-4-6",
+        model_name="claude-sonnet-5",
         api_key="k",
         max_tokens=8000,
     )
@@ -143,7 +143,7 @@ def test_call_llm_passes_built_kwargs_to_litellm(
     disable_langsmith, mock_litellm_completion
 ) -> None:
     config = LLMConfig(
-        provider="Anthropic API", model_name="claude-sonnet-4-6", api_key="k"
+        provider="Anthropic API", model_name="claude-sonnet-5", api_key="k"
     )
     messages = [{"role": "user", "content": "hi"}]
 
@@ -151,7 +151,7 @@ def test_call_llm_passes_built_kwargs_to_litellm(
 
     _args, kwargs = mock_litellm_completion.calls[0]
     assert kwargs["messages"] == messages
-    assert kwargs["model"] == "anthropic/claude-sonnet-4-6"
+    assert kwargs["model"] == "anthropic/claude-sonnet-5"
     assert kwargs["max_tokens"] == 16000
     assert kwargs["api_key"] == "k"
     assert kwargs["num_retries"] == 3

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -39,6 +39,27 @@ def test_openai_reasoning_model_without_max_tokens_omits_completion_tokens() -> 
     assert "max_tokens" not in kwargs
 
 
+def test_openai_reasoning_model_omits_temperature() -> None:
+    """gpt-5.x reject any temperature but the default (1), so we must not send
+    one — otherwise litellm raises BadRequestError (regression: v0.13)."""
+    config = LLMConfig(
+        provider="OpenAI API", model_name="gpt-5.5", api_key="k", temperature=0.7
+    )
+    kwargs = _build_litellm_kwargs(config)
+    assert "temperature" not in kwargs
+
+
+def test_non_reasoning_models_still_send_temperature() -> None:
+    config = LLMConfig(
+        provider="Anthropic API",
+        model_name="claude-sonnet-4-6",
+        api_key="k",
+        temperature=0.7,
+    )
+    kwargs = _build_litellm_kwargs(config)
+    assert kwargs["temperature"] == 0.7
+
+
 def test_anthropic_defaults_max_tokens_to_16000_when_unset() -> None:
     config = LLMConfig(
         provider="Anthropic API", model_name="claude-sonnet-4-6", api_key="k"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -19,7 +19,7 @@ def test_from_session_state_reads_populated_keys(fake_session_state) -> None:
     fake_session_state.update(
         {
             "chosen_model_provider": "Anthropic API",
-            "llm_model_name": "claude-sonnet-4-6",
+            "llm_model_name": "claude-sonnet-5",
             "llm_api_key": "sk-test",
             "llm_api_base": "https://example.invalid/v1",
         }
@@ -28,7 +28,7 @@ def test_from_session_state_reads_populated_keys(fake_session_state) -> None:
     config = LLMConfig.from_session_state()
 
     assert config.provider == "Anthropic API"
-    assert config.model_name == "claude-sonnet-4-6"
+    assert config.model_name == "claude-sonnet-5"
     assert config.api_key == "sk-test"
     assert config.api_base == "https://example.invalid/v1"
 


### PR DESCRIPTION
Patch release **v0.13.1** — a correctness fix and a model-registry refresh.

## 🐛 Fix: GPT-5.x scenario generation

OpenAI's GPT-5.x reasoning models reject any `temperature` other than their default (1), so AttackGen's fixed `0.7` made **every GPT-5.x generation fail**:

```
litellm.BadRequestError: Unsupported value: 'temperature' does not support 0.7
with this model. Only the default (1) value is supported.
```

`core/llm.py` now omits `temperature` for models flagged `uses_max_completion_tokens` (the GPT-5.x reasoning family — the same models that already swap `max_tokens` for `max_completion_tokens`). Other providers still receive the configured value. Regression test added.

## 🔄 Model registry refresh (researched against provider docs, 2026-07-14)

| Provider | Change |
|---|---|
| **OpenAI** | + GPT-5.6 family (`gpt-5.6-sol` / `-terra` / `-luna` — the `-pro/-mini/-nano` suffixes were dropped for named tiers at 5.6); keep `gpt-5.5` (one prior gen); drop the 5.4 line |
| **Anthropic** | + `claude-fable-5` (new top tier), + `claude-sonnet-5`; keep `claude-opus-4-8` and one prior gen (`claude-opus-4-7`); drop `claude-sonnet-4-6` |
| **Google** | − `gemini-3-flash-preview` (superseded by 3.5 Flash) |
| **Mistral** | − `mistral-medium-2508` (dup of Medium 3.5), − `magistral-medium-2509` (retired 22 May 2026) |
| **Groq** | − `qwen/qwen3-32b` (**Groq shuts it down 17 Jul 2026**), + `llama-3.1-8b-instant` |

All GPT-5.x entries keep `uses_max_completion_tokens=True`; the registry invariant test still holds. Dropping `qwen3-32b` is time-sensitive — leaving it would give users a dropdown entry that 404s within days.

## Tests
Full suite **132 passing**, incl. new temperature-omission coverage. pyflakes clean. Registry sanity-checked (all provider lists resolve; reasoning-flag invariant holds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)