### PR TITLE
fix(security): make pip-audit gate, drop the Safety step

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,15 +47,14 @@ jobs:
 
       - name: Run pip-audit for dependency vulnerabilities
         run: |
+          # Full-fidelity report for the artifact, same split as Bandit above.
           pip-audit --desc --format json > pip-audit-report.json || true
+          # The gate. pip-audit exits non-zero on any known vulnerability.
+          # If a transitive dependency picks up a CVE with no fix available,
+          # suppress it here with `--ignore-vuln GHSA-xxxx` and a reason, so
+          # the exception lands in a reviewable diff rather than being blanket
+          # ignored by continue-on-error.
           pip-audit --desc
-        continue-on-error: true
-
-      - name: Run Safety Action to check for vulnerabilities
-        uses: pyupio/safety-action@v1
-        with:
-          api-key: ${{ secrets.SAFETY_API_KEY }}
-        continue-on-error: true
 
       - name: Upload security reports
         uses: actions/upload-artifact@v7

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,7 +77,7 @@ When deploying AttackGen:
 1. **Dependency Management**
    - Regularly update dependencies to patch security vulnerabilities
    - Review `requirements.txt` for outdated or vulnerable packages
-   - Automated scanning with `pip-audit` and `safety` runs on every commit (see Automated Security Scanning section)
+   - Automated scanning with `pip-audit` runs on every commit and fails the build on a known vulnerability (see Automated Security Scanning section)
 
 2. **Input Validation**
    - The application validates inputs, but always review user-provided data
@@ -101,7 +101,6 @@ Our security workflow runs automatically on every push and pull request, using:
 
 2. **Dependency Scanning**
    - **pip-audit**: Scans Python dependencies against the OSV vulnerability database
-   - **Safety**: Checks dependencies using PyUp's comprehensive vulnerability database
    - **Dependabot**: Automated dependency updates and security alerts
 
 3. **Secret Detection**


### PR DESCRIPTION
Closes off the last two scanners that could fail silently. Follows #84, which fixed the same masking on Bandit.

## What was actually happening

Both steps carried `continue-on-error: true`. Neither is failing today, so nothing was being hidden right now — but neither could ever have told you if that changed. That is the same pattern as the Bandit step, which had been red on every run since it was added and reported `conclusion=success` throughout.

Checking the last run on `main` ([`31378308317`](https://github.com/mrwadams/attackgen/actions/runs/31378308317)) turned up a second problem, specific to Safety:

```
Scan policy: fetched from Safety Platform, ignoring any local Safety CLI policy files
✅ requirements.txt: No issues found.
Tested 17 dependencies for security issues using policy fetched from Safety Platform
56 vulnerabilities found, 56 ignored due to policy.
```

It found 56 and suppressed all 56. The policy doing the suppressing lives on the SafetyCLI dashboard, not in this repo — so the suppression list is invisible in a diff and unreviewable in a PR. A green tick from that step means "the dashboard says so", which is not a property this repo controls.

## pip-audit — now a gate

`continue-on-error` removed. It reports `No known vulnerabilities found`, needs no secret, and works on fork PRs, so there is nothing to trade off.

The JSON run keeps its `|| true` so the artifact still gets full-fidelity output even when the gate fails — same split as Bandit.

If a transitive dependency later picks up a CVE with no fix available, the escape hatch is `--ignore-vuln GHSA-xxxx` with a reason in the workflow. That is deliberate: it keeps the exception in a reviewable diff, consistent with the `# nosec B310` in `scripts/generate_atlas_case_studies.py` and the `skip-files` note in this workflow.

## Safety — removed

Two reasons, either sufficient on its own:

1. **It contributes no signal.** All 56 findings are suppressed by a remote policy. Leaving the step in place implies coverage that is not there.
2. **It breaks on fork PRs.** GitHub does not expose secrets to `pull_request` events from forks, so `SAFETY_API_KEY` would be empty and `safety scan` would fail unauthenticated. This repo is public and has taken 5 fork PRs historically — none ran this workflow, as they predate it, but the next one would hit this. A step-level `if` cannot read the `secrets` context, so guarding it means hoisting the key into `env` first. Not worth the machinery for a step reporting nothing.

pip-audit covers dependency scanning with its configuration in the repo and no key required. Safety's database is proprietary and genuinely broader than OSV, so this is a real if small reduction in coverage — worth restoring only alongside a policy that actually reports something.

**`SAFETY_API_KEY` is now unused and can be revoked.**

## Docs

`SECURITY.md` claimed Safety runs on every commit. Corrected, and the pip-audit line now states that it fails the build. The `README.md` mentions are historical changelog entries for past releases and are left alone.

## After this

Every step in `security.yml` can now fail the job. No scanner in this workflow is advisory-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)