### PR TITLE
chore(deps): move all actions off the Node 20 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -55,7 +55,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload security reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: python-security-reports
@@ -70,12 +70,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
@@ -91,19 +91,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"
 
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build Docker image
         run: docker build -t attackgen:${{ github.sha }} .
@@ -140,7 +140,7 @@ jobs:
           skip-files: 'usr/local/lib/python3.14/site-packages/pip/_vendor/bom.cdx.json'
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
@@ -161,10 +161,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: moderate
           deny-licenses: GPL-3.0, AGPL-3.0


### PR DESCRIPTION
Supersedes #77, #78, #79, #80 and #81 — closes all five on merge.

## Why one PR

Those five Dependabot PRs are a single change wearing five hats. Every action in `security.yml` declares `node20`:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 `node20` | v7 `node24` |
| `actions/setup-python` | v5 `node20` | v7 `node24` |
| `actions/upload-artifact` | v4 `node20` | v7 `node24` |
| `github/codeql-action/*` | v3 `node20` | v4 `node24` |
| `gitleaks/gitleaks-action` | v2 `node20` | v3 `node24` |
| `actions/dependency-review-action` | v4 `node20` | v5 `node24` |

GitHub [removes Node 20 from hosted runners on 16 September 2026](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Since March the runner has been force-substituting Node 24; after that date the fallback goes away and this workflow breaks.

It is already warning on every run:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/checkout@v4, actions/setup-python@v5,
actions/upload-artifact@v4.
```

All five PRs edit the same file, so merging them individually means five serial rebases and five CI rounds for one logical change.

## What the five PRs would have missed

**`actions/setup-python@v5`.** It is `node20`, it is named in the warning above, and no Dependabot PR covers it — nor has one ever been opened for it. Merging all five would still have left the workflow breaking in September.

This PR takes it to v7 in `security.yml` and also bumps `release.yml` from v6 to v7, so both workflows agree. That version split is a plausible reason the updater skipped it — flagging that as a hypothesis rather than something the job logs confirm.

## On codeql-action v4

Worth merging on its own merits regardless of Node: v3 is deprecated in December 2026, and the runs already emit that as a separate warning.

## Verification

Both workflows parse. Every action reference across both now resolves to `node24`, or is `composite`/`docker`:

```
actions/checkout@v7                       node24
actions/dependency-review-action@v5       node24
actions/setup-python@v7                   node24
actions/upload-artifact@v7                node24
aquasecurity/trivy-action@ed142fd0…       composite
docker/* (5 actions)                      node24
github/codeql-action/* (4 actions)        node24
gitleaks/gitleaks-action@v3               node24
pyupio/safety-action@v1                   docker
softprops/action-gh-release@v3            node24

node20 actions remaining: NONE
```

Behavioural checks on the majors:

- **checkout v7** blocks fork checkouts for `pull_request_target`/`workflow_run`; both workflows use plain `pull_request`, so unaffected. Already in use in `release.yml`, so proven in this repo. `fetch-depth: 0` still supported.
- **setup-python v7** removes the `pip-install` input — neither workflow uses it. `python-version` and `cache` unchanged.
- **upload-artifact v7** adds an optional `archive` input; defaults unchanged, and the existing `name`/`path`/`retention-days` usage is untouched.
- **gitleaks v3** is a runtime-only bump — *"No changes to inputs, outputs, or behavior."*
- **dependency-review v5** needs runner ≥2.327.1, satisfied by `ubuntu-latest`.

`trivy-action` stays pinned to its commit SHA from #73 — untouched.

## Separately

While reviewing I saw a `failure: Process completed with exit code 1` annotation on a job reporting success. I could not attribute it to a step on a second pass, so it is not addressed here — but `python-security` runs bandit, pip-audit and safety with `continue-on-error: true`, which would let a failing security tool pass silently. Worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)