### PR TITLE
fix: cap mcp below 2.0, which removed mcp.server.fastmcp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ requires-python = ">=3.10"
 dependencies = [
     "langsmith",
     "litellm>=1.83.7",
-    "mcp>=1.2.0",
+    # mcp 2.0 removed mcp.server.fastmcp, which mcp_server.py imports — see requirements.txt.
+    "mcp>=1.2.0,<2",
     "mitreattack-python",
     "openai",
     "pandas",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 langsmith
 litellm>=1.83.7
-mcp>=1.2.0
+# mcp 2.0 removed mcp.server.fastmcp (replaced by mcp.server.mcpserver.MCPServer),
+# which mcp_server.py imports. Hold on 1.x until that migration is done.
+mcp>=1.2.0,<2
 mitreattack-python
 openai
 pandas


### PR DESCRIPTION
Unblocks the **v0.15.0** release, whose test job failed on all four Python versions.

## What broke

```
tests/test_mcp_server.py:17: in <module>
    import mcp_server as s
mcp_server.py:32: in <module>
    from mcp.server.fastmcp import FastMCP
E   ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

**`mcp 2.0.0` shipped and removed `mcp.server.fastmcp` outright.** The server class is now `mcp.server.mcpserver.MCPServer`. Our constraint was unbounded (`mcp>=1.2.0`), so a fresh CI install resolved to 2.0.0 while local environments pinned earlier (1.28.1 here) kept passing — the failure only appears when the dependency tree is built from scratch, which is exactly what a release does.

## The fix

Cap at `<2` in both `requirements.txt` and `pyproject.toml`. Migrating `mcp_server.py` to the 2.0 `MCPServer` API is real work that doesn't belong in a release commit; the cap makes that upgrade an explicit, testable change instead of something a fresh install does silently.

## Verification

Reproduced the CI environment in a clean venv built from `requirements-dev.txt`:

| | Before | After |
|---|---|---|
| Resolved `mcp` | 2.0.0 | **1.29.0** (highest 1.x, still exports `mcp.server.fastmcp`) |
| `pytest` | 2 collection errors, exit 2 | **239 passed, exit 0** |

## Worth knowing

`release.yml` is the **only** workflow that runs `pytest` — `security.yml` runs scans alone. The suite therefore never runs on a PR and executes for the first time when a version tag is pushed, which is why this surfaced at release time rather than on #64/#65/#66. Adding a test job to PRs would have caught it days earlier; happy to do that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)