### PR TITLE
ci: automated Docker Hub release pipeline (bump to 0.14.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+# Fires on version tags (e.g. v0.14.0). One tag drives the whole release:
+# verify the tag matches the packaged version, run the test suite, build and
+# push the multi-arch image to Docker Hub, then cut a GitHub Release with
+# generated notes.
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never cancel an in-flight release: a half-published tag is worse than a wait.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Check tag matches packaged version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          VERSION="$(grep -m1 -E '^version\s*=' pyproject.toml | cut -d'"' -f2)"
+          echo "Tag: $TAG  |  pyproject version: $VERSION"
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match pyproject version $VERSION. Bump the version and re-tag."
+            exit 1
+          fi
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    needs: verify
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest
+
+  docker:
+    name: Build and push image
+    needs: [verify, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: mrwadams/attackgen
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push (amd64 + arm64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  github-release:
+    name: Create GitHub Release
+    needs: docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attackgen"
-version = "0.13.1"
+version = "0.14.0"
 description = "Generate tailored incident-response scenarios from MITRE ATT&CK / ATLAS using LLMs"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yml` — an automated release pipeline that publishes a Docker image to Docker Hub whenever a version tag is pushed. Also bumps the packaged version `0.13.1 → 0.14.0` for the first automated release.

## How it works

Triggered on `v*.*.*` tags. Four gated jobs:

1. **verify** — fail fast if the tag doesn't match `pyproject.toml` version
2. **test** — pytest on Python 3.10–3.13 (pip + `requirements-dev.txt`)
3. **docker** — build multi-arch (`linux/amd64,linux/arm64`) from the existing `Dockerfile`, push `mrwadams/attackgen` tagged `{version}` / `{major}.{minor}` / `latest`
4. **github-release** — cut a GitHub Release with generated notes

Mirrors the STRIDE-GPT release pipeline, adapted to this repo (pip instead of `uv`; no PyPI job — AttackGen is a Streamlit app). The pinned base image (`python:3.12-slim@sha256:090ba77e…`) is a multi-arch OCI index, so the arm64 build works with the Dockerfile unchanged.

## Prerequisites

Repo secrets `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` — already configured.

## Releasing after merge

Once this lands on `main`:

```
git tag v0.14.0 && git push origin v0.14.0
```

That fires the pipeline and publishes `mrwadams/attackgen:0.14.0`, `:0.14`, and `:latest` (amd64 + arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)