### PR TITLE
fix(security): cut scan noise and clear the actionable image CVEs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -120,12 +120,18 @@ jobs:
         run: docker build -t attackgen:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: attackgen:${{ github.sha }}
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'
+          # `severity` alone does not apply to SARIF output; without this the
+          # Security tab also collects LOW/UNKNOWN base-image findings.
+          limit-severities-for-sarif: true
+          # Base-image CVEs with no vendor patch cannot be actioned here, and
+          # they crowd out the findings that can be.
+          ignore-unfixed: true
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v3
@@ -134,11 +140,12 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy in table format
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: attackgen:${{ github.sha }}
           format: 'table'
           severity: 'CRITICAL,HIGH,MEDIUM'
+          ignore-unfixed: true
 
   dependency-review:
     name: Dependency Review

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use specific version with SHA256 for reproducibility and security
-FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
+FROM python:3.12-slim@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36
 
 # Create non-root user for security
 RUN groupadd -r attackgen && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,8 @@ mitreattack-python
 openai
 pandas
 python-dotenv
-setuptools
+# The base image preinstalls setuptools, so an unpinned requirement is already
+# satisfied and pip never upgrades it. Floor it above CVE-2025-47273 (78.1.1)
+# and CVE-2026-59890 (83.0.0) so the image build actually pulls a fixed version.
+setuptools>=83.0.0
 streamlit

--- a/tests/test_scenario_page.py
+++ b/tests/test_scenario_page.py
@@ -87,7 +87,7 @@ def stub_streamlit(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     monkeypatch.setattr(st, "warning", _noop)
     monkeypatch.setattr(st, "error", _noop)
     # `render_feedback_widget` calls `st.empty()` then `st.markdown('---')`.
-    monkeypatch.setattr(st, "empty", lambda: _FakePlaceholder())
+    monkeypatch.setattr(st, "empty", _FakePlaceholder)
     # `st.secrets` membership tests — pretend no LangSmith key is configured
     # so the feedback widget short-circuits cleanly during tests.
     monkeypatch.setattr(st, "secrets", {})


### PR DESCRIPTION
## Why

The Security tab had **223 open alerts** — 1 from CodeQL, 222 from Trivy. Triaging them showed the volume was mostly configuration, not risk:

| Bucket | Count | Actionable? |
|---|---|---|
| Base-image OS packages, **no vendor patch** | 173 | No — includes all 4 criticals (perl, Storable, Archive::Tar) |
| Base-image OS packages, **fix available** | 46 | Yes — openssl ×3 packages, liblzma5 |
| Python packages in the image | 3 | Partly — see below |
| Your own code (CodeQL) | 1 | Yes — cosmetic |

## What changed

**1. Trivy reporting config** (`security.yml`)

`severity: 'CRITICAL,HIGH,MEDIUM'` was already set, but trivy-action only applies it to SARIF when `limit-severities-for-sarif` is also true — which is why 96 LOW and 29 UNKNOWN findings still reached the Security tab. Added that, plus `ignore-unfixed: true` to drop the 173 findings with no available patch.

**2. Base image digest**

The pinned digest was built **2026-05-19**, roughly three months stale. Verified the new digest carries the fixed packages:

```
liblzma5             5.8.1-1+deb13u1   (was 5.8.1-1)
libssl3t64           3.5.6-1~deb13u2   (was 3.5.6-1~deb13u1)
openssl              3.5.6-1~deb13u2
openssl-provider-legacy  3.5.6-1~deb13u2
```

That clears all 46 fixable OS alerts, including **CVE-2026-45447** (high — OpenSSL PKCS#7/S-MIME use-after-free).

**3. `setuptools>=83.0.0`**

Clears CVE-2025-47273 (high) and CVE-2026-59890 (medium). Confirmed the built image now ships setuptools 84.0.0.

**4. CodeQL `py/unnecessary-lambda`**

`_FakePlaceholder` defines no `__init__`, so passing the class directly is exactly equivalent to `lambda: _FakePlaceholder()`.

**5. trivy-action pinned to a release SHA** rather than `@master` — a mutable ref in a security workflow.

## One alert this does *not* fix

`GHSA-6v7p-g79w-8964` (high, msgpack 1.1.2) **will remain open**. msgpack is not a project dependency — it is pip's vendored copy at `pip/_vendor/msgpack`, and current pip (26.2.1) still vendors 1.1.2. `ignore-unfixed` won't suppress it because a fixed version (1.2.1) exists upstream. It is only reachable through pip's own HTTP cache path, not app runtime, so it is a reasonable dismissal until pip revendors.

## Expected result

Trivy findings in the Security tab: **222 → 1**. CodeQL: **1 → 0**.

## Verification

- Image builds clean (`pip check` passes as part of the build)
- `setuptools 84.0.0`, fixed openssl/liblzma5 confirmed in the built image
- Full suite: **242 passed**
- Workflow YAML parses, both Trivy steps carry the intended inputs

## Not included

Dependabot alerts and GitHub secret scanning are **disabled** at the repo level — both are settings changes, not code, so they aren't in this PR. Worth enabling: nothing currently watches the dependency tree between builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)