### PR TITLE
fix(security): stop Trivy reporting pip's vendored SBOM as installed packages

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -132,6 +132,12 @@ jobs:
           # Base-image CVEs with no vendor patch cannot be actioned here, and
           # they crowd out the findings that can be.
           ignore-unfixed: true
+          # pip ships a CycloneDX SBOM of its own vendored tree. Trivy parses it
+          # and reports those pins as installed packages, which they are not:
+          # it claimed setuptools 70.3.0 while site-packages held 84.0.0. Only
+          # pip imports pip._vendor, and it does not run in the container at
+          # runtime. Real site-packages metadata is still scanned.
+          skip-files: 'usr/local/lib/python3.12/site-packages/pip/_vendor/bom.cdx.json'
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v3
@@ -146,6 +152,7 @@ jobs:
           format: 'table'
           severity: 'CRITICAL,HIGH,MEDIUM'
           ignore-unfixed: true
+          skip-files: 'usr/local/lib/python3.12/site-packages/pip/_vendor/bom.cdx.json'
 
   dependency-review:
     name: Dependency Review

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,9 @@ mitreattack-python
 openai
 pandas
 python-dotenv
-# The base image preinstalls setuptools, so an unpinned requirement is already
-# satisfied and pip never upgrades it. Floor it above CVE-2025-47273 (78.1.1)
-# and CVE-2026-59890 (83.0.0) so the image build actually pulls a fixed version.
+# Floor kept as a guard so a future resolve cannot land on a version below the
+# CVE-2025-47273 (78.1.1) and CVE-2026-59890 (83.0.0) fixes. It is not what
+# cleared those alerts — they were never about the installed setuptools, which
+# already resolved to 84.0.0. See the skip-files note in security.yml.
 setuptools>=83.0.0
 streamlit


### PR DESCRIPTION
Follow-up to #73, which took the Security tab from 223 open alerts to 3. This clears the last 3 — and corrects a claim in #73 that turned out to be wrong.

## What the remaining 3 actually were

| Alert | Package | "Installed" |
|---|---|---|
| CVE-2025-47273 (high) | setuptools | 70.3.0 |
| CVE-2026-59890 (medium) | setuptools | 70.3.0 |
| GHSA-6v7p-g79w-8964 (high) | msgpack | 1.1.2 |

None describes a package the image installs. The build log shows `Successfully installed … setuptools-84.0.0`, and no file on the image filesystem contains the string `70.3.0` — I searched, text and binary.

The source is `/usr/local/lib/python3.12/site-packages/pip/_vendor/bom.cdx.json`, a CycloneDX SBOM that pip 26.x ships describing its own vendored tree. Trivy parses embedded SBOMs and surfaces those pins as installed packages. That explains two things that were otherwise confusing: the findings appear under a bare `Python` target with **no file path**, and the bare base image is clean (it carries pip 25.0.1, which predates the SBOM).

## Why not the other options

- **`setuptools>=83.0.0` (added in #73)** — could never have fixed these. They were never about the installed setuptools. Keeping the floor as a guard, with a corrected comment.
- **`ignore-unfixed`** — doesn't apply; fixed versions exist upstream.
- **Dismissing the alerts** — hides them one at a time and they return if the fingerprint shifts.
- **`.trivyignore` by CVE ID** — would also mask those same CVEs in a *real* dependency. Skipping the SBOM file is narrower.

## Trade-off

The scan no longer sees vulnerabilities in pip's vendored packages. Only pip imports `pip._vendor`, and pip does not run in the container at runtime — it is build-time tooling. Real `site-packages` metadata is still scanned, so genuine dependency vulnerabilities are unaffected.

## Verification

Local build, Trivy 0.36-equivalent, with a control:

```
with    skip-files -> NO python-pkg vulns remaining
without skip-files -> msgpack 1.1.2, setuptools 70.3.0 x2
```

I also confirmed the source by elimination: deleting `pip/_vendor/vendor.txt` did *not* clear the findings, which ruled out the vendor manifest and pointed at the SBOM.

Expected result: Trivy alerts **3 → 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)