### PR TITLE
feat(docker): move base image to python 3.14-slim

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -137,7 +137,7 @@ jobs:
           # it claimed setuptools 70.3.0 while site-packages held 84.0.0. Only
           # pip imports pip._vendor, and it does not run in the container at
           # runtime. Real site-packages metadata is still scanned.
-          skip-files: 'usr/local/lib/python3.12/site-packages/pip/_vendor/bom.cdx.json'
+          skip-files: 'usr/local/lib/python3.14/site-packages/pip/_vendor/bom.cdx.json'
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v3
@@ -152,7 +152,7 @@ jobs:
           format: 'table'
           severity: 'CRITICAL,HIGH,MEDIUM'
           ignore-unfixed: true
-          skip-files: 'usr/local/lib/python3.12/site-packages/pip/_vendor/bom.cdx.json'
+          skip-files: 'usr/local/lib/python3.14/site-packages/pip/_vendor/bom.cdx.json'
 
   dependency-review:
     name: Dependency Review

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use specific version with SHA256 for reproducibility and security
-FROM python:3.12-slim@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36
+FROM python:3.14-slim@sha256:a7fb1e634c4a578f9e0bd6327f11a3cde11b7a9395f48e24360c0988bcc5c2bc
 
 # Create non-root user for security
 RUN groupadd -r attackgen && \


### PR DESCRIPTION
Takes the upgrade Dependabot proposed in #24 back in November, which was closed at the time.

## Why now

The Dependabot job log explains why the docker ecosystem has produced nothing since #24 was closed:

```
INFO Latest version is 3.14-slim
INFO Pull request #24 already exists for python with latest version 3.14-slim
```

`ignore-conditions` is empty — there's no ignore rule. Dependabot resolves the latest version of this image as `3.14-slim`, sees #24 recorded in `existing-pull-requests`, and stops. It never evaluates a digest refresh of `3.12-slim`, which is why the base sat three months stale and both recent digest bumps were done by hand.

Landing 3.14 clears that marker, so the docker ecosystem starts working again.

## Changes

| File | Change |
|---|---|
| `Dockerfile` | `3.12-slim` → `3.14-slim`, pinned by digest `sha256:a7fb1e63…` (built 2026-08-05) |
| `security.yml` | Repointed the `skip-files` path from #74 to `python3.14` |
| `release.yml` | Added `3.14` to the test matrix |

**The `skip-files` change is the one worth a second look.** The path added in #74 is interpreter-version specific:

```
usr/local/lib/python3.12/site-packages/pip/_vendor/bom.cdx.json
```

A base bump alone would leave it pointing at a directory that no longer exists. It wouldn't error — it would silently stop matching, and the three pip-vendored SBOM findings would quietly come back.

The matrix change matters for a similar reason: it stopped at 3.13, so the published image would have run a Python version CI never tested.

## Verification

Built this branch and ran against it:

- **Python 3.14.7**
- **Full suite: 242 passed** — same as on 3.12
- Every `core.*` module plus `mcp_server` imports cleanly
- Dependencies resolve with no conflicts: streamlit 1.61.1, litellm 1.96.0, mitreattack-python 6.2.0, mcp 1.29.0, pandas 3.0.5, numpy 2.5.2, pyarrow 24.0.0
- Trivy using the workflow's own flags (`--ignore-unfixed --severity CRITICAL,HIGH,MEDIUM --skip-files …`): **no findings**

Control run to prove the repointed path is doing the work rather than the base change masking it:

```
with    skip-files -> NO findings
without skip-files -> msgpack 1.1.2, setuptools 70.3.0 x2
```

## Note

The README's v0.12 release note mentions `python:3.12-slim`. Left as-is — it's a historical record of what that release did, not a statement of current state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)