### PR TITLE
chore(deps): let Dependabot track GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,32 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+
+  # Monitor GitHub Actions used by the workflows. Without this, pinned refs
+  # go stale silently — trivy-action is pinned to a commit SHA, which has no
+  # other update path, and the two workflows have already drifted apart on
+  # shared actions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "mrwadams"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    # Group minor and patch updates together to reduce PR noise, matching the
+    # pip ecosystem above. Major bumps still arrive as individual PRs.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Adds a third ecosystem to `.github/dependabot.yml`. Config-only — no workflow behaviour changes in this PR.

## Why

`dependabot.yml` covered `pip` and `docker`, but not `github-actions`. Nothing was keeping the workflow action refs current.

That gap matters more since #73, which pinned `trivy-action` to a commit SHA:

```yaml
uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
```

Pinning to a SHA is the right call for an action running inside a security workflow — but a SHA never moves on its own. Without a Dependabot ecosystem watching it, that pin has **no update path at all**. It's the same failure mode as the base image digest, which sat three months stale until we bumped it by hand earlier today.

## Already drifting

The two workflows have diverged on actions they share:

| Action | `security.yml` | `release.yml` |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-python` | v5 | v6 |

Deliberately **not** changing those here — that's a separate call about whether the older majors still work for those jobs. Dependabot will raise them as PRs once this lands, which is the point.

## Shape of the config

Mirrors the existing entries: weekly on Monday at 09:00, same `dependencies` label plus an ecosystem-specific one, same reviewer, same `deps` commit prefix. Minor/patch updates are grouped into a single PR the way the `pip` ecosystem already does; major bumps still arrive individually, since those are the ones worth reading.

`open-pull-requests-limit: 5`, matching the docker entry.

## Verification

Parses as a valid v2 config with three ecosystems:

```
pip              dir=/ interval=weekly groups=['python-dependencies']
docker           dir=/ interval=weekly groups=-
github-actions   dir=/ interval=weekly groups=['github-actions']
```

## Related, not in this PR

Dependabot **alerts** and **secret scanning** are still disabled at the repo level — those are settings toggles rather than code. This PR covers version updates for actions only.

Separately: the `docker` ecosystem hasn't opened a PR since 2025-11-11 despite the base digest going stale, which is worth a look under Insights → Dependency graph → Dependabot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)