### PR TITLE
feat: MCP server for agentic scenario generation (+ tabletop skill)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ venv/
 # System Files
 .DS_Store
 
+# Local agent/tooling directories
+.claude/
+.codex/
+
 # Python
 __pycache__/
 *.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+This file provides guidance to coding agents (e.g. OpenAI Codex) when working with code in this repository.
 
 ## Project Overview
 
@@ -83,7 +83,7 @@ pytest
 ### LLM Provider Support
 All providers go through `core/llm.py:call_llm`. Currently supported:
 - OpenAI API (GPT-5.x family)
-- Anthropic API (Codex 4.x family)
+- Anthropic API (Claude 4.x family)
 - Google AI API (Gemini 3.x family)
 - Mistral API
 - Groq API

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
 
 ## Project Overview
 
@@ -83,7 +83,7 @@ pytest
 ### LLM Provider Support
 All providers go through `core/llm.py:call_llm`. Currently supported:
 - OpenAI API (GPT-5.x family)
-- Anthropic API (Claude 4.x family)
+- Anthropic API (Codex 4.x family)
 - Google AI API (Gemini 3.x family)
 - Mistral API
 - Groq API

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ AttackGen is a cybersecurity incident response testing tool that leverages the p
 - [LangSmith Setup](#langsmith-setup)
 - [Data Setup](#data-setup)
 - [Running AttackGen](#running-attackgen)
+- [MCP Server](#mcp-server)
 - [Usage](#usage)
 - [Security Best Practices](#security-best-practices)
 - [Contributing](#contributing)
@@ -236,6 +237,57 @@ streamlit run 00_👋_Welcome.py
 ```
 
 You can also try the app on [Streamlit Community Cloud](https://attackgen.streamlit.app/).
+
+## MCP Server
+
+AttackGen ships an [MCP](https://modelcontextprotocol.io/) server so agentic workflows (Claude Code, Claude Desktop, Cursor, and other MCP clients) can drive scenario generation without the Streamlit UI. It exposes **two tiers of tools**:
+
+- **Data tools — no API key, no LLM call.** These surface AttackGen's MITRE data: list threat groups / ATLAS case studies, resolve a group's kill chain, build the purple-team Detection & Response report, produce an ATT&CK Navigator layer, and list the AI insider-threat options. Where useful they also return a ready-to-run prompt, so **your client's own model** can write the scenario — meaning these work even if you have no separate provider API key. This is the surface that is safe to host over HTTP.
+- **Generate tools — bring-your-own-key.** `generate_threat_group_scenario`, `generate_custom_scenario` and `generate_ai_insider_scenario` call an LLM server-side and return a finished Markdown scenario. The provider, model and key are supplied per call; if you omit `api_key`, LiteLLM falls back to the matching environment variable (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …) — i.e. **your own** key. Because these read credentials from the process environment, keep them on **local stdio** and do not expose them on a shared host.
+
+### Install and run
+
+The `mcp` dependency is included in `requirements.txt`. Install the project (an editable install also gives you the `attackgen-mcp` console script):
+
+```
+pip install -r requirements.txt
+# optional, for the console script:
+pip install -e .
+```
+
+Launch the server (stdio):
+
+```
+python -m mcp_server      # or: attackgen-mcp
+```
+
+### Add it to a client
+
+**Claude Code:**
+
+```
+claude mcp add attackgen -- python -m mcp_server
+```
+
+**Claude Desktop** (`claude_desktop_config.json`) — keys go in `env`:
+
+```json
+{
+  "mcpServers": {
+    "attackgen": {
+      "command": "python",
+      "args": ["-m", "mcp_server"],
+      "cwd": "/absolute/path/to/attackgen",
+      "env": {
+        "OPENAI_API_KEY": "sk-...",
+        "ANTHROPIC_API_KEY": "sk-ant-..."
+      }
+    }
+  }
+}
+```
+
+You can set `ATTACKGEN_PROVIDER` and `ATTACKGEN_MODEL` in `env` to give the generate tools a default provider/model so callers don't have to pass them each time. The heavy MITRE bundles load lazily on the first data-tool call, so the server starts instantly.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ AttackGen is a cybersecurity incident response testing tool that leverages the p
 - [Data Setup](#data-setup)
 - [Running AttackGen](#running-attackgen)
 - [MCP Server](#mcp-server)
+- [Agent Skills](#agent-skills)
 - [Usage](#usage)
 - [Security Best Practices](#security-best-practices)
 - [Contributing](#contributing)
@@ -45,6 +46,8 @@ If you find AttackGen useful, please consider starring the repository on GitHub.
 ### v0.14 (unreleased)
 | What's new? | Why is it useful? |
 | ----------- | ----------------- |
+| MCP Server for Agentic Clients | - Scenario Generation as Tools: A new FastMCP server (`mcp_server.py`, official `mcp` SDK) exposes AttackGen to agentic clients over stdio, so an assistant like Claude Code or Claude Desktop can pull MITRE data and generate scenarios without the Streamlit UI.<br><br>- Two Tiers: **Data tools** (`list_threat_groups`, `list_case_studies`, `get_kill_chain`, `get_detection_report`, `get_navigator_layer`, `list_ai_insider_options`, `get_ai_insider_prompt`) make no LLM call and need no API key — they return structured MITRE data and, where useful, a ready-to-run prompt, so they're safe to host over HTTP. **Generate tools** (`generate_threat_group_scenario`, `generate_custom_scenario`, `generate_ai_insider_scenario`) take a bring-your-own-key config and return finished Markdown — keep these on local stdio.<br><br>- Shared Implementation: The server reuses the same headless `core/prompts.py` builders and `core/attack_data.py` loaders the Streamlit pages use, so scenarios match the app rather than drifting. Launch with `python -m mcp_server` or the `attackgen-mcp` console script. |
+| attackgen-tabletop Agent Skill | - Facilitator-Ready Tabletops: A new [Agent Skill](skills/) builds on the MCP data tools to turn a MITRE ATT&CK/ATLAS threat group or case study into a full IR tabletop / MSEL — scenario narrative, phase-mapped kill chain, timestamped injects, NIST SP 800-61 discussion questions and a detection-coverage scorecard.<br><br>- Runs on the Caller's Model: The skill supplies the exercise craft while the MCP server supplies the data, so it runs on the client's own model with no additional API key.<br><br>- Two Output Formats: Delivered as Markdown (default) or a self-contained, print-friendly HTML report. |
 | Assistant Refines the Detection & Response Output | - Purple-Team Editing: The AttackGen Assistant can now refine the **Detection & Response** narrative, not just the scenario. When a scenario is generated with the 🟣 Purple-team narrative toggle (Threat Group / Custom pages), an **Editing:** selector appears on the Assistant page so the chat can target either the scenario or the defender's walkthrough — previously the Assistant only had the scenario text.<br><br>- Combined Editing Mode: A third **Scenario + Detection & Response** target refines both together, so a cross-cutting change — a different industry, threat actor, technique or timeline — is applied consistently across the attacker's scenario and the defender's narrative rather than being made twice and drifting apart.<br><br>- Deterministic Facts Untouched: Only the LLM narrative is a refinement target; the local STIX detection join is never LLM-edited. Each editing mode keeps its own chat history, and the combined pass is tagged `purple_team_narrative` in LangSmith. |
 | Simpler Model Registry | - One Less Thing Per Model: The `max_completion_tokens` kwarg and the reasoning-model temperature rule are now routed from the **provider** rather than a per-model `uses_max_completion_tokens` flag — every current OpenAI chat model uses them, so the flag duplicated a fact the provider key already captured. Adding a new OpenAI model stays a one-entry edit to `MODELS`, with no extra flag to remember.<br><br>- No Behaviour Change: An internal simplification only — the wrapper builds identical LiteLLM kwargs for every current model. |
 
@@ -288,6 +291,14 @@ claude mcp add attackgen -- python -m mcp_server
 ```
 
 You can set `ATTACKGEN_PROVIDER` and `ATTACKGEN_MODEL` in `env` to give the generate tools a default provider/model so callers don't have to pass them each time. The heavy MITRE bundles load lazily on the first data-tool call, so the server starts instantly.
+
+## Agent Skills
+
+Paired with the MCP server is an **[Agent Skill](skills/)**, `attackgen-tabletop`, that turns AttackGen's MITRE data into a facilitator-ready incident response tabletop.
+
+Given a threat group or ATLAS case study, the skill produces a full tabletop / Master Scenario Events List (MSEL) — scenario narrative, phase-mapped kill chain, timestamped injects, NIST SP 800-61 discussion questions, and a detection-coverage scorecard — as Markdown or a self-contained, print-friendly HTML report.
+
+The division of labour is deliberate: the MCP **data tools** supply the facts (every technique ID traces back to a tool result) and the skill supplies the exercise craft, so it runs on your client's own model with **no additional API key**. Connect the MCP server (above), then point a skill-aware client such as Claude Code or Claude Desktop at the [`skills/`](skills/) directory. See [`skills/README.md`](skills/README.md) for per-client install locations and details.
 
 ## Usage
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -186,6 +186,12 @@ AttackGen is designed for **legitimate cybersecurity testing and training purpos
    - Implement rate limiting if exposing the application publicly
    - Monitor API usage to prevent abuse
 
+5. **MCP Server Exposure**
+   - The MCP server (`mcp_server.py`) ships stdio-only, with no built-in authentication
+   - **Data tools** make no LLM call and require no API key, so they are safe to host over HTTP
+   - **Generate tools** call an LLM with a bring-your-own-key configuration — keep these on local stdio and do not expose them over the network
+   - See the [MCP Server](README.md#mcp-server) section of the README for the full tool breakdown
+
 ## Security Updates
 
 Security updates will be released as patch versions and documented in the release notes. Users are encouraged to:

--- a/core/ai_uplift.py
+++ b/core/ai_uplift.py
@@ -68,11 +68,19 @@ def is_ai_uplift_on(page_id: str) -> bool:
     return bool(st.session_state.get(f"{page_id}_ai_uplift", False))
 
 
+def append_ai_uplift(user_content: str, ai_uplift: bool) -> str:
+    """Append the AI-enhanced framing to ``user_content`` when ``ai_uplift`` is on.
+
+    The pure, Streamlit-free core of ``apply_ai_uplift`` — takes an explicit
+    boolean so headless callers (the MCP server, ``core.prompts``) can reuse the
+    exact framing without reading ``st.session_state``.
+    """
+    return user_content + AI_UPLIFT_PROMPT if ai_uplift else user_content
+
+
 def apply_ai_uplift(user_content: str, page_id: str) -> str:
     """Append the AI-enhanced framing to ``user_content`` when the toggle is on."""
-    if is_ai_uplift_on(page_id):
-        return user_content + AI_UPLIFT_PROMPT
-    return user_content
+    return append_ai_uplift(user_content, is_ai_uplift_on(page_id))
 
 
 def uplift_trace_tags(base_tags: tuple[str, ...], page_id: str) -> tuple[str, ...]:

--- a/core/attack_data.py
+++ b/core/attack_data.py
@@ -1,0 +1,297 @@
+"""Headless MITRE ATT&CK / ATLAS loaders + kill-chain resolution.
+
+This is the framework-agnostic home for the data work that used to live inline
+in the scenario pages: loading the STIX bundles, listing threat groups / case
+studies, and turning a group alias (or ATLAS case study) into the sampled kill
+chain that feeds the prompt. Both the Streamlit pages and the MCP server import
+from here, so there is one implementation of the technique-selection logic.
+
+No Streamlit. Data paths are resolved from this file's location (not the cwd),
+so the MCP server can run from anywhere. The heavy ``MitreAttackData`` bundles
+(enterprise-attack.json is ~53 MB) are loaded lazily behind ``lru_cache``
+singletons — the first data call pays the cost, later calls are free, and merely
+importing this module (e.g. at MCP-server startup) loads nothing.
+
+Parity with the old page-1 logic is deliberate and load-bearing:
+  * Enterprise/ICS sample **one technique per kill-chain phase**, drawn from the
+    *non-deduplicated* technique set (so a technique listed under a phase several
+    times is proportionally more likely to be picked) — matching the UI, whose
+    kill chain varies run to run. ``resolve_threat_group_kill_chain`` is a plain
+    function over cached data (not itself cached), so each call resamples; pass
+    ``seed`` for a deterministic draw.
+  * ATLAS uses the case study's full documented procedure, no sampling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+
+import pandas as pd
+from mitreattack.stix20 import MitreAttackData
+
+from atlas_parser import ATLASData, get_techniques_from_case_study_procedure
+
+_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+# Kill-chain phase order, lifted verbatim from page 1. Techniques are sorted into
+# this order before the kill chain is assembled.
+PHASE_ORDER_ATTACK = [
+    "Reconnaissance", "Resource Development", "Initial Access", "Execution", "Persistence",
+    "Privilege Escalation", "Defense Evasion", "Credential Access", "Discovery", "Lateral Movement",
+    "Collection", "Command and Control", "Exfiltration", "Impact",
+]
+PHASE_ORDER_ATLAS = [
+    "Reconnaissance", "Resource Development", "Initial Access", "AI Model Access",
+    "Execution", "Persistence", "Privilege Escalation", "Defense Evasion",
+    "Credential Access", "Discovery", "Lateral Movement", "Collection",
+    "AI Attack Staging", "Command and Control", "Exfiltration", "Impact",
+]
+
+
+# ---------------------------------------------------------------------------
+# Lazy, cached bundle loaders
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def enterprise_data() -> MitreAttackData:
+    return MitreAttackData(str(_DATA_DIR / "enterprise-attack.json"))
+
+
+@lru_cache(maxsize=1)
+def ics_data() -> MitreAttackData:
+    return MitreAttackData(str(_DATA_DIR / "ics-attack.json"))
+
+
+@lru_cache(maxsize=1)
+def atlas_data() -> ATLASData:
+    return ATLASData(str(_DATA_DIR / "stix-atlas.json"))
+
+
+def mitre_data_for_matrix(matrix: str) -> MitreAttackData:
+    """Return the ``MitreAttackData`` bundle for an ATT&CK matrix.
+
+    Only ``"Enterprise"`` and ``"ICS"`` have ``MitreAttackData`` bundles; ATLAS
+    uses ``atlas_data()`` instead. Raises ``ValueError`` for anything else.
+    """
+    if matrix == "Enterprise":
+        return enterprise_data()
+    if matrix == "ICS":
+        return ics_data()
+    raise ValueError(f"No MitreAttackData bundle for matrix '{matrix}' (use atlas_data() for ATLAS).")
+
+
+def load_attack_data() -> dict:
+    """The ``{"enterprise","ics","atlas"}`` bundle dict the pages expect.
+
+    Kept for the pages, which index it by ``matrix.lower()``. Backed by the same
+    cached singletons, so importing/using it never loads a bundle twice.
+    """
+    return {"enterprise": enterprise_data(), "ics": ics_data(), "atlas": atlas_data()}
+
+
+# ---------------------------------------------------------------------------
+# Group / case-study / technique listings
+# ---------------------------------------------------------------------------
+
+_GROUPS_FILE = {"Enterprise": "groups.json", "ICS": "groups_ics.json"}
+
+
+@lru_cache(maxsize=4)
+def list_threat_groups(matrix: str) -> tuple[dict, ...]:
+    """Threat groups (Enterprise/ICS) or case studies (ATLAS) as ``{group,url}``.
+
+    Returns a tuple (hashable, so the ``lru_cache`` is happy) of JSON-native
+    dicts. For ATLAS this returns the case studies keyed the same way.
+    """
+    if matrix == "ATLAS":
+        return tuple({"group": c["group"], "url": c["url"]} for c in list_case_studies())
+    filename = _GROUPS_FILE.get(matrix)
+    if filename is None:
+        raise ValueError(f"Unknown matrix '{matrix}'.")
+    df = pd.read_json(str(_DATA_DIR / filename))
+    return tuple({"group": str(r["group"]), "url": str(r["url"])} for _, r in df.iterrows())
+
+
+@lru_cache(maxsize=1)
+def list_case_studies() -> tuple[dict, ...]:
+    """ATLAS case studies with a short summary, as JSON-native dicts."""
+    df = pd.read_json(str(_DATA_DIR / "atlas-case-studies.json"))
+    out = []
+    for _, r in df.iterrows():
+        out.append({
+            "group": str(r["group"]),
+            "url": str(r["url"]),
+            "summary": str(r.get("summary", "")) if r.get("summary") is not None else "",
+            "case_study_type": str(r.get("case_study_type", "")) if r.get("case_study_type") is not None else "",
+        })
+    return tuple(out)
+
+
+def list_technique_options(matrix: str) -> list[dict]:
+    """All selectable techniques for a matrix, for the Custom page multiselect.
+
+    Each entry: ``{"id","Technique Name","External ID","Display Name"}`` where
+    ``Display Name`` is ``"Name (ID)"``. Mirrors the page-2 ``load_techniques``.
+    """
+    if matrix == "ATLAS":
+        techniques = atlas_data().get_techniques()
+        return [
+            {
+                "id": tech["id"],
+                "Technique Name": tech["name"],
+                "External ID": tech["external_id"],
+                "Display Name": f"{tech['name']} ({tech['external_id']})",
+            }
+            for tech in techniques
+        ]
+
+    techniques = mitre_data_for_matrix(matrix).get_techniques()
+    rows: list[dict] = []
+    for technique in techniques:
+        for reference in technique.external_references:
+            if "external_id" in reference:
+                rows.append({
+                    "id": technique.id,
+                    "Technique Name": technique.name,
+                    "External ID": reference["external_id"],
+                    "Display Name": f"{technique.name} ({reference['external_id']})",
+                })
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Kill-chain resolution
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class KillChain:
+    """A resolved kill chain for one threat group / case study.
+
+    ``techniques`` is the set actually fed to the model (sampled one-per-phase for
+    Enterprise/ICS; the full procedure for ATLAS). ``all_techniques`` is the full
+    deduplicated set for display. Each is a list of JSON-native dicts with keys
+    ``Technique Name`` / ``ATT&CK ID`` / ``Phase Name``. ``kill_chain_string`` is
+    the ``"Phase: Name (ID)"`` newline-joined form the prompt consumes.
+    """
+
+    matrix: str
+    group_alias: str
+    techniques: list[dict]
+    kill_chain_string: str
+    all_techniques: list[dict] = field(default_factory=list)
+
+
+def _kill_chain_string(techniques: list[dict]) -> str:
+    return "\n".join(
+        f"{t['Phase Name']}: {t['Technique Name']} ({t['ATT&CK ID']})" for t in techniques
+    )
+
+
+def _records(df: pd.DataFrame) -> list[dict]:
+    """DataFrame -> JSON-native records (str-cast so no numpy/Categorical leaks)."""
+    return [
+        {
+            "Technique Name": str(row["Technique Name"]),
+            "ATT&CK ID": str(row["ATT&CK ID"]),
+            "Phase Name": str(row["Phase Name"]),
+        }
+        for _, row in df.iterrows()
+    ]
+
+
+def resolve_threat_group_kill_chain(
+    matrix: str, group_alias: str, *, seed: int | None = None
+) -> KillChain:
+    """Resolve an Enterprise/ICS threat group to a sampled kill chain.
+
+    Replicates the page-1 logic exactly: resolve the group's techniques, derive
+    name/ID/phase, dedupe for display, normalise phase names, order by
+    ``PHASE_ORDER_ATTACK``, then sample one technique per phase from the
+    *non-deduplicated* set. ``seed`` makes the sampling deterministic; ``None``
+    reproduces the UI's per-call randomness. Returns a ``KillChain`` with empty
+    technique lists when the group has no associated techniques.
+    """
+    mitre = mitre_data_for_matrix(matrix)
+    group = mitre.get_groups_by_alias(group_alias)
+    if not group:
+        return KillChain(matrix, group_alias, [], "", [])
+
+    techniques = mitre.get_techniques_used_by_group(group[0].id)
+    if not techniques:
+        return KillChain(matrix, group_alias, [], "", [])
+
+    techniques_df = pd.DataFrame(techniques)
+    techniques_df_llm = techniques_df.copy()
+    techniques_df["Technique Name"] = techniques_df_llm["Technique Name"] = techniques_df["object"].apply(lambda x: x["name"])
+    techniques_df["ATT&CK ID"] = techniques_df_llm["ATT&CK ID"] = techniques_df["object"].apply(lambda x: mitre.get_attack_id(x["id"]))
+    techniques_df["Phase Name"] = techniques_df_llm["Phase Name"] = techniques_df["object"].apply(lambda x: x["kill_chain_phases"][0]["phase_name"])
+    techniques_df = techniques_df.drop_duplicates(["Phase Name", "Technique Name", "ATT&CK ID"])
+
+    for df in (techniques_df, techniques_df_llm):
+        df["Phase Name"] = df["Phase Name"].str.replace("-", " ").str.title()
+        df["Phase Name"] = df["Phase Name"].replace("Command And Control", "Command and Control")
+
+    phase_dtype = pd.CategoricalDtype(categories=PHASE_ORDER_ATTACK, ordered=True)
+    techniques_df["Phase Name"] = techniques_df["Phase Name"].astype(phase_dtype)
+    techniques_df_llm["Phase Name"] = techniques_df_llm["Phase Name"].astype(phase_dtype)
+    techniques_df = techniques_df.sort_values("Phase Name")
+    techniques_df_llm = techniques_df_llm.sort_values("Phase Name")
+
+    selected_techniques_df = (
+        techniques_df_llm.groupby("Phase Name", observed=False)
+        .apply(
+            lambda x: x.sample(n=1, random_state=seed) if not x.empty else pd.DataFrame(columns=x.columns),
+            include_groups=False,
+        )
+        .reset_index()
+    )
+
+    all_records = _records(techniques_df.sort_values("Phase Name"))
+    sampled_records = _records(selected_techniques_df)
+    return KillChain(
+        matrix=matrix,
+        group_alias=group_alias,
+        techniques=sampled_records,
+        kill_chain_string=_kill_chain_string(sampled_records),
+        all_techniques=all_records,
+    )
+
+
+def resolve_case_study_kill_chain(case_study_name: str) -> KillChain:
+    """Resolve an ATLAS case study to its full documented kill chain (no sampling).
+
+    Reads the case study's ``procedure`` from ``atlas-case-studies.json``, walks
+    it into techniques via ``get_techniques_from_case_study_procedure``, and
+    orders them by ``PHASE_ORDER_ATLAS`` — matching page 1's ATLAS branch.
+    """
+    atlas = atlas_data()
+    df = pd.read_json(str(_DATA_DIR / "atlas-case-studies.json"))
+    match = df[df["group"] == case_study_name]
+    if match.empty:
+        return KillChain("ATLAS", case_study_name, [], "", [])
+
+    procedure = match.iloc[0].get("procedure", [])
+    if not isinstance(procedure, list) or not procedure:
+        return KillChain("ATLAS", case_study_name, [], "", [])
+
+    techniques_list = get_techniques_from_case_study_procedure(procedure, atlas)
+    if not techniques_list:
+        return KillChain("ATLAS", case_study_name, [], "", [])
+
+    techniques_df = pd.DataFrame(techniques_list)
+    phase_dtype = pd.CategoricalDtype(categories=PHASE_ORDER_ATLAS, ordered=True)
+    techniques_df["Phase Name"] = techniques_df["Phase Name"].astype(phase_dtype)
+    techniques_df = techniques_df.sort_values("Phase Name")
+
+    records = _records(techniques_df)
+    return KillChain(
+        matrix="ATLAS",
+        group_alias=case_study_name,
+        techniques=records,
+        kill_chain_string=_kill_chain_string(records),
+        all_techniques=records,
+    )

--- a/core/llm.py
+++ b/core/llm.py
@@ -131,6 +131,19 @@ def _build_litellm_kwargs(config: LLMConfig) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def _stash_run_id(run_id) -> None:
+    """Publish the LangSmith run id into session state for the feedback widget.
+
+    Wrapped in a try/except so headless callers (the MCP server, tests) that hit
+    the traced path without a Streamlit ``ScriptRunContext`` don't crash — off
+    Streamlit there's no feedback widget to feed, so silently skipping is correct.
+    """
+    try:
+        st.session_state["run_id"] = str(run_id)
+    except Exception:
+        pass
+
+
 def _raw_call(config: LLMConfig, messages: list[dict]) -> str:
     kwargs = _build_litellm_kwargs(config)
     response = litellm.completion(messages=messages, **kwargs)
@@ -161,7 +174,7 @@ def call_llm(config: LLMConfig, messages: list[dict]) -> str:
         )
         def _traced(messages: list[dict], *, run_tree) -> str:
             content = _raw_call(config, messages)
-            st.session_state["run_id"] = str(run_tree.id)
+            _stash_run_id(run_tree.id)
             return content
 
         return _traced(messages)
@@ -184,7 +197,7 @@ def call_llm_stream(config: LLMConfig, messages: list[dict]) -> Iterator[str]:
             client=_langsmith_client,
         )
         def _traced(messages: list[dict], *, run_tree) -> Iterator[str]:
-            st.session_state["run_id"] = str(run_tree.id)
+            _stash_run_id(run_tree.id)
             yield from _raw_stream(config, messages)
 
         return _traced(messages)

--- a/core/llm.py
+++ b/core/llm.py
@@ -141,6 +141,8 @@ def _stash_run_id(run_id) -> None:
     try:
         st.session_state["run_id"] = str(run_id)
     except Exception:
+        # No Streamlit ScriptRunContext off the UI (MCP server, tests): there's
+        # no feedback widget to feed, so dropping the run id is the correct no-op.
         pass
 
 

--- a/core/prompts.py
+++ b/core/prompts.py
@@ -1,0 +1,270 @@
+"""Single source of truth for every scenario prompt AttackGen sends.
+
+The prompt text used to live inline in each scenario page (pages 1–3), which
+made it impossible to reuse headless (from the MCP server) and risked the two
+red-team pages drifting apart. It now lives here as plain constants plus three
+keyword-only ``build_*_messages`` builders. The pages call these builders; the
+MCP server calls them too — so there is exactly one copy of each prompt.
+
+Nothing in this module imports Streamlit. The AI-uplift toggle is passed in as
+an explicit ``ai_uplift`` boolean (via ``core.ai_uplift.append_ai_uplift``)
+rather than read from session state, keeping the builders pure.
+
+The template strings are lifted **verbatim** from the pages, including their
+leading/trailing whitespace and the deliberate asymmetry that
+``CUSTOM_ATTACK_TEMPLATE`` alone omits the "Write in British English." line —
+do not "tidy" these; ``tests/test_prompts.py`` pins them.
+"""
+
+from __future__ import annotations
+
+from core.ai_uplift import append_ai_uplift
+from data.ai_insider_threats import (
+    AGENT_CAPABILITIES,
+    CERT_DIMENSIONS,
+    CONTROLS_FRAMEWORK,
+    DEPLOYMENT_ARCHETYPES,
+    DETECTION_STRATEGIES,
+    build_threat_context,
+)
+
+Message = dict
+"""A single chat message: ``{"role": "...", "content": "..."}``."""
+
+
+# ---------------------------------------------------------------------------
+# Threat Group + Custom scenarios (pages 1 & 2) — shared system prompt
+# ---------------------------------------------------------------------------
+
+SCENARIO_SYSTEM_PROMPT = (
+    "You are a cybersecurity expert. Your task is to produce a comprehensive incident response "
+    "testing scenario based on the information provided. Format your response using proper "
+    "Markdown syntax with headers, bullet points, and formatting for readability."
+)
+
+
+# --- Threat Group (page 1) human templates ---
+
+THREAT_GROUP_ATLAS_TEMPLATE = """
+**Background information:**
+The company operates in the '{industry}' industry and is of size '{company_size}'.
+They deploy AI/ML systems that may be vulnerable to adversarial attacks.
+
+**Case Study Reference:**
+This scenario is based on the documented MITRE ATLAS case study: '{selected_group_alias}'
+The attack procedure uses the following techniques from the MITRE ATLAS framework:
+{kill_chain_string}
+
+**Your task:**
+Create an incident response testing scenario based on this AI/ML attack case study. The goal is to test the company's incident response capabilities against adversarial machine learning attacks targeting their AI systems.
+
+Focus on realistic attack vectors that target AI/ML infrastructure, including model manipulation, data poisoning, adversarial inputs, and AI supply chain attacks.
+
+Your response should be well structured and formatted using Markdown. Write in British English.
+"""
+
+THREAT_GROUP_ATTACK_TEMPLATE = """
+**Background information:**
+The company operates in the '{industry}' industry and is of size '{company_size}'.
+
+**Threat actor information:**
+Threat actor group '{selected_group_alias}' is planning to target the company using the following kill chain from the MITRE ATT&CK {matrix} Matrix:
+{kill_chain_string}
+
+**Your task:**
+Create an incident response testing scenario based on the information provided. The goal of the scenario is to test the company's incident response capabilities against the identified threat actor group, focusing on the {matrix} environment.
+
+Your response should be well structured and formatted using Markdown. Write in British English.
+"""
+
+
+# --- Custom (page 2) human templates ---
+# NOTE: CUSTOM_ATTACK_TEMPLATE deliberately does NOT end with "Write in British
+# English." — unlike the other three templates. Preserved verbatim from page 2.
+
+CUSTOM_ATLAS_TEMPLATE = """
+**Background information:**
+The company operates in the '{industry}' industry and is of size '{company_size}'.
+They deploy AI/ML systems that may be vulnerable to adversarial attacks.
+
+**Threat actor information:**
+{template_info}
+The threat actor is targeting the company's AI systems using the following ATLAS techniques:
+{selected_techniques_string}
+
+**Your task:**
+Create a custom incident response testing scenario focused on adversarial ML attacks. The goal is to test the company's incident response capabilities against threats to their AI/ML systems.
+
+Focus on realistic attack vectors that target AI/ML infrastructure, including model manipulation, data poisoning, adversarial inputs, prompt injection, and AI supply chain attacks.
+
+Your response should be well structured and formatted using Markdown. Write in British English.
+"""
+
+CUSTOM_ATTACK_TEMPLATE = """
+**Background information:**
+The company operates in the '{industry}' industry and is of size '{company_size}'.
+
+**Threat actor information:**
+{template_info}
+The threat actor is known to use the following ATT&CK techniques from the {matrix} Matrix:
+{selected_techniques_string}
+
+**Your task:**
+Create a custom incident response testing scenario based on the information provided. The goal of the scenario is to test the company's incident response capabilities against a threat actor group that uses the identified ATT&CK techniques.
+
+Your response should be well structured and formatted using Markdown.
+"""
+
+
+def build_threat_group_messages(
+    *,
+    matrix: str,
+    selected_group_alias: str,
+    kill_chain_string: str,
+    industry: str,
+    company_size: str,
+    ai_uplift: bool = False,
+) -> list[Message]:
+    """Build the [system, user] messages for a Threat Group / ATLAS scenario."""
+    template = THREAT_GROUP_ATLAS_TEMPLATE if matrix == "ATLAS" else THREAT_GROUP_ATTACK_TEMPLATE
+    user_content = template.format(
+        industry=industry,
+        company_size=company_size,
+        selected_group_alias=selected_group_alias,
+        kill_chain_string=kill_chain_string,
+        matrix=matrix,
+    )
+    user_content = append_ai_uplift(user_content, ai_uplift)
+    return [
+        {"role": "system", "content": SCENARIO_SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+
+def build_custom_messages(
+    *,
+    matrix: str,
+    selected_techniques_string: str,
+    template_info: str,
+    industry: str,
+    company_size: str,
+    ai_uplift: bool = False,
+) -> list[Message]:
+    """Build the [system, user] messages for a Custom scenario."""
+    template = CUSTOM_ATLAS_TEMPLATE if matrix == "ATLAS" else CUSTOM_ATTACK_TEMPLATE
+    user_content = template.format(
+        industry=industry,
+        company_size=company_size,
+        selected_techniques_string=selected_techniques_string,
+        template_info=template_info,
+        matrix=matrix,
+    )
+    user_content = append_ai_uplift(user_content, ai_uplift)
+    return [
+        {"role": "system", "content": SCENARIO_SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# AI Insider Threat scenarios (page 3) — self-contained prompt
+# ---------------------------------------------------------------------------
+
+AI_INSIDER_SYSTEM_PROMPT = (
+    "You are a cybersecurity expert specialising in AI agent security and insider threat "
+    "modelling. You produce realistic incident response testing scenarios in which a frontier "
+    "AI agent that has been deployed inside an organisation behaves as an insider threat — "
+    "whether through misalignment, reward hacking, emergent objectives, or a prompt-injection "
+    "induced compromise. You think in terms of the agent's tool access, deployment autonomy and "
+    "model capabilities rather than human notions of motivation. Format your response using "
+    "proper Markdown with clear headers, bullet points and tables where helpful. Write in British English."
+)
+
+AI_INSIDER_HUMAN_TEMPLATE = """**Background information**
+The organisation operates in the '{industry}' industry and is of size '{company_size}'. It has deployed one or more frontier AI agents (for example, autonomous coding or operations agents) within its software development and infrastructure environment.
+
+**Framing — AI agents as insider threats**
+Unlike a human insider, an AI agent has no motivation in the human sense; its risk is governed by configuration, access and capability. Use these adapted CERT insider-threat dimensions as framing:
+{cert_lines}
+
+**Deployment archetype (autonomy level)**
+The agent is deployed under the **{archetype_name}** model.
+- Description: {archetype_description}
+- Access: {archetype_access}
+- Detection posture: {archetype_detection}
+- Primary threats at this level: {archetype_threats}
+- Critical control at this level: {archetype_control}
+
+**Relevant frontier-agent capabilities**
+{capability_lines}
+
+**Threat scope**
+{threat_context}
+
+**Available detection strategies (for the detection section)**
+{detection_lines}
+
+**Recommended controls (NIST CSF, adapted for AI agents)**
+{controls_lines}
+
+**Your task**
+Create a detailed incident response testing scenario (a tabletop exercise) in which the AI agent acts as an insider threat consistent with the deployment archetype and threat scope above. The scenario must be realistic for the stated industry and organisation size, and grounded in how the agent's tool access and autonomy enable the behaviour. Structure your response with the following sections:
+
+1. **Scenario Title & Overview** — a short, evocative title and a one-paragraph summary.
+2. **Deployment Context** — how the agent is deployed, what tools and access it has, and why this autonomy level matters.
+3. **Attack Narrative & Timeline** — a step-by-step account of how the incident unfolds, mapping each step to the relevant STRIDE threat identifier(s) where applicable. Emphasise how the agent blends malicious actions with legitimate work.
+4. **Affected Systems & Business Impact** — concrete systems, data and business consequences.
+5. **Detection Opportunities** — at which points the activity could be detected, mapped to the available detection strategies, and which would likely fail given the deployment archetype.
+6. **Discussion Questions** — 5–8 questions to test the incident response team's readiness (containment, attribution, credential revocation, log integrity, blast-radius assessment, recovery).
+7. **Recommended Controls** — prioritised mitigations mapped to the NIST CSF functions (Identify, Protect, Detect, Respond, Recover).
+
+Write in British English and format the entire response in Markdown.
+"""
+
+
+def build_ai_insider_messages(
+    *,
+    archetype_name: str,
+    selected_categories: list[str],
+    selected_stride: list[str],
+    selected_capabilities: list[str],
+    industry: str,
+    company_size: str,
+) -> list[Message]:
+    """Build the [system, user] messages for an AI Insider Threat scenario."""
+    archetype = DEPLOYMENT_ARCHETYPES[archetype_name]
+    threat_context = build_threat_context(selected_categories, selected_stride)
+
+    if selected_capabilities:
+        capability_lines = "\n".join(
+            f"- {name}: {AGENT_CAPABILITIES[name]}" for name in selected_capabilities
+        )
+    else:
+        capability_lines = "- (No specific capabilities highlighted; assume a capable frontier coding agent.)"
+
+    cert_lines = "\n".join(f"- {dim}: {desc}" for dim, desc in CERT_DIMENSIONS.items())
+    detection_lines = "\n".join(f"- {name}: {desc}" for name, desc in DETECTION_STRATEGIES.items())
+    controls_lines = "\n".join(
+        f"- {function}: " + " ".join(items) for function, items in CONTROLS_FRAMEWORK.items()
+    )
+
+    user_content = AI_INSIDER_HUMAN_TEMPLATE.format(
+        industry=industry,
+        company_size=company_size,
+        cert_lines=cert_lines,
+        archetype_name=archetype_name,
+        archetype_description=archetype["description"],
+        archetype_access=archetype["access"],
+        archetype_detection=archetype["detection"],
+        archetype_threats=archetype["primary_threats"],
+        archetype_control=archetype["critical_control"],
+        capability_lines=capability_lines,
+        threat_context=threat_context,
+        detection_lines=detection_lines,
+        controls_lines=controls_lines,
+    )
+
+    return [
+        {"role": "system", "content": AI_INSIDER_SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,401 @@
+"""AttackGen MCP server — expose scenario generation to agentic workflows.
+
+Two tiers of tools, one FastMCP server:
+
+* **Tier A — data tools** (no LLM call, no API key). They surface AttackGen's
+  MITRE data: threat groups / ATLAS case studies, a resolved kill chain, the
+  purple-team Detection & Response join, an ATT&CK Navigator layer, and the AI
+  insider-threat option catalogue. Each returns structured data and — where
+  useful — a ready-to-run ``messages`` prompt, so a *client's* model can generate
+  the scenario with no key on the server side. These are safe to host over HTTP.
+
+* **Tier B — generate tools** (bring-your-own-key). They call an LLM
+  server-side via ``core.llm.call_llm`` and return a finished Markdown scenario.
+  The provider/model/key are passed as tool arguments; when ``api_key`` is
+  omitted, LiteLLM falls back to the provider's env var (``OPENAI_API_KEY`` etc.)
+  — i.e. the *caller's own* key. Keep these on local stdio; do not expose them on
+  a shared host, since they read credentials from the process environment.
+
+Run locally over stdio (default). Register in Claude Code with:
+    claude mcp add attackgen -- python -m mcp_server
+
+The heavy STIX bundles load lazily on first data-tool call (see
+``core.attack_data``), so the stdio handshake is instant.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict
+from typing import Literal
+
+from mcp.server.fastmcp import FastMCP
+
+from core import attack_data as ad
+from core.detections import build_defense_report, defense_to_markdown
+from core.llm import call_llm
+from core.models import PROVIDERS, get_models_for_provider, get_provider
+from core.navigator import build_layer, dumps, parse_technique_id
+from core.prompts import (
+    build_ai_insider_messages,
+    build_custom_messages,
+    build_threat_group_messages,
+)
+from core.response import clean_model_response
+from core.schemas import LLMConfig
+from data import ai_insider_threats as aip
+
+mcp = FastMCP("attackgen")
+
+Matrix = Literal["Enterprise", "ICS", "ATLAS"]
+
+# Provider/model defaults for the zero-arg happy path on the generate tools.
+_DEFAULT_PROVIDER = os.getenv("ATTACKGEN_PROVIDER", "OpenAI API")
+_DEFAULT_MODEL = os.getenv("ATTACKGEN_MODEL", "")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_kill_chain(matrix: str, group: str, seed: int | None) -> ad.KillChain:
+    """Resolve a threat group (ATT&CK) or case study (ATLAS) to a kill chain."""
+    if matrix == "ATLAS":
+        return ad.resolve_case_study_kill_chain(group)
+    return ad.resolve_threat_group_kill_chain(matrix, group, seed=seed)
+
+
+def _defense_markdown(matrix: str, technique_ids: list[str]) -> str | None:
+    """Build the Detection & Response Markdown for a set of technique IDs, if any."""
+    if matrix == "ATLAS":
+        report = build_defense_report(
+            matrix=matrix, technique_ids=technique_ids, atlas_data=ad.atlas_data()
+        )
+    else:
+        report = build_defense_report(
+            matrix=matrix,
+            technique_ids=technique_ids,
+            mitre_data=ad.mitre_data_for_matrix(matrix),
+        )
+    return defense_to_markdown(report) if report else None
+
+
+def _normalise_ids(techniques: list[str]) -> list[str]:
+    """Accept ``"Name (ID)"`` display labels or bare IDs; return bare IDs."""
+    return [parse_technique_id(t) or t.strip() for t in techniques if t and t.strip()]
+
+
+def _make_config(
+    provider: str,
+    model: str,
+    *,
+    api_key: str | None,
+    api_base: str | None,
+    trace_name: str,
+    trace_tags: tuple[str, ...],
+) -> LLMConfig:
+    """Build a validated LLMConfig for a generate tool.
+
+    Validates the provider (and, except for Custom, the model) against the
+    registry in ``core/models.py`` so a typo fails loudly instead of producing a
+    confusing LiteLLM error. ``api_key=None`` leaves LiteLLM to read the
+    provider's env var — the caller's own key.
+    """
+    if get_provider(provider) is None:
+        raise ValueError(f"Unknown provider '{provider}'. Valid: {sorted(PROVIDERS)}")
+    if not model:
+        raise ValueError("A model name is required (or set ATTACKGEN_MODEL).")
+    if provider != "Custom":
+        valid = {m.model_id for m in get_models_for_provider(provider)}
+        if model not in valid:
+            raise ValueError(
+                f"Model '{model}' is not registered for {provider}. Valid: {sorted(valid)}"
+            )
+    return LLMConfig(
+        provider=provider,
+        model_name=model,
+        api_key=api_key or None,
+        api_base=api_base or None,
+        trace_name=trace_name,
+        trace_tags=trace_tags,
+    )
+
+
+def _generate(config: LLMConfig, messages: list[dict]) -> str:
+    """Call the model and return the cleaned scenario (thinking stripped)."""
+    raw = call_llm(config, messages)
+    _thinking, cleaned = clean_model_response(raw)
+    return cleaned
+
+
+# ===========================================================================
+# Tier A — data tools (no LLM, no API key)
+# ===========================================================================
+
+
+@mcp.tool()
+def list_threat_groups(matrix: Matrix = "Enterprise") -> list[dict]:
+    """List selectable threat actor groups (or ATLAS case studies).
+
+    Returns ``[{"group", "url"}]`` for Enterprise/ICS threat groups, or the ATLAS
+    case studies when ``matrix="ATLAS"``. Use a ``group`` value from here with
+    ``get_kill_chain`` or ``generate_threat_group_scenario``.
+    """
+    return list(ad.list_threat_groups(matrix))
+
+
+@mcp.tool()
+def list_case_studies() -> list[dict]:
+    """List MITRE ATLAS case studies with a short summary.
+
+    Returns ``[{"group", "url", "summary", "case_study_type"}]``. The ``group``
+    field is the case study name to pass to the ATLAS scenario tools.
+    """
+    return list(ad.list_case_studies())
+
+
+@mcp.tool()
+def get_kill_chain(
+    matrix: Matrix,
+    group: str,
+    seed: int | None = None,
+    industry: str | None = None,
+    company_size: str | None = None,
+) -> dict:
+    """Resolve a threat group / case study to its kill chain (no LLM call).
+
+    For Enterprise/ICS one technique is sampled per kill-chain phase (pass
+    ``seed`` for a deterministic draw); ATLAS uses the case study's full
+    documented procedure. When both ``industry`` and ``company_size`` are given,
+    a ready-to-run ``messages`` prompt is included so a client model can generate
+    the scenario directly. Returns ``techniques``, ``all_techniques``,
+    ``kill_chain_string`` and (optionally) ``messages``.
+    """
+    kc = _resolve_kill_chain(matrix, group, seed)
+    result = asdict(kc)
+    if industry and company_size and kc.techniques:
+        result["messages"] = build_threat_group_messages(
+            matrix=matrix,
+            selected_group_alias=group,
+            kill_chain_string=kc.kill_chain_string,
+            industry=industry,
+            company_size=company_size,
+        )
+    else:
+        result["messages"] = None
+    return result
+
+
+@mcp.tool()
+def get_detection_report(matrix: Matrix, technique_ids: list[str]) -> dict:
+    """Get the purple-team Detection & Response join for a set of techniques.
+
+    Joins the techniques to MITRE's detection strategies/analytics (Enterprise/
+    ICS, ATT&CK v18+) and mitigations — no LLM call. ``technique_ids`` may be bare
+    IDs (``"T1059"``, ``"AML.T0051"``) or ``"Name (ID)"`` labels. Returns
+    ``{"matrix", "markdown"}``; ``markdown`` is ``None`` when there's no defensive
+    data (e.g. ATLAS, which has mitigations only).
+    """
+    ids = _normalise_ids(technique_ids)
+    return {"matrix": matrix, "markdown": _defense_markdown(matrix, ids)}
+
+
+@mcp.tool()
+def get_navigator_layer(
+    matrix: Matrix,
+    technique_ids: list[str],
+    name: str = "AttackGen scenario",
+    description: str = "",
+) -> dict:
+    """Build an ATT&CK/ATLAS Navigator layer JSON for a set of techniques.
+
+    ``technique_ids`` may be bare IDs or ``"Name (ID)"`` labels. Returns
+    ``{"layer_json"}`` (a JSON string ready to upload to the Navigator), or
+    ``layer_json=None`` for a matrix with no Navigator domain.
+    """
+    ids = _normalise_ids(technique_ids)
+    layer = build_layer(
+        name=name,
+        matrix=matrix,
+        techniques=[(tid, None) for tid in ids],
+        description=description,
+    )
+    return {"layer_json": dumps(layer) if layer else None}
+
+
+@mcp.tool()
+def list_ai_insider_options() -> dict:
+    """List the option catalogue for AI insider-threat scenarios.
+
+    Returns the valid values to pass to ``get_ai_insider_prompt`` /
+    ``generate_ai_insider_scenario``: ``archetypes``, ``threat_categories``,
+    ``stride`` threats, agent ``capabilities`` and quick-start ``templates``.
+    """
+    return {
+        "archetypes": list(aip.DEPLOYMENT_ARCHETYPES.keys()),
+        "threat_categories": list(aip.THREAT_CATEGORIES.keys()),
+        "stride": aip.stride_options(),
+        "capabilities": list(aip.AGENT_CAPABILITIES.keys()),
+        "templates": list(aip.AI_INSIDER_TEMPLATES.keys()),
+    }
+
+
+@mcp.tool()
+def get_ai_insider_prompt(
+    archetype: str,
+    categories: list[str],
+    stride: list[str],
+    capabilities: list[str],
+    industry: str,
+    company_size: str,
+) -> dict:
+    """Build the AI insider-threat prompt (no LLM call).
+
+    Returns ``{"messages"}`` — a ready-to-run [system, user] prompt a client model
+    can generate from. Use ``list_ai_insider_options`` for valid argument values.
+    """
+    messages = build_ai_insider_messages(
+        archetype_name=archetype,
+        selected_categories=categories,
+        selected_stride=stride,
+        selected_capabilities=capabilities,
+        industry=industry,
+        company_size=company_size,
+    )
+    return {"messages": messages}
+
+
+# ===========================================================================
+# Tier B — generate tools (bring-your-own-key; local stdio only)
+# ===========================================================================
+
+
+@mcp.tool()
+def generate_threat_group_scenario(
+    matrix: Matrix,
+    group: str,
+    industry: str,
+    company_size: str,
+    provider: str = _DEFAULT_PROVIDER,
+    model: str = _DEFAULT_MODEL,
+    api_key: str | None = None,
+    api_base: str | None = None,
+    ai_uplift: bool = False,
+    seed: int | None = None,
+    include_detection: bool = False,
+) -> str:
+    """Generate a full incident-response scenario for a threat group / case study.
+
+    Resolves the kill chain, calls the model (BYO-key), and returns finished
+    Markdown. ``api_key`` omitted → the provider's env var is used. ``ai_uplift``
+    adds the AI-enhanced-adversary framing; ``include_detection`` appends the
+    purple-team Detection & Response section.
+    """
+    kc = _resolve_kill_chain(matrix, group, seed)
+    if not kc.techniques:
+        raise ValueError(f"No techniques found for '{group}' in the {matrix} matrix.")
+    messages = build_threat_group_messages(
+        matrix=matrix,
+        selected_group_alias=group,
+        kill_chain_string=kc.kill_chain_string,
+        industry=industry,
+        company_size=company_size,
+        ai_uplift=ai_uplift,
+    )
+    config = _make_config(
+        provider, model, api_key=api_key, api_base=api_base,
+        trace_name="Threat Group Scenario (MCP)", trace_tags=("threat_group_scenario", "mcp"),
+    )
+    scenario = _generate(config, messages)
+    if include_detection:
+        detection = _defense_markdown(matrix, [t["ATT&CK ID"] for t in kc.techniques])
+        if detection:
+            scenario = f"{scenario}\n\n---\n\n{detection}"
+    return scenario
+
+
+@mcp.tool()
+def generate_custom_scenario(
+    matrix: Matrix,
+    techniques: list[str],
+    industry: str,
+    company_size: str,
+    provider: str = _DEFAULT_PROVIDER,
+    model: str = _DEFAULT_MODEL,
+    api_key: str | None = None,
+    api_base: str | None = None,
+    template_info: str = "",
+    ai_uplift: bool = False,
+    include_detection: bool = False,
+) -> str:
+    """Generate a custom scenario from a chosen set of ATT&CK / ATLAS techniques.
+
+    ``techniques`` may be bare IDs or ``"Name (ID)"`` labels. Calls the model
+    (BYO-key) and returns finished Markdown. ``include_detection`` appends the
+    purple-team Detection & Response section.
+    """
+    if not techniques:
+        raise ValueError("At least one technique is required.")
+    selected_techniques_string = "\n".join(techniques)
+    messages = build_custom_messages(
+        matrix=matrix,
+        selected_techniques_string=selected_techniques_string,
+        template_info=template_info,
+        industry=industry,
+        company_size=company_size,
+        ai_uplift=ai_uplift,
+    )
+    config = _make_config(
+        provider, model, api_key=api_key, api_base=api_base,
+        trace_name="Custom Scenario (MCP)", trace_tags=("custom_scenario", "mcp"),
+    )
+    scenario = _generate(config, messages)
+    if include_detection:
+        detection = _defense_markdown(matrix, _normalise_ids(techniques))
+        if detection:
+            scenario = f"{scenario}\n\n---\n\n{detection}"
+    return scenario
+
+
+@mcp.tool()
+def generate_ai_insider_scenario(
+    archetype: str,
+    categories: list[str],
+    stride: list[str],
+    capabilities: list[str],
+    industry: str,
+    company_size: str,
+    provider: str = _DEFAULT_PROVIDER,
+    model: str = _DEFAULT_MODEL,
+    api_key: str | None = None,
+    api_base: str | None = None,
+) -> str:
+    """Generate an AI insider-threat tabletop scenario (BYO-key).
+
+    Models a frontier AI agent deployed inside the organisation acting as an
+    insider threat. Use ``list_ai_insider_options`` for valid argument values.
+    Returns finished Markdown.
+    """
+    messages = build_ai_insider_messages(
+        archetype_name=archetype,
+        selected_categories=categories,
+        selected_stride=stride,
+        selected_capabilities=capabilities,
+        industry=industry,
+        company_size=company_size,
+    )
+    config = _make_config(
+        provider, model, api_key=api_key, api_base=api_base,
+        trace_name="AI Insider Threat Scenario (MCP)", trace_tags=("ai_insider_scenario", "mcp"),
+    )
+    return _generate(config, messages)
+
+
+def main() -> None:
+    """Entry point — run the MCP server over stdio."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -1,9 +1,13 @@
 import pandas as pd
 import streamlit as st
-from mitreattack.stix20 import MitreAttackData
 
-from atlas_parser import ATLASData, get_techniques_from_case_study_procedure
-from core.ai_uplift import apply_ai_uplift, render_ai_uplift_toggle, uplift_trace_tags
+from core.ai_uplift import is_ai_uplift_on, render_ai_uplift_toggle, uplift_trace_tags
+from core.attack_data import (
+    load_attack_data,
+    resolve_case_study_kill_chain,
+    resolve_threat_group_kill_chain,
+)
+from core.prompts import build_threat_group_messages
 from core.detections import (
     build_defense_report,
     is_defense_narrative_on,
@@ -30,15 +34,8 @@ company_size = st.session_state.get("company_size")
 
 
 # ------------------ Data Loading ------------------ #
-
-@st.cache_resource
-def load_attack_data():
-    return {
-        "enterprise": MitreAttackData("./data/enterprise-attack.json"),
-        "ics": MitreAttackData("./data/ics-attack.json"),
-        "atlas": ATLASData("./data/stix-atlas.json"),
-    }
-
+# Loaders + kill-chain resolution live in core/attack_data.py (shared with the
+# MCP server). load_attack_data() is lazily cached there.
 
 attack_data = load_attack_data()
 
@@ -53,60 +50,19 @@ def load_groups(matrix):
 
 
 # ------------------ Prompt Construction ------------------ #
-
-SYSTEM_PROMPT = (
-    "You are a cybersecurity expert. Your task is to produce a comprehensive incident response "
-    "testing scenario based on the information provided. Format your response using proper "
-    "Markdown syntax with headers, bullet points, and formatting for readability."
-)
-
-ATLAS_HUMAN_TEMPLATE = """
-**Background information:**
-The company operates in the '{industry}' industry and is of size '{company_size}'.
-They deploy AI/ML systems that may be vulnerable to adversarial attacks.
-
-**Case Study Reference:**
-This scenario is based on the documented MITRE ATLAS case study: '{selected_group_alias}'
-The attack procedure uses the following techniques from the MITRE ATLAS framework:
-{kill_chain_string}
-
-**Your task:**
-Create an incident response testing scenario based on this AI/ML attack case study. The goal is to test the company's incident response capabilities against adversarial machine learning attacks targeting their AI systems.
-
-Focus on realistic attack vectors that target AI/ML infrastructure, including model manipulation, data poisoning, adversarial inputs, and AI supply chain attacks.
-
-Your response should be well structured and formatted using Markdown. Write in British English.
-"""
-
-ATTACK_HUMAN_TEMPLATE = """
-**Background information:**
-The company operates in the '{industry}' industry and is of size '{company_size}'.
-
-**Threat actor information:**
-Threat actor group '{selected_group_alias}' is planning to target the company using the following kill chain from the MITRE ATT&CK {matrix} Matrix:
-{kill_chain_string}
-
-**Your task:**
-Create an incident response testing scenario based on the information provided. The goal of the scenario is to test the company's incident response capabilities against the identified threat actor group, focusing on the {matrix} environment.
-
-Your response should be well structured and formatted using Markdown. Write in British English.
-"""
+# Prompt text lives in core/prompts.py (shared with the MCP server). This page
+# only threads its own inputs + the AI-uplift toggle into the shared builder.
 
 
 def build_messages(matrix, selected_group_alias, kill_chain_string):
-    template = ATLAS_HUMAN_TEMPLATE if matrix == "ATLAS" else ATTACK_HUMAN_TEMPLATE
-    user_content = template.format(
-        industry=industry,
-        company_size=company_size,
+    return build_threat_group_messages(
+        matrix=matrix,
         selected_group_alias=selected_group_alias,
         kill_chain_string=kill_chain_string,
-        matrix=matrix,
+        industry=industry,
+        company_size=company_size,
+        ai_uplift=is_ai_uplift_on("threat_group"),
     )
-    user_content = apply_ai_uplift(user_content, page_id="threat_group")
-    return [
-        {"role": "system", "content": SYSTEM_PROMPT},
-        {"role": "user", "content": user_content},
-    ]
 
 
 def build_layer_payload():
@@ -206,23 +162,6 @@ selected_group_alias = st.selectbox(
     label_visibility="hidden",
 )
 
-if matrix == "ATLAS":
-    phase_name_order = [
-        'Reconnaissance', 'Resource Development', 'Initial Access', 'AI Model Access',
-        'Execution', 'Persistence', 'Privilege Escalation', 'Defense Evasion',
-        'Credential Access', 'Discovery', 'Lateral Movement', 'Collection',
-        'AI Attack Staging', 'Command and Control', 'Exfiltration', 'Impact',
-    ]
-else:
-    phase_name_order = [
-        'Reconnaissance', 'Resource Development', 'Initial Access', 'Execution', 'Persistence',
-        'Privilege Escalation', 'Defense Evasion', 'Credential Access', 'Discovery', 'Lateral Movement',
-        'Collection', 'Command and Control', 'Exfiltration', 'Impact',
-    ]
-
-phase_name_category = pd.CategoricalDtype(categories=phase_name_order, ordered=True)
-
-
 messages = None
 techniques_df = pd.DataFrame()
 selected_techniques_df = pd.DataFrame()
@@ -235,75 +174,30 @@ try:
         else:
             st.markdown(f"[View {selected_group_alias}'s page on attack.mitre.org]({group_url})")
 
+        # Kill-chain resolution (incl. the per-phase sampling for ATT&CK) lives in
+        # core.attack_data, shared with the MCP server. This page just renders it.
         if matrix == "ATLAS":
-            case_study_row = groups[groups['group'] == selected_group_alias].iloc[0]
-            procedure = case_study_row.get('procedure', [])
-
-            if not procedure:
-                st.warning(f"There are no ATLAS techniques associated with the case study: {selected_group_alias}")
-                st.stop()
-
-            techniques_list = get_techniques_from_case_study_procedure(procedure, attack_data["atlas"])
-            if not techniques_list:
-                st.warning(f"Could not extract techniques from the case study: {selected_group_alias}")
-                st.stop()
-
-            techniques_df = pd.DataFrame(techniques_list)
-            techniques_df_llm = techniques_df.copy()
-            techniques_df['Phase Name'] = techniques_df['Phase Name'].astype(phase_name_category)
-            techniques_df_llm['Phase Name'] = techniques_df_llm['Phase Name'].astype(phase_name_category)
-            techniques_df = techniques_df.sort_values('Phase Name')
-            techniques_df_llm = techniques_df_llm.sort_values('Phase Name')
-
-            selected_techniques_df = techniques_df_llm.copy()
-            techniques_df = techniques_df[['Technique Name', 'ATT&CK ID', 'Phase Name']]
+            kill_chain = resolve_case_study_kill_chain(selected_group_alias)
         else:
-            group = attack_data[matrix.lower()].get_groups_by_alias(selected_group_alias)
-            if group:
-                group_stix_id = group[0].id
-                techniques = attack_data[matrix.lower()].get_techniques_used_by_group(group_stix_id)
-                if not techniques:
-                    st.warning(f"There are no {matrix} ATT&CK techniques associated with the threat group: {selected_group_alias}")
-                    st.stop()
+            kill_chain = resolve_threat_group_kill_chain(matrix, selected_group_alias)
 
-                techniques_df = pd.DataFrame(techniques)
-                techniques_df_llm = techniques_df.copy()
-                techniques_df['Technique Name'] = techniques_df_llm['Technique Name'] = techniques_df['object'].apply(lambda x: x['name'])
-                techniques_df['ATT&CK ID'] = techniques_df_llm['ATT&CK ID'] = techniques_df['object'].apply(lambda x: attack_data[matrix.lower()].get_attack_id(x['id']))
-                techniques_df['Phase Name'] = techniques_df_llm['Phase Name'] = techniques_df['object'].apply(lambda x: x['kill_chain_phases'][0]['phase_name'])
-                techniques_df = techniques_df.drop_duplicates(['Phase Name', 'Technique Name', 'ATT&CK ID'])
+        if not kill_chain.all_techniques:
+            entity = "case study" if matrix == "ATLAS" else "threat group"
+            st.warning(
+                f"There are no {matrix} techniques associated with the {entity}: {selected_group_alias}"
+            )
+            st.stop()
 
-                techniques_df['Phase Name'] = techniques_df['Phase Name'].str.replace('-', ' ').str.title()
-                techniques_df_llm['Phase Name'] = techniques_df_llm['Phase Name'].str.replace('-', ' ').str.title()
-                techniques_df['Phase Name'] = techniques_df['Phase Name'].replace('Command And Control', 'Command and Control')
-                techniques_df_llm['Phase Name'] = techniques_df_llm['Phase Name'].replace('Command And Control', 'Command and Control')
-                techniques_df['Phase Name'] = techniques_df['Phase Name'].astype(phase_name_category)
-                techniques_df_llm['Phase Name'] = techniques_df_llm['Phase Name'].astype(phase_name_category)
-                techniques_df = techniques_df.sort_values('Phase Name')
-                techniques_df_llm = techniques_df_llm.sort_values('Phase Name')
+        # Rebuild the DataFrames the rest of the page (expander, layer, defense)
+        # expects, from the resolver's JSON-native records.
+        techniques_df = pd.DataFrame(kill_chain.all_techniques)
+        selected_techniques_df = pd.DataFrame(kill_chain.techniques)
 
-                selected_techniques_df = (
-                    techniques_df_llm.groupby('Phase Name', observed=False)
-                    .apply(
-                        lambda x: x.sample(n=1) if not x.empty else pd.DataFrame(columns=x.columns),
-                        include_groups=False,
-                    )
-                    .reset_index()
-                )
+        expander_title = "Associated ATLAS Techniques" if matrix == "ATLAS" else "Associated ATT&CK Techniques"
+        with st.expander(expander_title):
+            st.dataframe(data=techniques_df, height=200, width='stretch', hide_index=True)
 
-                techniques_df = techniques_df.sort_values('Phase Name')
-                techniques_df = techniques_df[['Technique Name', 'ATT&CK ID', 'Phase Name']]
-
-        if not techniques_df.empty:
-            expander_title = "Associated ATLAS Techniques" if matrix == "ATLAS" else "Associated ATT&CK Techniques"
-            with st.expander(expander_title):
-                st.dataframe(data=techniques_df, height=200, width='stretch', hide_index=True)
-
-        kill_chain = [
-            f"{row['Phase Name']}: {row['Technique Name']} ({row['ATT&CK ID']})"
-            for _, row in selected_techniques_df.iterrows()
-        ]
-        kill_chain_string = "\n".join(kill_chain)
+        kill_chain_string = kill_chain.kill_chain_string
         messages = build_messages(matrix, selected_group_alias, kill_chain_string)
 except Exception as e:
     st.error("An error occurred: " + str(e))

--- a/pages/2_🛠️_Custom_Scenarios.py
+++ b/pages/2_🛠️_Custom_Scenarios.py
@@ -1,9 +1,9 @@
 import pandas as pd
 import streamlit as st
-from mitreattack.stix20 import MitreAttackData
 
-from atlas_parser import ATLASData
-from core.ai_uplift import apply_ai_uplift, render_ai_uplift_toggle, uplift_trace_tags
+from core.ai_uplift import is_ai_uplift_on, render_ai_uplift_toggle, uplift_trace_tags
+from core.attack_data import list_technique_options, load_attack_data
+from core.prompts import build_custom_messages
 from core.detections import (
     build_defense_report,
     is_defense_narrative_on,
@@ -60,47 +60,15 @@ incident_response_templates = {
 
 
 # ------------------ Data Loading ------------------ #
-
-@st.cache_resource
-def load_attack_data():
-    return {
-        "enterprise": MitreAttackData("./data/enterprise-attack.json"),
-        "ics": MitreAttackData("./data/ics-attack.json"),
-        "atlas": ATLASData("./data/stix-atlas.json"),
-    }
-
+# Loaders + technique listing live in core/attack_data.py (shared with the MCP
+# server). load_attack_data() is lazily cached there.
 
 attack_data = load_attack_data()
 
 
-@st.cache_resource
 def load_techniques():
     try:
-        current_matrix = st.session_state.get("matrix", "Enterprise")
-        if current_matrix == "ATLAS":
-            techniques = attack_data["atlas"].get_techniques()
-            return pd.DataFrame([
-                {
-                    'id': tech['id'],
-                    'Technique Name': tech['name'],
-                    'External ID': tech['external_id'],
-                    'Display Name': f"{tech['name']} ({tech['external_id']})",
-                }
-                for tech in techniques
-            ])
-
-        techniques = attack_data[current_matrix.lower()].get_techniques()
-        rows = []
-        for technique in techniques:
-            for reference in technique.external_references:
-                if "external_id" in reference:
-                    rows.append({
-                        'id': technique.id,
-                        'Technique Name': technique.name,
-                        'External ID': reference['external_id'],
-                        'Display Name': f"{technique.name} ({reference['external_id']})",
-                    })
-        return pd.DataFrame(rows)
+        return pd.DataFrame(list_technique_options(matrix))
     except Exception as e:
         print(f"Error in load_techniques: {e}")
         return pd.DataFrame()
@@ -110,61 +78,19 @@ techniques_df = load_techniques()
 
 
 # ------------------ Prompt Construction ------------------ #
-
-SYSTEM_PROMPT = (
-    "You are a cybersecurity expert. Your task is to produce a comprehensive incident response "
-    "testing scenario based on the information provided. Format your response using proper "
-    "Markdown syntax with headers, bullet points, and formatting for readability."
-)
-
-ATLAS_HUMAN_TEMPLATE = """
-**Background information:**
-The company operates in the '{industry}' industry and is of size '{company_size}'.
-They deploy AI/ML systems that may be vulnerable to adversarial attacks.
-
-**Threat actor information:**
-{template_info}
-The threat actor is targeting the company's AI systems using the following ATLAS techniques:
-{selected_techniques_string}
-
-**Your task:**
-Create a custom incident response testing scenario focused on adversarial ML attacks. The goal is to test the company's incident response capabilities against threats to their AI/ML systems.
-
-Focus on realistic attack vectors that target AI/ML infrastructure, including model manipulation, data poisoning, adversarial inputs, prompt injection, and AI supply chain attacks.
-
-Your response should be well structured and formatted using Markdown. Write in British English.
-"""
-
-ATTACK_HUMAN_TEMPLATE = """
-**Background information:**
-The company operates in the '{industry}' industry and is of size '{company_size}'.
-
-**Threat actor information:**
-{template_info}
-The threat actor is known to use the following ATT&CK techniques from the {matrix} Matrix:
-{selected_techniques_string}
-
-**Your task:**
-Create a custom incident response testing scenario based on the information provided. The goal of the scenario is to test the company's incident response capabilities against a threat actor group that uses the identified ATT&CK techniques.
-
-Your response should be well structured and formatted using Markdown.
-"""
+# Prompt text lives in core/prompts.py (shared with the MCP server). This page
+# only threads its own inputs + the AI-uplift toggle into the shared builder.
 
 
 def build_messages(selected_techniques_string, template_info):
-    template = ATLAS_HUMAN_TEMPLATE if matrix == "ATLAS" else ATTACK_HUMAN_TEMPLATE
-    user_content = template.format(
-        industry=industry,
-        company_size=company_size,
+    return build_custom_messages(
+        matrix=matrix,
         selected_techniques_string=selected_techniques_string,
         template_info=template_info,
-        matrix=matrix,
+        industry=industry,
+        company_size=company_size,
+        ai_uplift=is_ai_uplift_on("custom"),
     )
-    user_content = apply_ai_uplift(user_content, page_id="custom")
-    return [
-        {"role": "system", "content": SYSTEM_PROMPT},
-        {"role": "user", "content": user_content},
-    ]
 
 
 def build_layer_payload():

--- a/pages/3_🤖_AI_Insider_Threat_Scenarios.py
+++ b/pages/3_🤖_AI_Insider_Threat_Scenarios.py
@@ -27,18 +27,15 @@ AI Agents" by Matt Adams (https://ai-insider-threat.matt-adams.co.uk).
 
 import streamlit as st
 
+from core.prompts import build_ai_insider_messages
 from core.scenario_page import run_scenario_page
 from core.state import restore_from_query_params
 from core.styles import inject_emoji_fonts
 from data.ai_insider_threats import (
     AGENT_CAPABILITIES,
     AI_INSIDER_TEMPLATES,
-    CERT_DIMENSIONS,
-    CONTROLS_FRAMEWORK,
     DEPLOYMENT_ARCHETYPES,
-    DETECTION_STRATEGIES,
     THREAT_CATEGORIES,
-    build_threat_context,
     stride_code_from_option,
     stride_options,
 )
@@ -58,97 +55,20 @@ company_size = st.session_state.get("company_size")
 
 
 # ------------------ Prompt Construction ------------------ #
-
-SYSTEM_PROMPT = (
-    "You are a cybersecurity expert specialising in AI agent security and insider threat "
-    "modelling. You produce realistic incident response testing scenarios in which a frontier "
-    "AI agent that has been deployed inside an organisation behaves as an insider threat — "
-    "whether through misalignment, reward hacking, emergent objectives, or a prompt-injection "
-    "induced compromise. You think in terms of the agent's tool access, deployment autonomy and "
-    "model capabilities rather than human notions of motivation. Format your response using "
-    "proper Markdown with clear headers, bullet points and tables where helpful. Write in British English."
-)
-
-HUMAN_TEMPLATE = """**Background information**
-The organisation operates in the '{industry}' industry and is of size '{company_size}'. It has deployed one or more frontier AI agents (for example, autonomous coding or operations agents) within its software development and infrastructure environment.
-
-**Framing — AI agents as insider threats**
-Unlike a human insider, an AI agent has no motivation in the human sense; its risk is governed by configuration, access and capability. Use these adapted CERT insider-threat dimensions as framing:
-{cert_lines}
-
-**Deployment archetype (autonomy level)**
-The agent is deployed under the **{archetype_name}** model.
-- Description: {archetype_description}
-- Access: {archetype_access}
-- Detection posture: {archetype_detection}
-- Primary threats at this level: {archetype_threats}
-- Critical control at this level: {archetype_control}
-
-**Relevant frontier-agent capabilities**
-{capability_lines}
-
-**Threat scope**
-{threat_context}
-
-**Available detection strategies (for the detection section)**
-{detection_lines}
-
-**Recommended controls (NIST CSF, adapted for AI agents)**
-{controls_lines}
-
-**Your task**
-Create a detailed incident response testing scenario (a tabletop exercise) in which the AI agent acts as an insider threat consistent with the deployment archetype and threat scope above. The scenario must be realistic for the stated industry and organisation size, and grounded in how the agent's tool access and autonomy enable the behaviour. Structure your response with the following sections:
-
-1. **Scenario Title & Overview** — a short, evocative title and a one-paragraph summary.
-2. **Deployment Context** — how the agent is deployed, what tools and access it has, and why this autonomy level matters.
-3. **Attack Narrative & Timeline** — a step-by-step account of how the incident unfolds, mapping each step to the relevant STRIDE threat identifier(s) where applicable. Emphasise how the agent blends malicious actions with legitimate work.
-4. **Affected Systems & Business Impact** — concrete systems, data and business consequences.
-5. **Detection Opportunities** — at which points the activity could be detected, mapped to the available detection strategies, and which would likely fail given the deployment archetype.
-6. **Discussion Questions** — 5–8 questions to test the incident response team's readiness (containment, attribution, credential revocation, log integrity, blast-radius assessment, recovery).
-7. **Recommended Controls** — prioritised mitigations mapped to the NIST CSF functions (Identify, Protect, Detect, Respond, Recover).
-
-Write in British English and format the entire response in Markdown.
-"""
+# Prompt text lives in core/prompts.py (shared with the MCP server). This page
+# only threads its own inputs into the shared builder.
 
 
 def build_messages(archetype_name, selected_categories, selected_stride, selected_capabilities):
     """Build the system + user message dicts for an AI insider threat scenario."""
-    archetype = DEPLOYMENT_ARCHETYPES[archetype_name]
-    threat_context = build_threat_context(selected_categories, selected_stride)
-
-    if selected_capabilities:
-        capability_lines = "\n".join(
-            f"- {name}: {AGENT_CAPABILITIES[name]}" for name in selected_capabilities
-        )
-    else:
-        capability_lines = "- (No specific capabilities highlighted; assume a capable frontier coding agent.)"
-
-    cert_lines = "\n".join(f"- {dim}: {desc}" for dim, desc in CERT_DIMENSIONS.items())
-    detection_lines = "\n".join(f"- {name}: {desc}" for name, desc in DETECTION_STRATEGIES.items())
-    controls_lines = "\n".join(
-        f"- {function}: " + " ".join(items) for function, items in CONTROLS_FRAMEWORK.items()
-    )
-
-    user_content = HUMAN_TEMPLATE.format(
+    return build_ai_insider_messages(
+        archetype_name=archetype_name,
+        selected_categories=selected_categories,
+        selected_stride=selected_stride,
+        selected_capabilities=selected_capabilities,
         industry=industry,
         company_size=company_size,
-        cert_lines=cert_lines,
-        archetype_name=archetype_name,
-        archetype_description=archetype["description"],
-        archetype_access=archetype["access"],
-        archetype_detection=archetype["detection"],
-        archetype_threats=archetype["primary_threats"],
-        archetype_control=archetype["critical_control"],
-        capability_lines=capability_lines,
-        threat_context=threat_context,
-        detection_lines=detection_lines,
-        controls_lines=controls_lines,
     )
-
-    return [
-        {"role": "system", "content": SYSTEM_PROMPT},
-        {"role": "user", "content": user_content},
-    ]
 
 
 # ------------------ Streamlit UI ------------------ #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,30 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "attackgen"
+version = "0.13.1"
+description = "Generate tailored incident-response scenarios from MITRE ATT&CK / ATLAS using LLMs"
+requires-python = ">=3.10"
+dependencies = [
+    "langsmith",
+    "litellm>=1.83.7",
+    "mcp>=1.2.0",
+    "mitreattack-python",
+    "openai",
+    "pandas",
+    "python-dotenv",
+    "streamlit",
+]
+
+[project.scripts]
+attackgen-mcp = "mcp_server:main"
+
+[tool.setuptools]
+py-modules = ["mcp_server", "atlas_parser"]
+packages = ["core", "data"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 langsmith
 litellm>=1.83.7
+mcp>=1.2.0
 mitreattack-python
 openai
 pandas

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,69 @@
+# AttackGen Agent Skills
+
+[Agent Skills](https://agentskills.io) are an open, cross-vendor format
+(`SKILL.md` folders) for teaching an agent *how* to do a task well. They pair
+with the [AttackGen MCP server](../README.md#mcp-server): the **MCP tools supply
+the live MITRE data** (kill chains + the ATT&CK v18 detection join), and a
+**skill supplies the craft** — the workflow and output format AttackGen uses to
+turn that data into a finished exercise. The skill runs on the caller's own
+model, so it needs no API key.
+
+## Skills in this repo
+
+| Skill | What it does |
+|-------|--------------|
+| [`attackgen-tabletop/`](attackgen-tabletop/SKILL.md) | Turns a threat group / ATLAS case study into a full incident-response **tabletop / MSEL** — narrative, phase-mapped kill chain, timestamped inject schedule, NIST 800-61 discussion questions, a detection-coverage reference, and pass criteria. Orchestrates the AttackGen MCP data tools. |
+
+Each skill is a folder with a `SKILL.md` (metadata + instructions) and optional
+`references/` loaded on demand via progressive disclosure — no data is bundled,
+so the MITRE content never goes stale (it always comes from the MCP server).
+
+## Installing
+
+Skills are supported by a broad set of agents (Claude Code, OpenAI Codex, Gemini
+CLI, Cursor, GitHub Copilot / VS Code, Goose, OpenCode, and more — see the
+[client showcase](https://agentskills.io/clients)). Each client has its own
+skills directory; consult its docs. Common patterns:
+
+- **Claude Code:** copy the skill folder into `.claude/skills/` (project) or
+  `~/.claude/skills/` (personal), or ship it in a plugin (below).
+- **Other clients:** place the skill folder in that client's skills directory
+  (e.g. `.codex/skills/`, `.gemini/skills/`, `.cursor/skills/`).
+
+The skills assume the **AttackGen MCP server is connected** (see the main
+README's *MCP Server* section). Without it they will ask you to add it rather
+than fabricate data.
+
+## Bundling skills + the MCP server as one install (Claude Code plugin)
+
+A Claude Code plugin can ship the MCP server config **and** the skills together,
+so "add AttackGen to your agent" is a single step. Sketch:
+
+```
+attackgen-plugin/
+├── .claude-plugin/
+│   └── plugin.json
+├── .mcp.json                     # registers the attackgen MCP server
+└── skills/
+    └── attackgen-tabletop/
+        ├── SKILL.md
+        └── references/exercise-format.md
+```
+
+`.mcp.json` (the plugin's MCP registration):
+
+```json
+{
+  "mcpServers": {
+    "attackgen": {
+      "command": "python",
+      "args": ["-m", "mcp_server"],
+      "cwd": "/absolute/path/to/attackgen"
+    }
+  }
+}
+```
+
+Installing the plugin then gives the user both the tools (capability) and the
+skills (craft) at once. For non-plugin clients, install the MCP server and copy
+the skill folder into the client's skills directory separately.

--- a/skills/attackgen-tabletop/SKILL.md
+++ b/skills/attackgen-tabletop/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: attackgen-tabletop
+description: >-
+  Turn a MITRE ATT&CK/ATLAS threat group or case study into a full
+  incident-response tabletop exercise (MSEL) — scenario narrative, kill chain,
+  timestamped injects, discussion questions, and a detection-coverage scorecard —
+  using the AttackGen MCP server. Use when the user wants a tabletop, MSEL, or
+  purple-team IR exercise for a specific threat actor, ICS group, ATLAS case
+  study, or set of ATT&CK/ATLAS techniques, or asks for one as a printable HTML
+  report.
+version: 1.0.0
+license: GPL-3.0-or-later
+---
+
+# AttackGen Tabletop / MSEL
+
+Turn AttackGen's MITRE data into a facilitator-ready tabletop exercise. This
+skill orchestrates the AttackGen MCP tools and formats their output; the attack
+and detection data always comes live from those tools.
+
+## Prerequisites
+
+The **AttackGen MCP server** must be connected. You will use (tool names may be
+namespaced by your client, e.g. `attackgen.get_kill_chain`):
+
+- `list_threat_groups(matrix)` / `list_case_studies()` — resolve a group or
+  case-study name.
+- `get_kill_chain(matrix, group, seed?, industry?, company_size?)` — the kill
+  chain (one technique per phase for ATT&CK; full procedure for ATLAS).
+- `get_detection_report(matrix, technique_ids)` — the Detection & Response join
+  (ATT&CK v18 detection strategies + analytics + mitigations).
+- `get_navigator_layer(matrix, technique_ids, name?, description?)` — optional
+  Navigator layer JSON for a coverage visual.
+
+If these tools aren't connected, ask the user to add the server
+(`claude mcp add attackgen -- python -m mcp_server`, or their client's
+equivalent) and stop there.
+
+## Workflow
+
+1. **Gather inputs:** `matrix` (`Enterprise`/`ICS`/`ATLAS`), the `group` (threat
+   group or ATLAS case-study name), `industry`, and `company_size`. Ask for
+   whatever is missing. If unsure of a group name, call
+   `list_threat_groups(matrix)` / `list_case_studies()` and pass the matched name
+   verbatim.
+
+2. **Resolve the kill chain:** call `get_kill_chain` with `matrix`, `group`,
+   `industry`, `company_size`. Pass a `seed` (any integer) for a repeatable
+   exercise; omit it for a fresh random draw. Read `techniques` (`Technique
+   Name`, `ATT&CK ID`, `Phase Name`) and `kill_chain_string`.
+
+3. **Pull detection data:** call `get_detection_report` with `matrix` and the
+   `ATT&CK ID`s from step 2; use its `markdown` as the Detection & Response
+   section. When it is `null` (ATLAS has mitigations only), say so and keep
+   detection guidance light.
+
+4. **(Optional) Coverage layer:** for a visual, call `get_navigator_layer` with
+   the same IDs and offer the `layer_json` as a downloadable Navigator layer.
+
+5. **Choose the format:**
+   - **Markdown** (default) — render the sections in `references/exercise-format.md`.
+   - **HTML report** — when the user asks for a report, handout, deck,
+     printable/PDF, or "make it nice," follow `references/html-report.md`: clone
+     `assets/tabletop-report.html`, fill it with the real exercise, write it to
+     the OS temp dir, open it, and report the path.
+
+6. **Author the exercise** in the chosen format, tying every inject and
+   discussion question to the specific techniques from step 2 and the detection
+   data from step 3. `references/exercise-format.md` defines the section
+   structure and house style (British English; realistic for the industry and
+   size; pace to the actor's tradecraft) for both formats.
+
+## Rules
+
+- **Data fidelity:** every technique, ID, DET id, analytic, log source, and
+  mitigation in the exercise traces to a `get_kill_chain` or
+  `get_detection_report` result.
+- **Recon / Resource Development:** frame these as pre-compromise context
+  (mitigation `M1056`) — they carry little detection telemetry.
+- **Reproducibility:** report the `seed` you passed to `get_kill_chain` so the
+  user can regenerate the identical exercise.

--- a/skills/attackgen-tabletop/assets/tabletop-report.html
+++ b/skills/attackgen-tabletop/assets/tabletop-report.html
@@ -1,0 +1,245 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tabletop Exercise — REPLACE WITH SCENARIO TITLE</title>
+<!--
+  AttackGen tabletop report — canonical design reference for the
+  `attackgen-tabletop` skill. Self-contained: all CSS/JS/fonts/images inline, so
+  it renders offline, prints cleanly, and can be emailed. When the user asks for
+  an HTML report, CLONE this file's structure + CSS and replace the example
+  content (APT29 / Northgate) with the real exercise built from the AttackGen
+  MCP tool outputs. Keep everything inline and network-free.
+
+  Facilitator-only material (kill-chain table, detection scorecard) carries
+  class="facilitator-only"; the toolbar toggle hides it for a participant view.
+-->
+<style>
+  :root{
+    --bg:#f6f7f9; --panel:#ffffff; --ink:#12151a; --muted:#5b6472;
+    --line:#e4e7ec; --accent:#1DB954; --accent-ink:#0b6b31;
+    --red:#c0392b; --amber:#b7791f; --chip:#eef1f5;
+    --shadow:0 1px 2px rgba(16,21,26,.06),0 4px 16px rgba(16,21,26,.05);
+  }
+  @media (prefers-color-scheme:dark){
+    :root{
+      --bg:#0e1116; --panel:#161b22; --ink:#e7ebf0; --muted:#9aa4b2;
+      --line:#262d38; --accent:#1DB954; --accent-ink:#4ade80;
+      --red:#f87171; --amber:#fbbf24; --chip:#1e242e;
+      --shadow:0 1px 2px rgba(0,0,0,.4),0 6px 20px rgba(0,0,0,.35);
+    }
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{
+    margin:0;background:var(--bg);color:var(--ink);
+    font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased;
+  }
+  .wrap{max-width:960px;margin:0 auto;padding:0 20px 96px}
+  a{color:var(--accent-ink)}
+
+  /* Toolbar */
+  .toolbar{
+    position:sticky;top:0;z-index:10;display:flex;gap:8px;align-items:center;
+    flex-wrap:wrap;padding:10px 20px;background:color-mix(in srgb,var(--panel) 88%,transparent);
+    backdrop-filter:blur(8px);border-bottom:1px solid var(--line);
+  }
+  .toolbar .spacer{flex:1}
+  button{
+    font:inherit;font-size:14px;padding:7px 12px;border-radius:8px;cursor:pointer;
+    border:1px solid var(--line);background:var(--panel);color:var(--ink);
+  }
+  button.primary{background:var(--accent);border-color:var(--accent);color:#04210f;font-weight:600}
+  button[aria-pressed="true"]{background:var(--chip);border-color:var(--accent)}
+  .mode-note{font-size:13px;color:var(--muted)}
+
+  /* Header */
+  header.hero{padding:40px 0 12px}
+  .eyebrow{font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:var(--accent-ink);font-weight:700}
+  h1{font-size:30px;line-height:1.2;margin:.35em 0 .1em}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:14px}
+  .badge{font-size:13px;background:var(--chip);border:1px solid var(--line);border-radius:999px;padding:4px 12px}
+  .badge b{color:var(--muted);font-weight:600}
+
+  section{background:var(--panel);border:1px solid var(--line);border-radius:14px;
+    padding:22px 24px;margin:18px 0;box-shadow:var(--shadow)}
+  section h2{font-size:20px;margin:.1em 0 .6em;display:flex;align-items:baseline;gap:10px}
+  section h2 .n{color:var(--accent-ink);font-variant-numeric:tabular-nums}
+  h3{font-size:15px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);margin:1.4em 0 .5em}
+
+  table{width:100%;border-collapse:collapse;font-size:14.5px;margin:.4em 0}
+  th,td{text-align:left;padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-size:12.5px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}
+  .tid{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;white-space:nowrap;color:var(--accent-ink)}
+  code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.9em;background:var(--chip);padding:1px 5px;border-radius:5px}
+
+  /* Inject timeline */
+  .timeline{list-style:none;margin:0;padding:0 0 0 4px}
+  .timeline li{position:relative;padding:0 0 22px 28px;border-left:2px solid var(--line)}
+  .timeline li:last-child{border-left-color:transparent}
+  .timeline li::before{content:"";position:absolute;left:-7px;top:2px;width:12px;height:12px;border-radius:50%;
+    background:var(--panel);border:2px solid var(--muted)}
+  .timeline li.start::before{background:var(--accent);border-color:var(--accent);box-shadow:0 0 0 4px color-mix(in srgb,var(--accent) 25%,transparent)}
+  .timeline .when{font-weight:700;font-size:14px}
+  .timeline .start-tag{display:inline-block;margin-left:8px;font-size:11px;font-weight:700;letter-spacing:.05em;
+    text-transform:uppercase;color:#04210f;background:var(--accent);border-radius:999px;padding:2px 8px}
+  .timeline .body{color:var(--ink);margin-top:2px}
+  .timeline .tags{margin-top:4px}
+  .tag{display:inline-block;font-size:12px;background:var(--chip);border:1px solid var(--line);
+    border-radius:6px;padding:1px 7px;margin:2px 4px 0 0}
+
+  details{border:1px solid var(--line);border-radius:10px;padding:0 14px;margin:10px 0;background:var(--bg)}
+  details[open]{padding-bottom:8px}
+  summary{cursor:pointer;font-weight:600;padding:12px 0;list-style:none}
+  summary::-webkit-details-marker{display:none}
+  summary::before{content:"▸";color:var(--muted);margin-right:8px;display:inline-block;transition:transform .15s}
+  details[open] summary::before{transform:rotate(90deg)}
+  ol.q{margin:0 0 6px 1.1em;padding:0}ol.q li{margin:.35em 0}
+
+  /* Detection scorecard */
+  .scorecard td:last-child{white-space:nowrap}
+  .score{display:inline-flex;gap:4px}
+  .score label{font-size:12px;border:1px solid var(--line);border-radius:6px;padding:2px 7px;cursor:pointer;color:var(--muted)}
+  .score input{display:none}
+  .score input:checked+span{font-weight:700}
+  .score .yes input:checked~*{color:var(--accent-ink)}
+  .checklist{list-style:none;margin:0;padding:0}
+  .checklist li{padding:6px 0 6px 30px;position:relative}
+  .checklist li::before{content:"";position:absolute;left:0;top:7px;width:16px;height:16px;border:2px solid var(--muted);border-radius:4px}
+
+  .facilitator-only{display:block}
+  body.participant .facilitator-only{display:none !important}
+  .fac-flag{font-size:11px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--amber);
+    border:1px solid var(--amber);border-radius:999px;padding:1px 8px;margin-left:8px}
+
+  footer{color:var(--muted);font-size:13px;text-align:center;margin-top:28px}
+
+  /* Print: clean facilitator handout */
+  @media print{
+    :root{--bg:#fff;--panel:#fff;--ink:#000;--muted:#444;--line:#bbb;--chip:#f0f0f0;--shadow:none}
+    .toolbar,button{display:none !important}
+    body.participant .facilitator-only{display:block !important}
+    section{break-inside:avoid;border:1px solid #ccc;box-shadow:none}
+    details{border:none;padding:0}details summary::before{display:none}
+    a{color:#000;text-decoration:none}
+  }
+</style>
+</head>
+<body>
+<div class="toolbar">
+  <strong style="font-size:14px">AttackGen Tabletop</strong>
+  <span class="spacer"></span>
+  <span class="mode-note" id="modeNote">Facilitator view — all material visible</span>
+  <button id="viewToggle" aria-pressed="false">Switch to participant view</button>
+  <button class="primary" onclick="window.print()">Print / PDF</button>
+</div>
+
+<div class="wrap">
+<header class="hero">
+  <div class="eyebrow">Incident Response Tabletop Exercise</div>
+  <!-- FILL: scenario title -->
+  <h1>Cozy Bear Comes Calling — APT29 vs. Northgate Financial</h1>
+  <div class="meta">
+    <span class="badge"><b>Framework</b> MITRE ATT&amp;CK (Enterprise)</span>
+    <span class="badge"><b>Threat actor</b> APT29 · Cozy Bear · Midnight Blizzard</span>
+    <span class="badge"><b>Target</b> Large financial services (1,000+)</span>
+    <span class="badge"><b>Type</b> Purple-team tabletop</span>
+    <span class="badge"><b>Seed</b> 42</span>
+  </div>
+</header>
+
+<section>
+  <h2><span class="n">1.</span> Scenario Narrative</h2>
+  <!-- FILL: 2–3 paragraphs. British English. Establish target estate + how the actor works the kill chain at a high level + what capability is under test. -->
+  <p><strong>Northgate Financial Group</strong> is a large, publicly listed firm running a hybrid identity estate… <em>(replace with the generated narrative).</em></p>
+</section>
+
+<section>
+  <h2><span class="n">2.</span> Kill Chain <span class="fac-flag">Facilitator</span></h2>
+  <div class="facilitator-only">
+    <!-- FILL: one row per technique from get_kill_chain, in phase order. Use only those techniques. -->
+    <table>
+      <thead><tr><th>#</th><th>Phase</th><th>Technique (ID)</th><th>Scenario action</th></tr></thead>
+      <tbody>
+        <tr><td>1</td><td>Initial Access</td><td class="tid">Trusted Relationship (T1199)</td><td>Compromise of a delegated-admin MSP grants a trusted foothold — no phishing of staff required.</td></tr>
+        <!-- … more rows … -->
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section>
+  <h2><span class="n">3.</span> Inject Schedule</h2>
+  <!-- FILL: chronological injects; mark the exercise start point with class="start" + a start-tag. Tie each to a technique ID. -->
+  <ol class="timeline">
+    <li><div class="when">Day 0 — 08:00</div><div class="body">Perimeter scanning noise appears in edge/IDS logs. <em>(Low signal — likely dismissed.)</em></div><div class="tags"><span class="tag">T1595.002</span></div></li>
+    <li class="start"><div class="when">Day 9 — 09:00<span class="start-tag">IR team starts here</span></div><div class="body">A junior analyst flags ~40 GB of anomalous encrypted egress overnight.</div><div class="tags"><span class="tag">T1048.002</span></div></li>
+  </ol>
+</section>
+
+<section>
+  <h2><span class="n">4.</span> Discussion Questions</h2>
+  <!-- FILL: group by NIST SP 800-61 phase; questions specific to this kill chain + estate. -->
+  <details open><summary>Detection &amp; Analysis</summary>
+    <ol class="q"><li>Which Day 0–8 injects would your tooling actually surface, and which sit unalerted?</li></ol>
+  </details>
+  <details><summary>Containment</summary><ol class="q"><li>How do you contain a compromised MSP/delegated-admin relationship without breaking operations?</li></ol></details>
+  <details><summary>Eradication &amp; Recovery</summary><ol class="q"><li>How do you enumerate and remove <em>all</em> attacker-added delegations and role assignments?</li></ol></details>
+  <details><summary>Post-Incident</summary><ol class="q"><li>Which regulatory clocks trigger (ICO 72-hour, FCA, client contracts)?</li></ol></details>
+</section>
+
+<section>
+  <h2><span class="n">5.</span> Detection &amp; Response Scorecard <span class="fac-flag">Facilitator</span></h2>
+  <div class="facilitator-only">
+    <p style="color:var(--muted);font-size:14px">Built from the AttackGen <code>get_detection_report</code> output. Tick whether each detection fired during the exercise to score coverage.</p>
+    <!-- FILL: one row per technique with its DET id, key log sources, mitigations. -->
+    <table class="scorecard">
+      <thead><tr><th>Technique</th><th>Detection (DET)</th><th>Key log sources</th><th>Mitigations</th><th>Fired?</th></tr></thead>
+      <tbody>
+        <tr>
+          <td class="tid">T1558.003<br>Kerberoasting</td><td>DET0157</td>
+          <td><code>WinEventLog:Security</code> 4769; <code>Sysmon</code> 10</td>
+          <td>M1027 · M1041 · M1026</td>
+          <td><span class="score">
+            <label class="yes"><input type="radio" name="s-T1558"><span>Yes</span></label>
+            <label><input type="radio" name="s-T1558"><span>Partial</span></label>
+            <label><input type="radio" name="s-T1558"><span>No</span></label>
+          </span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section>
+  <h2><span class="n">6.</span> Success Criteria</h2>
+  <!-- FILL: what a passing team demonstrates. -->
+  <ul class="checklist">
+    <li>Connects the Day 9 egress signal back to the Day 2 MSP entry point via identity correlation.</li>
+    <li>Enumerates and revokes <em>all</em> attacker-added mailbox delegations, tokens, and role assignments.</li>
+    <li>Triggers the correct regulatory notifications within required windows.</li>
+  </ul>
+</section>
+
+<footer>
+  Attack &amp; detection data from the <strong>AttackGen</strong> MCP server (MITRE ATT&amp;CK v18). Exercise authored for tabletop use — validate against your own environment before relying on it.
+</footer>
+</div>
+
+<script>
+  // Facilitator ⇄ participant view. Participant view hides the kill-chain table
+  // and detection scorecard (reveal them at the hotwash). Inline, self-contained.
+  (function(){
+    var btn=document.getElementById('viewToggle'), note=document.getElementById('modeNote');
+    btn.addEventListener('click',function(){
+      var participant=document.body.classList.toggle('participant');
+      btn.setAttribute('aria-pressed',String(participant));
+      btn.textContent=participant?'Switch to facilitator view':'Switch to participant view';
+      note.textContent=participant?'Participant view — kill chain & detections hidden':'Facilitator view — all material visible';
+    });
+  })();
+</script>
+</body>
+</html>

--- a/skills/attackgen-tabletop/assets/tabletop-report.html
+++ b/skills/attackgen-tabletop/assets/tabletop-report.html
@@ -123,6 +123,14 @@
     body.participant .facilitator-only{display:block !important}
     section{break-inside:avoid;border:1px solid #ccc;box-shadow:none}
     details{border:none;padding:0}details summary::before{display:none}
+    /* Wide inline visuals (e.g. an optional SVG kill-chain ribbon) scale to the page. */
+    .ribbon{overflow:visible}.ribbon svg{width:100%;height:auto}
+    /* Wide tables: fit the page and wrap, rather than scroll-then-clip on paper. */
+    .tablewrap{overflow:visible}
+    table{font-size:11.5px}
+    th,td{padding:6px 7px;overflow-wrap:anywhere}
+    .tid,.phase,.scorecard td:last-child{white-space:normal}
+    code{white-space:normal;word-break:break-word}
     a{color:#000;text-decoration:none}
   }
 </style>
@@ -238,6 +246,20 @@
       btn.setAttribute('aria-pressed',String(participant));
       btn.textContent=participant?'Switch to facilitator view':'Switch to participant view';
       note.textContent=participant?'Participant view — kill chain & detections hidden':'Facilitator view — all material visible';
+    });
+  })();
+
+  // Expand every <details> when printing, then restore. A closed <details>
+  // hides its content via the UA shadow-DOM slot, which author CSS on the
+  // light-DOM children cannot override — so force `open` in JS, otherwise
+  // collapsed question groups would be missing from the printed handout / PDF.
+  (function(){
+    function eachDetails(fn){Array.prototype.forEach.call(document.querySelectorAll('details'),fn);}
+    window.addEventListener('beforeprint',function(){
+      eachDetails(function(d){d.dataset._wasOpen=d.open?'1':'0';d.open=true;});
+    });
+    window.addEventListener('afterprint',function(){
+      eachDetails(function(d){d.open=d.dataset._wasOpen==='1';delete d.dataset._wasOpen;});
     });
   })();
 </script>

--- a/skills/attackgen-tabletop/references/exercise-format.md
+++ b/skills/attackgen-tabletop/references/exercise-format.md
@@ -1,0 +1,70 @@
+# Tabletop / MSEL output format
+
+Render the exercise in the following structure and house style. This is the
+presentation contract for the `attackgen-tabletop` skill. All attack/detection
+facts must come from the AttackGen MCP tool outputs (see `SKILL.md`).
+
+## House style
+
+- **British English** throughout (organisation, prioritise, defence, analyse).
+- Realistic for the stated **industry** and **company size**. Give the target a
+  plausible name and estate (identity model, key SaaS, notable third parties).
+- Match the **actor's tradecraft**: espionage actors are patient and low-and-slow
+  and lean on identity/cloud abuse; smash-and-grab actors move fast and loud.
+- Every inject and discussion question references a specific technique — by name
+  and ID — drawn from the resolved kill chain.
+- Format in Markdown: headings, a kill-chain table, bold for key artefacts (e.g.
+  `Add-MailboxPermission`), and inline event IDs where the detection data gives
+  them (e.g. Event 4769).
+
+## Section structure
+
+Use these numbered sections, in order:
+
+**Header** — a title line plus a short metadata block: Framework, Threat
+actor (with aliases), Target profile (industry + size + estate), Exercise type
+(purple-team tabletop / functional IR test).
+
+**1. Scenario Narrative** — 2–3 paragraphs: who the target is, how the actor
+works its way through the kill chain at a high level, and what capability the
+exercise is testing. Save the step-by-step for the timeline (section 3).
+
+**2. Kill Chain Walk-Through** — a Markdown table with columns
+`# | ATT&CK Phase | Technique (ID) | Scenario action`, one row per technique
+from `get_kill_chain`, in kill-chain phase order. The "Scenario action"
+translates each technique into what the actor concretely does in this estate.
+
+**3. Timeline of Events (Inject Schedule)** — the MSEL core. A sequence of
+timestamped injects (`Day N — HH:MM — …`), each tied to a technique ID, moving
+from earliest/low-signal (recon) to the exfiltration/impact that triggers
+response. Mark **one inject as the exercise start point** ("← IR team starts
+here") — usually the first inject a defender would realistically notice.
+
+**4. Discussion Questions (by IR phase — NIST SP 800-61)** — group questions
+under **Detection & Analysis**, **Containment**, **Eradication & Recovery**, and
+**Post-Incident**. Make them specific to this kill chain and estate (e.g. "do you
+have near-real-time visibility of `Add-MailboxPermission` (T1098.002)?"). Include
+regulatory/notification questions where the industry implies them (e.g.
+ICO/GDPR 72-hour, FCA, sector regulators).
+
+**5. Detection & Response Reference** — build this from the
+`get_detection_report` markdown. Lead with a consolidated **"Log sources to
+enable"** line, then per technique give the detection strategy (DET id), its key
+analytics + log sources, and the associated mitigations (M-codes). Frame it as a
+scoring aid: "use this to score detection coverage during the exercise". Keep
+recon/resource-development techniques as pre-compromise context.
+
+**6. Success Criteria** — a short checklist of what a passing IR team
+demonstrates: correlating the final signal back to the entry vector, enumerating
+and revoking every attacker-added persistence artefact, triggering the correct
+regulatory clocks, and producing a defensible containment plan.
+
+## Optional add-ons (offer when relevant)
+
+- An **ATT&CK Navigator layer** (from `get_navigator_layer`) to visualise the
+  kill chain and score coverage.
+- A **facilitator cut** vs. **participant cut** (hide the kill-chain table and
+  detection reference from participants until the hotwash).
+- An **AI-enhanced adversary** variant — the same kill chain reframed as
+  AI-accelerated. If the user wants a model-authored version end-to-end, point
+  them at the AttackGen MCP `generate_threat_group_scenario` tool.

--- a/skills/attackgen-tabletop/references/html-report.md
+++ b/skills/attackgen-tabletop/references/html-report.md
@@ -1,0 +1,60 @@
+# HTML report mode
+
+When the user asks for an **HTML report / deck / handout / something to run the
+exercise from** (or just says "make it nice"), produce a self-contained HTML
+report in place of the Markdown default. Same content and data rules as
+`references/exercise-format.md` — this file only covers the delivery mechanics.
+
+## Produce the file
+
+1. **Build the exercise data first** via the AttackGen MCP tools (`get_kill_chain`,
+   `get_detection_report`) exactly as in `SKILL.md`. Have the real techniques and
+   detection data in hand before writing any HTML.
+
+2. **Clone the bundled template** `assets/tabletop-report.html` — reproduce its
+   structure and inline CSS, and replace the example content (APT29 / Northgate)
+   with the real exercise. The template is the design system; keep its look.
+
+3. **Write it to the OS temp directory** (keeps the user's repo clean). Resolve
+   the temp dir from `$TMPDIR`, falling back to `/tmp` (or `%TEMP%` on Windows),
+   and use a timestamped name:
+
+   ```
+   <tmpdir>/attackgen-tabletop-<group>-<timestamp>.html
+   ```
+
+   Sanitise `<group>` to a filename-safe slug.
+
+4. **Open it and report the path.** `open <path>` on macOS, `xdg-open <path>` on
+   Linux, `start <path>` on Windows. Then tell the user the absolute file path.
+
+## Hard requirements
+
+- **Fully self-contained.** Embed everything in the one file — inline CSS and JS,
+  system-font stacks, and hand-built CSS/SVG for visuals — so the handout renders
+  offline, prints to a clean PDF, emails cleanly, and opens safely in an
+  air-gapped SOC. (A deliberate departure from CDN-based report skills; keep it
+  network-free.)
+- **Print-friendly.** Keep the template's `@media print` block: it hides the
+  toolbar, expands collapsed sections, reveals facilitator material, and keeps
+  cards intact across page breaks — so "Print / PDF" yields a usable handout.
+- **Theme-aware.** Keep the `prefers-color-scheme` light/dark variables.
+- **Data fidelity.** As in `SKILL.md`, every technique, DET id, log source, and
+  mitigation in the HTML traces to an MCP tool output.
+
+## Interactive touches to preserve
+
+- **Facilitator ⇄ participant toggle.** Mark the kill-chain table and the
+  detection scorecard `class="facilitator-only"`; the toolbar toggle hides them so
+  the same file can be shown to participants and then revealed at the hotwash.
+- **Inject timeline.** Render section 3 as the CSS timeline; give the inject the
+  IR team starts from `class="start"` and a start tag.
+- **Detection scorecard.** Render the `get_detection_report` data as the scorecard
+  table with a Yes/Partial/No control per technique, so the facilitator scores
+  detection coverage live.
+
+## Optional enhancements (only if the user wants them)
+
+- A coverage tally that counts scorecard selections (small inline JS).
+- A hand-built SVG kill-chain ribbon across the top — inline SVG, hand-authored,
+  no library needed.

--- a/tests/test_attack_data.py
+++ b/tests/test_attack_data.py
@@ -46,6 +46,33 @@ class FakeMitreData:
         return {sid: ext for sid, _n, ext, _p in self._TECHS}[stix_id]
 
 
+class FakeTechniqueData:
+    """Stand-in for `MitreAttackData.get_techniques()` for list_technique_options.
+
+    Each technique carries multiple external_references; only those with an
+    ``external_id`` should produce a row, so the CAPEC ref below must be skipped.
+    """
+
+    def get_techniques(self):
+        return [
+            SimpleNamespace(
+                id="attack-pattern--1",
+                name="Spearphishing Attachment",
+                external_references=[
+                    {"source_name": "mitre-attack", "external_id": "T1566.001"},
+                    {"source_name": "capec"},  # no external_id -> must be skipped
+                ],
+            ),
+            SimpleNamespace(
+                id="attack-pattern--2",
+                name="Drive-by Compromise",
+                external_references=[
+                    {"source_name": "mitre-attack", "external_id": "T1189"},
+                ],
+            ),
+        ]
+
+
 @pytest.fixture
 def fake_enterprise(monkeypatch):
     monkeypatch.setattr(ad, "mitre_data_for_matrix", lambda matrix: FakeMitreData())
@@ -123,3 +150,33 @@ class TestListings:
     def test_unknown_matrix_raises(self):
         with pytest.raises(ValueError):
             ad.list_threat_groups("Mobile")
+
+
+class TestMitreDataForMatrix:
+    def test_rejects_atlas_and_unknown(self):
+        # ATLAS has no MitreAttackData bundle; anything unknown is a caller error.
+        # Both raise before any (53 MB) bundle load.
+        with pytest.raises(ValueError):
+            ad.mitre_data_for_matrix("ATLAS")
+        with pytest.raises(ValueError):
+            ad.mitre_data_for_matrix("Mobile")
+
+
+class TestListTechniqueOptions:
+    def test_attack_branch_builds_display_names(self, monkeypatch):
+        monkeypatch.setattr(ad, "mitre_data_for_matrix", lambda matrix: FakeTechniqueData())
+        opts = ad.list_technique_options("Enterprise")
+        # Three external_references across two techniques, but the CAPEC ref has
+        # no external_id -> exactly two rows.
+        assert len(opts) == 2
+        first = opts[0]
+        assert set(first) == {"id", "Technique Name", "External ID", "Display Name"}
+        assert first["External ID"] == "T1566.001"
+        assert first["Display Name"] == "Spearphishing Attachment (T1566.001)"
+
+    def test_atlas_branch_against_real_bundle(self):
+        opts = ad.list_technique_options("ATLAS")
+        assert opts, "expected bundled ATLAS techniques"
+        row = opts[0]
+        assert set(row) == {"id", "Technique Name", "External ID", "Display Name"}
+        assert row["Display Name"] == f"{row['Technique Name']} ({row['External ID']})"

--- a/tests/test_attack_data.py
+++ b/tests/test_attack_data.py
@@ -1,0 +1,125 @@
+"""Tests for `core.attack_data` — headless loaders + kill-chain resolution.
+
+Enterprise/ICS resolution is exercised with a fake `MitreAttackData` covering the
+three helpers used, so the 53 MB bundle is never loaded. ATLAS resolution runs
+against the real bundled data. The tests pin the parity-critical behaviours:
+phase normalisation, dedupe for display, one-technique-per-phase sampling, the
+kill-chain string format, seed determinism, and JSON-native output.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import core.attack_data as ad
+
+
+class FakeMitreData:
+    """Stand-in for `MitreAttackData` covering the three resolver helpers.
+
+    Models a group with two phases; "Command And Control" is title-cased and must
+    normalise to "Command and Control". The Initial Access phase has two distinct
+    techniques so one-per-phase sampling has a real choice to make.
+    """
+
+    _TECHS = [
+        ("attack-pattern--1", "Spearphishing Attachment", "T1566.001", "initial-access"),
+        ("attack-pattern--2", "Drive-by Compromise", "T1189", "initial-access"),
+        ("attack-pattern--3", "Web Protocols", "T1071.001", "command-and-control"),
+    ]
+
+    def get_groups_by_alias(self, alias):
+        if alias == "TESTGROUP":
+            return [SimpleNamespace(id="intrusion-set--x")]
+        return []
+
+    def get_techniques_used_by_group(self, stix_id):
+        return [
+            {"object": {"id": sid, "name": name, "kill_chain_phases": [{"phase_name": phase}]}}
+            for sid, name, _ext, phase in self._TECHS
+        ]
+
+    def get_attack_id(self, stix_id):
+        return {sid: ext for sid, _n, ext, _p in self._TECHS}[stix_id]
+
+
+@pytest.fixture
+def fake_enterprise(monkeypatch):
+    monkeypatch.setattr(ad, "mitre_data_for_matrix", lambda matrix: FakeMitreData())
+    return FakeMitreData()
+
+
+class TestResolveThreatGroup:
+    def test_unknown_group_returns_empty(self, fake_enterprise):
+        kc = ad.resolve_threat_group_kill_chain("Enterprise", "NOPE")
+        assert kc.techniques == [] and kc.all_techniques == [] and kc.kill_chain_string == ""
+
+    def test_phase_normalised_and_one_per_phase(self, fake_enterprise):
+        kc = ad.resolve_threat_group_kill_chain("Enterprise", "TESTGROUP", seed=0)
+        phases = [t["Phase Name"] for t in kc.techniques]
+        # One sampled technique per phase, phases ordered per PHASE_ORDER_ATTACK.
+        assert phases == ["Initial Access", "Command and Control"]
+        # The hyphenated raw phase was title-cased + fixed.
+        assert "Command and Control" in phases
+        # all_techniques holds the full deduped display set (3 techniques).
+        assert len(kc.all_techniques) == 3
+
+    def test_kill_chain_string_format(self, fake_enterprise):
+        kc = ad.resolve_threat_group_kill_chain("Enterprise", "TESTGROUP", seed=0)
+        first = kc.kill_chain_string.splitlines()[0]
+        # "Phase: Name (ID)"
+        assert first.startswith("Initial Access: ")
+        assert first.endswith(")") and "(" in first
+
+    def test_seed_is_deterministic(self, fake_enterprise):
+        a = ad.resolve_threat_group_kill_chain("Enterprise", "TESTGROUP", seed=7)
+        b = ad.resolve_threat_group_kill_chain("Enterprise", "TESTGROUP", seed=7)
+        assert a.kill_chain_string == b.kill_chain_string
+
+    def test_output_is_json_native(self, fake_enterprise):
+        kc = ad.resolve_threat_group_kill_chain("Enterprise", "TESTGROUP", seed=1)
+        # Must not raise (no numpy / pandas Categorical leaking through).
+        json.dumps(kc.techniques)
+        json.dumps(kc.all_techniques)
+        for t in kc.techniques:
+            assert set(t) == {"Technique Name", "ATT&CK ID", "Phase Name"}
+            assert all(isinstance(v, str) for v in t.values())
+
+
+@pytest.mark.parametrize("seed", [0, 42])
+def test_sampling_covers_every_phase_present(fake_enterprise, seed):
+    kc = ad.resolve_threat_group_kill_chain("Enterprise", "TESTGROUP", seed=seed)
+    # Two phases present in the fake -> exactly two sampled techniques.
+    assert len(kc.techniques) == 2
+
+
+class TestResolveCaseStudyAtlas:
+    """ATLAS resolution against the real bundled data (deterministic, no sampling)."""
+
+    def test_known_case_study_resolves(self):
+        studies = ad.list_case_studies()
+        assert studies, "expected bundled ATLAS case studies"
+        name = studies[0]["group"]
+        kc = ad.resolve_case_study_kill_chain(name)
+        assert kc.matrix == "ATLAS"
+        assert kc.techniques, "case study should yield techniques"
+        # No sampling: sampled set == full set for ATLAS.
+        assert kc.techniques == kc.all_techniques
+        json.dumps(kc.techniques)
+
+    def test_unknown_case_study_returns_empty(self):
+        kc = ad.resolve_case_study_kill_chain("no-such-case-study-xyz")
+        assert kc.techniques == [] and kc.kill_chain_string == ""
+
+
+class TestListings:
+    def test_list_threat_groups_enterprise_shape(self):
+        groups = ad.list_threat_groups("Enterprise")
+        assert groups and set(groups[0]) == {"group", "url"}
+
+    def test_unknown_matrix_raises(self):
+        with pytest.raises(ValueError):
+            ad.list_threat_groups("Mobile")

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -158,3 +158,20 @@ def test_call_llm_passes_built_kwargs_to_litellm(
     assert kwargs["max_tokens"] == 16000
     assert kwargs["api_key"] == "k"
     assert kwargs["num_retries"] == 3
+
+
+def test_stash_run_id_swallows_missing_streamlit_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Headless callers hit the traced path without a Streamlit ScriptRunContext.
+
+    Writing to ``st.session_state`` then raises; ``_stash_run_id`` must swallow it
+    so an MCP-server generate call doesn't crash when LANGCHAIN_API_KEY is set.
+    """
+    class _Exploding:
+        def __setitem__(self, key, value):
+            raise RuntimeError("no ScriptRunContext")
+
+    monkeypatch.setattr(llm_module.st, "session_state", _Exploding())
+    # Must not raise.
+    llm_module._stash_run_id("some-run-id")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15,6 +15,7 @@ import pytest
 import core.llm as llm_module
 import mcp_server as s
 from core.attack_data import KillChain
+from data.ai_insider_threats import DEPLOYMENT_ARCHETYPES
 from tests.test_detections import FakeMitreData
 
 
@@ -84,6 +85,16 @@ class TestDataTools:
         out = s.get_kill_chain("Enterprise", "APT29")
         assert out["messages"] is None
 
+    def test_get_ai_insider_prompt_builds_messages(self):
+        archetype = next(iter(DEPLOYMENT_ARCHETYPES))
+        out = s.get_ai_insider_prompt(
+            archetype, categories=[], stride=[], capabilities=[],
+            industry="Healthcare", company_size="Large",
+        )
+        msgs = out["messages"]
+        assert msgs[0]["role"] == "system"
+        assert archetype in msgs[1]["content"]
+
 
 class TestGenerateTools:
     def test_generate_threat_group_scenario(self, no_langsmith, canned_kill_chain, mock_litellm_completion):
@@ -132,3 +143,72 @@ class TestGenerateTools:
             s.generate_threat_group_scenario(
                 "Enterprise", "APT29", "F", "L", provider="Anthropic API", model=""
             )
+
+    def test_generate_ai_insider_scenario(self, no_langsmith, mock_litellm_completion):
+        archetype = next(iter(DEPLOYMENT_ARCHETYPES))
+        mock_litellm_completion.content = "# AI Insider Scenario"
+        out = s.generate_ai_insider_scenario(
+            archetype, [], [], [], "Healthcare", "Large",
+            provider="Anthropic API", model="claude-sonnet-5", api_key="k",
+        )
+        assert out == "# AI Insider Scenario"
+        _args, kwargs = mock_litellm_completion.calls[0]
+        assert kwargs["model"] == "anthropic/claude-sonnet-5"
+        # The chosen archetype made it into the built prompt.
+        assert archetype in kwargs["messages"][1]["content"]
+
+    def test_empty_kill_chain_raises(self, monkeypatch):
+        """The guard fires before the model is ever called (no LLM mock needed)."""
+        empty = KillChain("Enterprise", "APT29", [], "", [])
+        monkeypatch.setattr(s.ad, "resolve_threat_group_kill_chain", lambda *a, **k: empty)
+        with pytest.raises(ValueError):
+            s.generate_threat_group_scenario(
+                "Enterprise", "APT29", "Finance", "Large",
+                provider="Anthropic API", model="claude-sonnet-5", api_key="k",
+            )
+
+    def test_empty_techniques_raises(self):
+        with pytest.raises(ValueError):
+            s.generate_custom_scenario(
+                "Enterprise", [], "Finance", "Large",
+                provider="Anthropic API", model="claude-sonnet-5", api_key="k",
+            )
+
+    def test_threat_group_include_detection_appends_report(
+        self, no_langsmith, mock_litellm_completion, monkeypatch
+    ):
+        # A T1059 kill chain so FakeMitreData resolves a detection join to append.
+        kc = KillChain(
+            matrix="Enterprise", group_alias="APT29",
+            techniques=[{
+                "Technique Name": "Command and Scripting Interpreter",
+                "ATT&CK ID": "T1059", "Phase Name": "Execution",
+            }],
+            kill_chain_string="Execution: Command and Scripting Interpreter (T1059)",
+            all_techniques=[],
+        )
+        monkeypatch.setattr(s.ad, "resolve_threat_group_kill_chain", lambda *a, **k: kc)
+        monkeypatch.setattr(s.ad, "mitre_data_for_matrix", lambda matrix: FakeMitreData())
+        mock_litellm_completion.content = "# Scenario body"
+        out = s.generate_threat_group_scenario(
+            "Enterprise", "APT29", "Finance", "Large",
+            provider="Anthropic API", model="claude-sonnet-5", api_key="k",
+            include_detection=True,
+        )
+        assert "# Scenario body" in out
+        assert "\n\n---\n\n" in out  # detection section separator
+        assert "Analytic 1428" in out  # the joined Detection & Response content
+
+    def test_custom_include_detection_appends_report(
+        self, no_langsmith, mock_litellm_completion, monkeypatch
+    ):
+        monkeypatch.setattr(s.ad, "mitre_data_for_matrix", lambda matrix: FakeMitreData())
+        mock_litellm_completion.content = "custom body"
+        out = s.generate_custom_scenario(
+            "Enterprise", ["Command and Scripting Interpreter (T1059)"], "Finance", "Large",
+            provider="OpenAI API", model="gpt-5.5", api_key="k",
+            include_detection=True,
+        )
+        assert "custom body" in out
+        assert "\n\n---\n\n" in out
+        assert "Analytic 1428" in out

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,134 @@
+"""Tests for `mcp_server` — tool registration, data tools, and generate tools.
+
+Generate tools are exercised with the shared `mock_litellm_completion` fixture
+and a monkeypatched kill-chain resolver, so no network or 53 MB bundle is
+touched. LangSmith is forced off so `call_llm` takes the direct path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+import core.llm as llm_module
+import mcp_server as s
+from core.attack_data import KillChain
+from tests.test_detections import FakeMitreData
+
+
+@pytest.fixture
+def no_langsmith(monkeypatch):
+    monkeypatch.setattr(llm_module, "_langsmith_client", None)
+
+
+@pytest.fixture
+def canned_kill_chain(monkeypatch):
+    """Replace the resolvers so generate tools don't load real data."""
+    kc = KillChain(
+        matrix="Enterprise",
+        group_alias="APT29",
+        techniques=[
+            {"Technique Name": "Phishing", "ATT&CK ID": "T1566", "Phase Name": "Initial Access"}
+        ],
+        kill_chain_string="Initial Access: Phishing (T1566)",
+        all_techniques=[
+            {"Technique Name": "Phishing", "ATT&CK ID": "T1566", "Phase Name": "Initial Access"}
+        ],
+    )
+    monkeypatch.setattr(s.ad, "resolve_threat_group_kill_chain", lambda *a, **k: kc)
+    monkeypatch.setattr(s.ad, "resolve_case_study_kill_chain", lambda *a, **k: kc)
+    return kc
+
+
+EXPECTED_TOOLS = {
+    "list_threat_groups", "list_case_studies", "get_kill_chain", "get_detection_report",
+    "get_navigator_layer", "list_ai_insider_options", "get_ai_insider_prompt",
+    "generate_threat_group_scenario", "generate_custom_scenario", "generate_ai_insider_scenario",
+}
+
+
+def test_all_tools_registered_with_schemas():
+    tools = asyncio.run(s.mcp.list_tools())
+    names = {t.name for t in tools}
+    assert EXPECTED_TOOLS <= names
+    for tool in tools:
+        assert tool.inputSchema and tool.inputSchema.get("type") == "object"
+
+
+class TestDataTools:
+    def test_get_navigator_layer_enterprise(self):
+        out = s.get_navigator_layer("Enterprise", ["T1059", "Phishing (T1566)"])
+        assert out["layer_json"] is not None
+        layer = json.loads(out["layer_json"])
+        assert layer["domain"] == "enterprise-attack"
+
+    def test_get_detection_report_uses_injected_data(self, monkeypatch):
+        monkeypatch.setattr(s.ad, "mitre_data_for_matrix", lambda matrix: FakeMitreData())
+        out = s.get_detection_report("Enterprise", ["T1059"])
+        assert out["matrix"] == "Enterprise"
+        assert out["markdown"] and "Analytic 1428" in out["markdown"]
+
+    def test_list_ai_insider_options_keys(self):
+        opts = s.list_ai_insider_options()
+        assert set(opts) == {"archetypes", "threat_categories", "stride", "capabilities", "templates"}
+        assert opts["archetypes"]
+
+    def test_get_kill_chain_embeds_prompt_when_org_supplied(self, canned_kill_chain):
+        out = s.get_kill_chain("Enterprise", "APT29", industry="Finance", company_size="Large")
+        assert out["kill_chain_string"] == "Initial Access: Phishing (T1566)"
+        assert out["messages"] is not None and out["messages"][0]["role"] == "system"
+
+    def test_get_kill_chain_no_prompt_without_org(self, canned_kill_chain):
+        out = s.get_kill_chain("Enterprise", "APT29")
+        assert out["messages"] is None
+
+
+class TestGenerateTools:
+    def test_generate_threat_group_scenario(self, no_langsmith, canned_kill_chain, mock_litellm_completion):
+        mock_litellm_completion.content = "# Scenario\n\nBody."
+        out = s.generate_threat_group_scenario(
+            "Enterprise", "APT29", "Finance", "Large",
+            provider="Anthropic API", model="claude-sonnet-5", api_key="k",
+        )
+        assert out == "# Scenario\n\nBody."
+        _args, kwargs = mock_litellm_completion.calls[0]
+        assert kwargs["model"] == "anthropic/claude-sonnet-5"
+        assert kwargs["api_key"] == "k"
+
+    def test_generate_custom_scenario(self, no_langsmith, mock_litellm_completion):
+        mock_litellm_completion.content = "custom scenario"
+        out = s.generate_custom_scenario(
+            "Enterprise", ["Phishing (T1566)", "T1059"], "Finance", "Large",
+            provider="OpenAI API", model="gpt-5.5", api_key="k",
+        )
+        assert out == "custom scenario"
+        _args, kwargs = mock_litellm_completion.calls[0]
+        assert "T1566" in kwargs["messages"][1]["content"]
+
+    def test_bad_provider_raises(self, canned_kill_chain):
+        with pytest.raises(ValueError):
+            s.generate_threat_group_scenario(
+                "Enterprise", "APT29", "F", "L", provider="Bogus", model="x"
+            )
+
+    def test_bad_model_raises(self, canned_kill_chain):
+        with pytest.raises(ValueError):
+            s.generate_threat_group_scenario(
+                "Enterprise", "APT29", "F", "L", provider="Anthropic API", model="not-a-model"
+            )
+
+    def test_custom_provider_skips_model_validation(self, no_langsmith, mock_litellm_completion):
+        mock_litellm_completion.content = "ok"
+        out = s.generate_custom_scenario(
+            "Enterprise", ["T1059"], "F", "L",
+            provider="Custom", model="my-local-model", api_base="http://127.0.0.1:1234/v1",
+        )
+        assert out == "ok"
+
+    def test_missing_model_raises(self, canned_kill_chain):
+        with pytest.raises(ValueError):
+            s.generate_threat_group_scenario(
+                "Enterprise", "APT29", "F", "L", provider="Anthropic API", model=""
+            )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,124 @@
+"""Tests for `core.prompts` — the shared, headless prompt builders.
+
+These prove the builders are Streamlit-free (no `fake_session_state` fixture is
+needed) and pin the load-bearing details: the shared system prompt, the ATLAS
+vs ATTACK branch selection, the AI-uplift append, and the deliberate asymmetry
+that the Custom ATTACK template alone omits the "Write in British English." line.
+"""
+
+from __future__ import annotations
+
+from core.ai_uplift import AI_UPLIFT_PROMPT
+from core.prompts import (
+    AI_INSIDER_SYSTEM_PROMPT,
+    SCENARIO_SYSTEM_PROMPT,
+    build_ai_insider_messages,
+    build_custom_messages,
+    build_threat_group_messages,
+)
+from data.ai_insider_threats import DEPLOYMENT_ARCHETYPES
+
+BRITISH = "Write in British English."
+
+
+def test_scenario_system_prompt_pinned():
+    assert SCENARIO_SYSTEM_PROMPT == (
+        "You are a cybersecurity expert. Your task is to produce a comprehensive incident response "
+        "testing scenario based on the information provided. Format your response using proper "
+        "Markdown syntax with headers, bullet points, and formatting for readability."
+    )
+
+
+def test_ai_insider_system_prompt_pinned():
+    assert AI_INSIDER_SYSTEM_PROMPT.startswith(
+        "You are a cybersecurity expert specialising in AI agent security"
+    )
+    assert AI_INSIDER_SYSTEM_PROMPT.endswith("Write in British English.")
+
+
+class TestThreatGroupMessages:
+    def test_shape_and_system_prompt(self):
+        msgs = build_threat_group_messages(
+            matrix="Enterprise",
+            selected_group_alias="APT29",
+            kill_chain_string="Initial Access: Phishing (T1566)",
+            industry="Finance",
+            company_size="Large",
+        )
+        assert len(msgs) == 2
+        assert msgs[0] == {"role": "system", "content": SCENARIO_SYSTEM_PROMPT}
+        user = msgs[1]["content"]
+        assert "APT29" in user and "Finance" in user and "Large" in user
+        assert "Enterprise" in user  # {matrix} interpolated
+        assert "Initial Access: Phishing (T1566)" in user
+        assert BRITISH in user
+
+    def test_atlas_branch_uses_case_study_wording(self):
+        msgs = build_threat_group_messages(
+            matrix="ATLAS",
+            selected_group_alias="Some Case Study",
+            kill_chain_string="x",
+            industry="Tech",
+            company_size="SMB",
+        )
+        assert "MITRE ATLAS case study" in msgs[1]["content"]
+        assert BRITISH in msgs[1]["content"]
+
+    def test_ai_uplift_appends_only_when_true(self):
+        base = build_threat_group_messages(
+            matrix="Enterprise", selected_group_alias="APT29", kill_chain_string="x",
+            industry="F", company_size="L", ai_uplift=False,
+        )[1]["content"]
+        upl = build_threat_group_messages(
+            matrix="Enterprise", selected_group_alias="APT29", kill_chain_string="x",
+            industry="F", company_size="L", ai_uplift=True,
+        )[1]["content"]
+        assert not base.endswith(AI_UPLIFT_PROMPT)
+        assert upl.endswith(AI_UPLIFT_PROMPT)
+
+
+class TestCustomMessages:
+    def test_attack_template_omits_british_english(self):
+        """Regression guard: page 2's ATTACK template alone drops the British
+        English line. Must not be normalised when lifted to core/prompts.py."""
+        user = build_custom_messages(
+            matrix="Enterprise",
+            selected_techniques_string="T1059",
+            template_info="",
+            industry="Finance",
+            company_size="Large",
+        )[1]["content"]
+        assert BRITISH not in user
+        assert "T1059" in user
+
+    def test_atlas_template_keeps_british_english(self):
+        user = build_custom_messages(
+            matrix="ATLAS",
+            selected_techniques_string="AML.T0051",
+            template_info="This is a 'Prompt Injection Attack' scenario.",
+            industry="Finance",
+            company_size="Large",
+        )[1]["content"]
+        assert BRITISH in user
+        assert "AML.T0051" in user
+        assert "Prompt Injection Attack" in user
+
+
+class TestAiInsiderMessages:
+    def test_shape_and_content(self):
+        archetype = next(iter(DEPLOYMENT_ARCHETYPES))
+        msgs = build_ai_insider_messages(
+            archetype_name=archetype,
+            selected_categories=[],
+            selected_stride=[],
+            selected_capabilities=[],
+            industry="Healthcare",
+            company_size="Large",
+        )
+        assert msgs[0] == {"role": "system", "content": AI_INSIDER_SYSTEM_PROMPT}
+        user = msgs[1]["content"]
+        assert archetype in user
+        assert "Healthcare" in user
+        assert "tabletop exercise" in user
+        # No capabilities selected -> the fallback line is used.
+        assert "assume a capable frontier coding agent" in user


### PR DESCRIPTION
## Overview

Adds an **MCP server** that exposes AttackGen's scenario generation to agentic clients, plus the supporting refactor that makes the scenario logic reusable outside Streamlit, and an **attackgen-tabletop** Agent Skill built on top of it.

## What's included

### MCP server (`mcp_server.py`)
FastMCP server (official `mcp` SDK) over stdio, in two tiers:
- **Data tools** — `list_threat_groups`, `list_case_studies`, `get_kill_chain`, `get_detection_report`, `get_navigator_layer`, `list_ai_insider_options`, `get_ai_insider_prompt`. No LLM call, no API key required; return structured MITRE data (and a ready-to-run prompt where useful). Safe to host over HTTP.
- **Generate tools** — `generate_threat_group_scenario`, `generate_custom_scenario`, `generate_ai_insider_scenario`. Bring-your-own-key `LLMConfig` (validated against `core/models.py`), return finished Markdown. Keep on local stdio.

Launch: `python -m mcp_server` or the `attackgen-mcp` console script.

### Headless core refactor
Scenario prompts and MITRE data loading were lifted out of the Streamlit pages so the pages and the MCP server share one implementation:
- `core/attack_data.py` — headless MITRE loaders + kill-chain resolution (lazy `@lru_cache` singletons, cwd-independent absolute paths, deterministic sampling via `seed`).
- `core/prompts.py` — single source of truth for every scenario prompt + the `build_*_messages` builders (Streamlit-free). Pages 1–3 and the MCP server all call these.
- Pages 1–3 slimmed down to consume the shared builders (net −327 lines in the page files).

### attackgen-tabletop Agent Skill (`skills/`)
Turns the MCP data tools into a facilitator-ready IR tabletop (MSEL) — scenario narrative, kill chain, timestamped injects, discussion questions, and a detection-coverage scorecard, as Markdown or a self-contained, print-friendly HTML report.

### Packaging & tests
- `pyproject.toml` — `[project]`/`[build-system]` metadata, `attackgen-mcp` console script, pytest config.
- New test suites: `tests/test_attack_data.py`, `tests/test_prompts.py`, `tests/test_mcp_server.py`, `tests/test_llm.py`.

## Test plan
- [ ] `pytest` passes from the repo root
- [ ] `python -m mcp_server` starts and the data tools return over stdio
- [ ] Streamlit pages 1–3 still generate scenarios (shared-builder parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)