### PR TITLE
Neutral, dead-end-free threat-group and case-study selectors

### DIFF
--- a/core/attack_data.py
+++ b/core/attack_data.py
@@ -24,6 +24,7 @@ Parity with the old page-1 logic is deliberate and load-bearing:
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
@@ -130,6 +131,21 @@ def list_case_studies() -> tuple[dict, ...]:
     return tuple(out)
 
 
+def _natural_sort_key(name: str) -> list:
+    """Sort key that reads digit runs as numbers, not text.
+
+    A plain string sort orders ``APT29`` before ``APT3`` before ``APT30`` (it
+    compares digit by digit). Splitting on digit runs and comparing those runs
+    numerically gives the ordering a reader expects: ``APT3, APT28, APT29,
+    APT30``. Non-numeric names (``Lazarus Group``, ATLAS case studies) fall back
+    to a case-insensitive text compare.
+    """
+    return [
+        int(token) if token.isdigit() else token.casefold()
+        for token in re.split(r"(\d+)", name)
+    ]
+
+
 @lru_cache(maxsize=3)
 def list_usable_scenario_options(matrix: str) -> tuple[dict, ...]:
     """Return only groups/case studies that can produce a scenario.
@@ -185,6 +201,7 @@ def list_usable_scenario_options(matrix: str) -> tuple[dict, ...]:
             "aliases": aliases,
             "label": label,
         })
+    options.sort(key=lambda option: _natural_sort_key(option["group"]))
     return tuple(options)
 
 

--- a/core/attack_data.py
+++ b/core/attack_data.py
@@ -130,6 +130,64 @@ def list_case_studies() -> tuple[dict, ...]:
     return tuple(out)
 
 
+@lru_cache(maxsize=3)
+def list_usable_scenario_options(matrix: str) -> tuple[dict, ...]:
+    """Return only groups/case studies that can produce a scenario.
+
+    Each option contains ``group``, ``url``, ``aliases`` and a searchable
+    ``label``. ATT&CK aliases are included in that label without changing the
+    canonical group value returned after selection. ATLAS case studies have no
+    aliases.
+
+    A candidate is omitted if kill-chain resolution fails or produces no
+    techniques. For ATLAS, resolution also verifies that the case study has a
+    procedure and that its technique IDs exist in the shipped ATLAS bundle.
+    """
+    if matrix == "ATLAS":
+        candidates = list_case_studies()
+        mitre = None
+    elif matrix in _GROUPS_FILE:
+        candidates = list_threat_groups(matrix)
+        mitre = mitre_data_for_matrix(matrix)
+    else:
+        raise ValueError(f"Unknown matrix '{matrix}'.")
+
+    options = []
+    for candidate in candidates:
+        name = candidate["group"]
+        try:
+            kill_chain = (
+                resolve_case_study_kill_chain(name)
+                if matrix == "ATLAS"
+                else resolve_threat_group_kill_chain(matrix, name, seed=0)
+            )
+        except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+            continue
+        if not kill_chain.techniques:
+            continue
+
+        aliases: tuple[str, ...] = ()
+        if mitre is not None:
+            matches = mitre.get_groups_by_alias(name)
+            if matches:
+                aliases = tuple(
+                    dict.fromkeys(
+                        str(alias)
+                        for alias in (getattr(matches[0], "aliases", None) or [])
+                        if str(alias).casefold() != name.casefold()
+                    )
+                )
+
+        label = f"{name} (aliases: {', '.join(aliases)})" if aliases else name
+        options.append({
+            "group": name,
+            "url": candidate["url"],
+            "aliases": aliases,
+            "label": label,
+        })
+    return tuple(options)
+
+
 def list_technique_options(matrix: str) -> list[dict]:
     """All selectable techniques for a matrix, for the Custom page multiselect.
 

--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -3,6 +3,7 @@ import streamlit as st
 
 from core.ai_uplift import is_ai_uplift_on, render_ai_uplift_toggle, uplift_trace_tags
 from core.attack_data import (
+    list_usable_scenario_options,
     load_attack_data,
     resolve_case_study_kill_chain,
     resolve_threat_group_kill_chain,
@@ -38,11 +39,10 @@ attack_data = load_attack_data()
 
 @st.cache_resource
 def load_groups(matrix):
-    if matrix == "Enterprise":
-        return pd.read_json("./data/groups.json")
-    if matrix == "ICS":
-        return pd.read_json("./data/groups_ics.json")
-    return pd.read_json("./data/atlas-case-studies.json")
+    return pd.DataFrame(
+        list_usable_scenario_options(matrix),
+        columns=["group", "url", "aliases", "label"],
+    )
 
 
 # ------------------ Prompt Construction ------------------ #
@@ -147,14 +147,15 @@ else:
     entity_label = "threat actor group"
     select_placeholder = "Select Group"
 
-group_names = sorted(groups['group'].unique())
-default_index = 0 if group_names else None
+group_names = sorted(groups["group"].unique())
+group_labels = dict(zip(groups["group"], groups["label"]))
 
 selected_group_alias = st.selectbox(
     f"Select a {entity_label} for the scenario",
     group_names,
-    index=default_index,
+    index=None,
     placeholder=select_placeholder,
+    format_func=group_labels.__getitem__,
     label_visibility="hidden",
 )
 
@@ -163,7 +164,7 @@ techniques_df = pd.DataFrame()
 selected_techniques_df = pd.DataFrame()
 
 try:
-    if selected_group_alias != select_placeholder:
+    if selected_group_alias is not None:
         group_url = groups[groups['group'] == selected_group_alias]['url'].values[0]
         if matrix == "ATLAS":
             st.markdown(f"[View case study on atlas.mitre.org]({group_url})")

--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -147,7 +147,10 @@ else:
     entity_label = "threat actor group"
     select_placeholder = "Select Group"
 
-group_names = sorted(groups["group"].unique())
+# Options arrive already in natural-sorted order from list_usable_scenario_options
+# (APT3, APT28, APT29, APT30…), so preserve that rather than re-sorting the labels
+# as plain strings.
+group_names = list(groups["group"].unique())
 group_labels = dict(zip(groups["group"], groups["label"]))
 
 selected_group_alias = st.selectbox(

--- a/tests/test_attack_data.py
+++ b/tests/test_attack_data.py
@@ -178,6 +178,27 @@ def test_every_shipped_threat_group_option_resolves(matrix):
             ).techniques
 
 
+def test_natural_sort_key_orders_apt_numbers_numerically():
+    # A plain string sort interleaves APT3 between APT29 and APT30; the natural
+    # key must read the digit run as a number so APT3 precedes both.
+    names = ["APT30", "APT3", "APT29", "APT1", "Lazarus Group", "apt28"]
+    assert sorted(names, key=ad._natural_sort_key) == [
+        "APT1",
+        "APT3",
+        "apt28",
+        "APT29",
+        "APT30",
+        "Lazarus Group",
+    ]
+
+
+@pytest.mark.parametrize("matrix", ["Enterprise", "ICS"])
+def test_scenario_options_are_natural_sorted(matrix):
+    options = ad.list_usable_scenario_options(matrix)
+    names = [option["group"] for option in options]
+    assert names == sorted(names, key=ad._natural_sort_key)
+
+
 def test_every_shipped_atlas_option_has_a_usable_procedure():
     options = ad.list_usable_scenario_options("ATLAS")
     assert options, "expected selectable ATLAS case studies"

--- a/tests/test_attack_data.py
+++ b/tests/test_attack_data.py
@@ -9,7 +9,9 @@ kill-chain string format, seed determinism, and JSON-native output.
 
 from __future__ import annotations
 
+import ast
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -150,6 +152,67 @@ class TestListings:
     def test_unknown_matrix_raises(self):
         with pytest.raises(ValueError):
             ad.list_threat_groups("Mobile")
+
+
+@pytest.mark.parametrize("matrix", ["Enterprise", "ICS"])
+def test_every_shipped_threat_group_option_resolves(matrix):
+    options = ad.list_usable_scenario_options(matrix)
+    assert options, f"expected selectable {matrix} groups"
+
+    enabled_names = {option["group"] for option in options}
+    assert any(option["aliases"] for option in options)
+    for option in options:
+        assert set(option) == {"group", "url", "aliases", "label"}
+        assert option["group"] in option["label"]
+        assert all(alias in option["label"] for alias in option["aliases"])
+        assert ad.resolve_threat_group_kill_chain(
+            matrix, option["group"], seed=0
+        ).techniques
+
+    # The shipped mappings currently contain groups whose relationships belong
+    # to another ATT&CK matrix. They must be filtered rather than selectable.
+    for candidate in ad.list_threat_groups(matrix):
+        if candidate["group"] not in enabled_names:
+            assert not ad.resolve_threat_group_kill_chain(
+                matrix, candidate["group"], seed=0
+            ).techniques
+
+
+def test_every_shipped_atlas_option_has_a_usable_procedure():
+    options = ad.list_usable_scenario_options("ATLAS")
+    assert options, "expected selectable ATLAS case studies"
+
+    data_path = Path(__file__).parents[1] / "data" / "atlas-case-studies.json"
+    studies = {study["group"]: study for study in json.loads(data_path.read_text())}
+    enabled_names = {option["group"] for option in options}
+    for option in options:
+        assert option["aliases"] == ()
+        assert studies[option["group"]]["procedure"]
+        assert ad.resolve_case_study_kill_chain(option["group"]).techniques
+
+    for name in studies.keys() - enabled_names:
+        procedure = studies[name].get("procedure")
+        assert not procedure or not ad.resolve_case_study_kill_chain(name).techniques
+
+
+def test_threat_group_selector_has_no_implicit_selection_and_keeps_search_labels():
+    page_path = (
+        Path(__file__).parents[1] / "pages" / "1_🛡️_Threat_Group_Scenarios.py"
+    )
+    tree = ast.parse(page_path.read_text())
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "selectbox"
+    ]
+    assert len(calls) == 1
+    keywords = {keyword.arg: keyword.value for keyword in calls[0].keywords}
+    assert isinstance(keywords["index"], ast.Constant)
+    assert keywords["index"].value is None
+    # The formatted labels contain aliases and are what Streamlit searches.
+    assert "format_func" in keywords
 
 
 class TestMitreDataForMatrix:


### PR DESCRIPTION
Automated by **agent-loop** — pi worked this issue on a fresh clone of `mrwadams/attackgen`; changes were gated outside the agent on agent-1.

Closes #47

## How to test
```bash
git fetch origin && git checkout agent/issue-47
python3 -m venv .venv && . .venv/bin/activate
pip install -r requirements.txt
streamlit run "00_👋_Welcome.py"
```
Then open the printed local URL.

**Confirm each acceptance criterion:**
- [x] Threat-group and ATLAS case-study selectors have no pre-selected first item; the first visible state is a neutral prompt
- [x] Every selectable group resolves to at least one associated technique; every selectable ATLAS case study has a usable procedure and extracted technique set
- [x] Groups/case studies with no usable techniques are removed or explicitly disabled with a reason, not silently selectable
- [x] Search by group name and alias remains available
- [x] Tests against the shipped Enterprise, ICS, and ATLAS data assert every enabled option resolves to ≥1 technique and that no implicit first selection exists

## Gates (non-authoritative)
- ✅ **files_non_empty** — 3 non-empty file(s) changed
- ✅ **containment** — diff stays within the allowed lane
- ✅ **verify** — pytest: 247 passed, no failures (browser/e2e excluded)

> **Draft.** Browser/e2e tests were NOT run in-gate — run them and review before merging. Nothing here is auto-merged.