### PR TITLE
Base-scenario-first phased generation

### DIFF
--- a/core/scenario_page.py
+++ b/core/scenario_page.py
@@ -12,10 +12,14 @@ Adding a new scenario page is now: write the widgets and prompt builder, then
 
 from __future__ import annotations
 
+import copy
+import inspect
 import json
 import re
+import time
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
+from typing import Any
 
 import streamlit as st
 
@@ -33,6 +37,28 @@ from core.schemas import LLMConfig
 
 Message = dict
 """A single chat message: ``{"role": "...", "content": "..."}``."""
+
+Snapshot = dict[str, Any]
+
+
+def _invoke_with_snapshot(callback: Callable, snapshot: Snapshot):
+    """Call a generation callback with its snapshot when it accepts one.
+
+    The no-argument form remains supported for callers outside the three main
+    pages, but snapshot-aware callbacks are what prevent mutable widgets from
+    changing an in-flight generation's prompt or exports.
+    """
+    try:
+        inspect.signature(callback).bind(snapshot)
+    except (TypeError, ValueError):
+        return callback()
+    return callback(snapshot)
+
+
+def _elapsed_label(phase: str, started: float) -> str:
+    elapsed = max(0, int(time.monotonic() - started))
+    minutes, seconds = divmod(elapsed, 60)
+    return f"{phase} · elapsed {minutes}:{seconds:02d}"
 
 
 def _unique_filenames(download_name: str) -> tuple[str, str, str]:
@@ -59,7 +85,7 @@ def _unique_filenames(download_name: str) -> tuple[str, str, str]:
 def run_scenario_page(
     *,
     page_id: str,
-    build_messages: Callable[[], list[Message] | None],
+    build_messages: Callable[..., list[Message] | None],
     is_ready: Callable[[], bool],
     download_name: str,
     trace_name: str,
@@ -67,9 +93,10 @@ def run_scenario_page(
     status_text: str = "Generating scenario...",
     button_label: str = "Generate Scenario",
     inline_control: Callable[[], None] | None = None,
-    build_layer: Callable[[], str | None] | None = None,
-    build_defense: Callable[[], dict | None] | None = None,
+    build_layer: Callable[..., str | None] | None = None,
+    build_defense: Callable[..., dict | None] | None = None,
     defense_narrative: bool = False,
+    capture_inputs: Callable[[], Snapshot] | None = None,
 ) -> None:
     """Render the generate-button + scenario lifecycle for one scenario page.
 
@@ -98,6 +125,11 @@ def run_scenario_page(
     weaves those detections/mitigations into a stage-by-stage defender's
     walkthrough; the flag is read at generation time from the page's toggle.
 
+    ``capture_inputs`` returns JSON-native metadata describing the inputs at
+    the instant Generate is pressed. Snapshot-aware build callbacks receive a
+    deep copy of that mapping; no-argument callbacks remain supported for
+    compatibility. The snapshot is persisted with the result.
+
     ``download_name`` is a human base label (e.g. ``"AttackGen APT29
     Enterprise.md"``); the markdown and layer downloads get a sanitised,
     timestamped variant so files are meaningful and unique across scenarios.
@@ -107,6 +139,7 @@ def run_scenario_page(
     layer_key = f"{page_id}_scenario_layer"
     filename_key = f"{page_id}_scenario_filename"
     defense_key = f"{page_id}_scenario_defense"
+    snapshot_key = f"{page_id}_scenario_input_snapshot"
 
     st.session_state.setdefault(generated_key, False)
 
@@ -121,36 +154,38 @@ def run_scenario_page(
 
     rendered = False
     if clicked and is_ready():
-        messages = build_messages()
-        if messages is not None:
-            # Fix names now, at generation time, so the markdown and layer
-            # downloads share one timestamp and stay stable across the reruns a
-            # download click triggers. The Navigator layer is likewise captured
-            # from the technique set the model is about to see and persisted, so
-            # a later resample-on-rerun can't drift from it.
-            md_name, layer_name, defense_name = _unique_filenames(download_name)
-            layer_json = build_layer() if build_layer is not None else None
-            layer_payload = (layer_json, layer_name) if layer_json else None
-            defense_report = build_defense() if build_defense is not None else None
-            _generate_and_render(
-                messages=messages,
-                page_id=page_id,
-                trace_name=trace_name,
-                trace_tags=trace_tags,
-                status_text=status_text,
-                download_name=md_name,
-                human_name=download_name,
-                generated_key=generated_key,
-                text_key=text_key,
-                layer_key=layer_key,
-                filename_key=filename_key,
-                defense_key=defense_key,
-                layer_payload=layer_payload,
-                defense_report=defense_report,
-                defense_name=defense_name,
-                defense_narrative=defense_narrative,
-            )
-            rendered = True
+        # Freeze every user-controlled value before any slow work starts. Page
+        # callbacks receive this snapshot rather than consulting live widgets.
+        snapshot = copy.deepcopy(capture_inputs() if capture_inputs else {})
+        snapshot.setdefault("scenario_type", page_id)
+        snapshot.setdefault("captured_at", datetime.now(timezone.utc).isoformat())
+        identity = snapshot.setdefault("identity", {})
+        identity.setdefault("page_id", page_id)
+        identity.setdefault("trace_name", trace_name)
+        identity.setdefault("trace_tags", list(trace_tags))
+        identity.setdefault("provider", st.session_state.get("chosen_model_provider"))
+        identity.setdefault("model", st.session_state.get("llm_model_name"))
+        identity.setdefault("download_name", download_name)
+        st.session_state[snapshot_key] = snapshot
+
+        _generate_and_render(
+            snapshot=snapshot,
+            build_messages=build_messages,
+            build_layer=build_layer,
+            build_defense=build_defense,
+            page_id=page_id,
+            trace_name=trace_name,
+            trace_tags=trace_tags,
+            status_text=status_text,
+            human_name=download_name,
+            generated_key=generated_key,
+            text_key=text_key,
+            layer_key=layer_key,
+            filename_key=filename_key,
+            defense_key=defense_key,
+            defense_narrative=defense_narrative,
+        )
+        rendered = bool(st.session_state.get(generated_key))
 
     # Re-render the persisted scenario on a plain rerun (e.g. after clicking a
     # download button, which reruns the script with the generate button
@@ -174,86 +209,155 @@ def run_scenario_page(
 
 def _generate_and_render(
     *,
-    messages: list[Message],
+    snapshot: Snapshot,
+    build_messages: Callable[..., list[Message] | None],
+    build_layer: Callable[..., str | None] | None,
+    build_defense: Callable[..., dict | None] | None,
     page_id: str,
     trace_name: str,
     trace_tags: tuple[str, ...],
     status_text: str,
-    download_name: str,
     human_name: str,
     generated_key: str,
     text_key: str,
     layer_key: str,
     filename_key: str,
     defense_key: str,
-    layer_payload: tuple[str, str] | None,
-    defense_report: dict | None,
-    defense_name: str,
     defense_narrative: bool,
 ) -> None:
-    config = LLMConfig.from_session_state(
-        trace_name=trace_name,
-        trace_tags=trace_tags,
-    )
-    scenario_text: str | None = None
+    """Coordinate and expose each phase of a scenario generation."""
+    started = time.monotonic()
     stream_placeholder = st.empty()
+    result_placeholder = st.empty()
     raw_chunks: list[str] = []
+    scenario_text: str | None = None
 
-    def _tee(chunks):
-        for chunk in chunks:
-            raw_chunks.append(chunk)
-            yield chunk
+    def set_phase(status, phase: str, *, state: str = "running") -> None:
+        status.update(label=_elapsed_label(phase, started), state=state)
 
     try:
-        with st.status(status_text, expanded=True) as status:
-            st.write("Streaming response from the model.")
+        with st.status(_elapsed_label("Preparing inputs", started), expanded=True) as status:
+            st.write(
+                "Generation often takes 30–50 seconds; reasoning and local models may "
+                "take several minutes. You can follow each phase here."
+            )
+            messages = _invoke_with_snapshot(build_messages, snapshot)
+            if messages is None:
+                status.update(label="No scenario inputs were available.", state="error")
+                return
+            config = LLMConfig.from_session_state(
+                trace_name=trace_name,
+                trace_tags=trace_tags,
+            )
+
+            set_phase(status, "Generating base scenario")
+            st.write(status_text)
+
+            def _tee(chunks):
+                for chunk in chunks:
+                    raw_chunks.append(chunk)
+                    # Streamlit renders the yielded delta immediately; refreshing
+                    # the label here keeps elapsed time visible as output arrives.
+                    set_phase(status, "Generating base scenario")
+                    yield chunk
+
             with stream_placeholder.container():
                 st.write_stream(
                     stream_filter_thinking(_tee(call_llm_stream(config, messages)))
                 )
             scenario_text = "".join(raw_chunks)
-            status.update(label="Scenario generated.", state="complete")
+            set_phase(status, "Base scenario available")
+
+            thinking, cleaned = clean_model_response(scenario_text)
+            if not cleaned:
+                status.update(label="The model returned no scenario.", state="error")
+                return
+
+            # Deterministic artifacts are built only after the base model has
+            # completed, and exclusively from the frozen input snapshot.
+            set_phase(status, "Building deterministic exports")
+            snapshot_human_name = (
+                snapshot.get("identity", {}).get("download_name") or human_name
+            )
+            md_name, layer_name, defense_name = _unique_filenames(snapshot_human_name)
+            layer_json = (
+                _invoke_with_snapshot(build_layer, snapshot) if build_layer else None
+            )
+            layer_payload = (layer_json, layer_name) if layer_json else None
+            defense_report = (
+                _invoke_with_snapshot(build_defense, snapshot) if build_defense else None
+            )
+            defense_state = _build_defense_state(
+                report=defense_report,
+                defense_name=defense_name,
+                human_name=snapshot_human_name,
+            )
+
+            # This is the key phase boundary: persist the base result, exports,
+            # and Assistant handoff before starting optional model enrichment.
+            stream_placeholder.empty()
+            st.markdown("---")
+            if thinking:
+                with st.expander("View Model's Reasoning"):
+                    st.markdown(thinking)
+            with result_placeholder.container():
+                _persist_and_render(
+                    cleaned=cleaned,
+                    page_id=page_id,
+                    download_name=md_name,
+                    generated_key=generated_key,
+                    text_key=text_key,
+                    layer_key=layer_key,
+                    filename_key=filename_key,
+                    defense_key=defense_key,
+                    layer_payload=layer_payload,
+                    defense_state=defense_state,
+                )
+
+            run_narrative = snapshot.get("modifiers", {}).get(
+                "purple_team_narrative", defense_narrative
+            )
+            if defense_report and run_narrative:
+                set_phase(status, "Generating purple-team narrative")
+                narrative_md = _stream_defense_narrative(
+                    report=defense_report,
+                    scenario_text=cleaned,
+                    trace_name=trace_name,
+                    on_chunk=lambda: set_phase(
+                        status, "Generating purple-team narrative"
+                    ),
+                )
+                if narrative_md:
+                    defense_state = _add_narrative_to_defense_state(
+                        defense_state=defense_state,
+                        narrative_md=narrative_md,
+                        human_name=snapshot_human_name,
+                    )
+                    st.session_state[defense_key] = defense_state
+                    st.session_state["last_defense_narrative"] = narrative_md
+                    # Replace, rather than duplicate, the already available base
+                    # render now that its optional companion is complete.
+                    result_placeholder.empty()
+                    with result_placeholder.container():
+                        _render_result(
+                            page_id=page_id,
+                            cleaned=cleaned,
+                            file_name=md_name,
+                            layer_payload=layer_payload,
+                            defense_state=defense_state,
+                            variant="current_enriched",
+                        )
+
+            set_phase(status, "Complete", state="complete")
     except Exception as e:
         st.error(f"An error occurred while generating the scenario: {e}")
 
-    st.markdown("---")
-    if scenario_text:
-        thinking, cleaned = clean_model_response(scenario_text)
-        if thinking:
-            with st.expander("View Model's Reasoning"):
-                st.markdown(thinking)
-        # Build the defense companion first — this may stream a second (purple-
-        # team narrative) model call that takes 20-40s. The scenario's live
-        # stream is deliberately left on screen throughout, so it doesn't vanish
-        # while the narrative generates; only once both are done do we swap the
-        # live streams for the canonical, tabbed result below.
-        defense_state = _build_defense_state(
-            report=defense_report,
-            run_narrative=defense_narrative,
-            scenario_text=cleaned,
-            defense_name=defense_name,
-            human_name=human_name,
-            trace_name=trace_name,
-        )
-        stream_placeholder.empty()
-        _persist_and_render(
-            cleaned=cleaned,
-            page_id=page_id,
-            download_name=download_name,
-            generated_key=generated_key,
-            text_key=text_key,
-            layer_key=layer_key,
-            filename_key=filename_key,
-            defense_key=defense_key,
-            layer_payload=layer_payload,
-            defense_state=defense_state,
-        )
-    elif st.session_state.get(generated_key) and st.session_state.get(text_key):
+    if not scenario_text and st.session_state.get(generated_key) and st.session_state.get(text_key):
         _render_previous(
             page_id=page_id,
             text_key=text_key,
             filename_key=filename_key,
-            download_name=download_name,
+            download_name=human_name,
             layer_key=layer_key,
             defense_key=defense_key,
         )
@@ -262,38 +366,43 @@ def _generate_and_render(
 def _build_defense_state(
     *,
     report: dict | None,
-    run_narrative: bool,
-    scenario_text: str,
     defense_name: str,
     human_name: str,
-    trace_name: str,
 ) -> dict | None:
-    """Turn a defense report into the persisted render/download state.
-
-    Renders the deterministic section from the STIX join and, when the
-    purple-team toggle is on, streams a second model call that narrates the
-    defence stage by stage. Returns ``None`` when there is no defensive data.
-    """
+    """Build the deterministic companion state without making an LLM call."""
     if not report:
         return None
     deterministic_md = defense_to_markdown(report)
-    narrative_md = None
-    if run_narrative:
-        narrative_md = _stream_defense_narrative(
-            report=report, scenario_text=scenario_text, trace_name=trace_name
-        )
     title = human_name[:-3] if human_name.endswith(".md") else human_name
-    download_md = assemble_defense_document(deterministic_md, narrative_md, title=title)
+    download_md = assemble_defense_document(deterministic_md, None, title=title)
     return {
         "deterministic_md": deterministic_md,
-        "narrative_md": narrative_md,
+        "narrative_md": None,
         "download_md": download_md,
         "filename": defense_name,
     }
 
 
+def _add_narrative_to_defense_state(
+    *, defense_state: dict | None, narrative_md: str, human_name: str
+) -> dict:
+    """Return a companion state enriched with the completed narrative."""
+    state = dict(defense_state or {})
+    deterministic_md = state.get("deterministic_md", "")
+    title = human_name[:-3] if human_name.endswith(".md") else human_name
+    state["narrative_md"] = narrative_md
+    state["download_md"] = assemble_defense_document(
+        deterministic_md, narrative_md, title=title
+    )
+    return state
+
+
 def _stream_defense_narrative(
-    *, report: dict, scenario_text: str, trace_name: str
+    *,
+    report: dict,
+    scenario_text: str,
+    trace_name: str,
+    on_chunk: Callable[[], None] | None = None,
 ) -> str | None:
     """Stream the optional purple-team narrative pass; return its cleaned text."""
     config = LLMConfig.from_session_state(
@@ -307,16 +416,16 @@ def _stream_defense_narrative(
     def _tee(gen):
         for chunk in gen:
             chunks.append(chunk)
+            if on_chunk:
+                on_chunk()
             yield chunk
 
     try:
-        with st.status("Generating purple-team narrative...", expanded=True) as status:
-            st.write("Walking the scenario from the defender's side.")
-            with placeholder.container():
-                st.write_stream(
-                    stream_filter_thinking(_tee(call_llm_stream(config, messages)))
-                )
-            status.update(label="Purple-team narrative generated.", state="complete")
+        st.write("Walking the scenario from the defender's side.")
+        with placeholder.container():
+            st.write_stream(
+                stream_filter_thinking(_tee(call_llm_stream(config, messages)))
+            )
     except Exception as e:
         st.error(f"An error occurred while generating the purple-team narrative: {e}")
         return None

--- a/core/scenario_page.py
+++ b/core/scenario_page.py
@@ -421,7 +421,14 @@ def _stream_defense_narrative(
             yield chunk
 
     try:
-        st.write("Walking the scenario from the defender's side.")
+        # Reasoning models can spend minutes on this second call before emitting
+        # any text; the elapsed label only advances as chunks arrive, so it looks
+        # stalled during that wait. Say so, so a still spinner reads as "working".
+        st.write(
+            "Walking the scenario from the defender's side. Reasoning models can "
+            "take several minutes here and may show no progress until the first "
+            "text arrives."
+        )
         with placeholder.container():
             st.write_stream(
                 stream_filter_thinking(_tee(call_llm_stream(config, messages)))

--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -50,18 +50,18 @@ def load_groups(matrix):
 # only threads its own inputs + the AI-uplift toggle into the shared builder.
 
 
-def build_messages(matrix, selected_group_alias, kill_chain_string):
+def build_messages(snapshot):
     return build_threat_group_messages(
-        matrix=matrix,
-        selected_group_alias=selected_group_alias,
-        kill_chain_string=kill_chain_string,
-        industry=industry,
-        company_size=company_size,
-        ai_uplift=is_ai_uplift_on("threat_group"),
+        matrix=snapshot["matrix"],
+        selected_group_alias=snapshot["selected_entity"]["name"],
+        kill_chain_string=snapshot["kill_chain_string"],
+        industry=snapshot["organisation"]["industry"],
+        company_size=snapshot["organisation"]["company_size"],
+        ai_uplift=snapshot["modifiers"]["ai_uplift"],
     )
 
 
-def build_layer_payload():
+def build_layer_payload(snapshot):
     """Serialise the scenario's kill chain as an ATT&CK Navigator layer.
 
     Reads the same ``selected_techniques_df`` the prompt was built from, so the
@@ -69,12 +69,15 @@ def build_layer_payload():
     one technique per phase, so the set differs run to run). Returns the layer
     JSON, or ``None`` when the matrix has no Navigator.
     """
-    if selected_techniques_df.empty:
+    sampled_techniques = snapshot["sampled_techniques"]
+    if not sampled_techniques:
         return None
     techniques = [
         (row["ATT&CK ID"], tactic_shortname(str(row["Phase Name"])))
-        for _, row in selected_techniques_df.iterrows()
+        for row in sampled_techniques
     ]
+    matrix = snapshot["matrix"]
+    selected_group_alias = snapshot["selected_entity"]["name"]
     layer = build_layer(
         name=f"AttackGen: {selected_group_alias} ({matrix})",
         matrix=matrix,
@@ -89,16 +92,18 @@ def build_layer_payload():
     return dumps(layer)
 
 
-def build_defense_payload():
+def build_defense_payload(snapshot):
     """Join the scenario's techniques to their detection strategies + mitigations.
 
     Uses the same ``selected_techniques_df`` the prompt and layer were built
     from, so the Detection & Response companion matches the scenario's kill
     chain. Returns ``None`` when there's no defensive data.
     """
-    if selected_techniques_df.empty:
+    sampled_techniques = snapshot["sampled_techniques"]
+    if not sampled_techniques:
         return None
-    technique_ids = [str(row["ATT&CK ID"]) for _, row in selected_techniques_df.iterrows()]
+    technique_ids = [str(row["ATT&CK ID"]) for row in sampled_techniques]
+    matrix = snapshot["matrix"]
     if matrix == "ATLAS":
         return build_defense_report(
             matrix=matrix, technique_ids=technique_ids, atlas_data=attack_data["atlas"]
@@ -158,7 +163,7 @@ selected_group_alias = st.selectbox(
     label_visibility="hidden",
 )
 
-messages = None
+kill_chain_string = ""
 techniques_df = pd.DataFrame()
 selected_techniques_df = pd.DataFrame()
 
@@ -194,7 +199,6 @@ try:
             st.dataframe(data=techniques_df, height=200, width='stretch', hide_index=True)
 
         kill_chain_string = kill_chain.kill_chain_string
-        messages = build_messages(matrix, selected_group_alias, kill_chain_string)
 except Exception as e:
     st.error("An error occurred: " + str(e))
 
@@ -208,7 +212,7 @@ if matrix == "ATLAS":
 
         Click the button below to generate a scenario based on the selected case study. The documented attack procedure from the case study will be used to generate the scenario.
 
-        It normally takes between 30-50 seconds to generate a scenario, although for local models this is highly dependent on your hardware and the selected model. ⏱️
+        Generation often takes 30–50 seconds. Reasoning models and local models can take several minutes, depending on the selected model and hardware. Progress and elapsed time are shown below. ⏱️
         """
     )
 else:
@@ -218,7 +222,7 @@ else:
 
         Click the button below to generate a scenario based on the selected threat actor group. A selection of the group's known techniques will be chosen at random and used to generate the scenario.
 
-        It normally takes between 30-50 seconds to generate a scenario, although for local models this is highly dependent on your hardware and the selected model. ⏱️
+        Generation often takes 30–50 seconds. Reasoning models and local models can take several minutes, depending on the selected model and hardware. Progress and elapsed time are shown below. ⏱️
         """
     )
 
@@ -229,14 +233,28 @@ def _ready() -> bool:
     if techniques_df.empty:
         st.info(f"Please select a {entity_label} with associated techniques.")
         return False
-    if messages is None:
-        return False
-    return True
+    return bool(kill_chain_string)
+
+
+def _capture_inputs():
+    return {
+        "scenario_type": "case_study" if matrix == "ATLAS" else "threat_group",
+        "matrix": matrix,
+        "organisation": {"industry": industry, "company_size": company_size},
+        "selected_entity": {"type": entity_label, "name": selected_group_alias},
+        "selected_techniques": techniques_df.to_dict(orient="records"),
+        "sampled_techniques": selected_techniques_df.to_dict(orient="records"),
+        "kill_chain_string": kill_chain_string,
+        "modifiers": {
+            "ai_uplift": is_ai_uplift_on("threat_group"),
+            "purple_team_narrative": is_defense_narrative_on("threat_group"),
+        },
+    }
 
 
 run_scenario_page(
     page_id="threat_group",
-    build_messages=lambda: messages,
+    build_messages=build_messages,
     is_ready=_ready,
     download_name=f"AttackGen {selected_group_alias} {matrix}.md",
     trace_name="Threat Group Scenario",
@@ -245,6 +263,7 @@ run_scenario_page(
     build_layer=build_layer_payload,
     build_defense=build_defense_payload,
     defense_narrative=is_defense_narrative_on("threat_group"),
+    capture_inputs=_capture_inputs,
 )
 
 

--- a/pages/2_🛠️_Custom_Scenarios.py
+++ b/pages/2_🛠️_Custom_Scenarios.py
@@ -78,18 +78,18 @@ techniques_df = load_techniques()
 # only threads its own inputs + the AI-uplift toggle into the shared builder.
 
 
-def build_messages(selected_techniques_string, template_info):
+def build_messages(snapshot):
     return build_custom_messages(
-        matrix=matrix,
-        selected_techniques_string=selected_techniques_string,
-        template_info=template_info,
-        industry=industry,
-        company_size=company_size,
-        ai_uplift=is_ai_uplift_on("custom"),
+        matrix=snapshot["matrix"],
+        selected_techniques_string="\n".join(snapshot["selected_techniques"]),
+        template_info=snapshot["template_info"],
+        industry=snapshot["organisation"]["industry"],
+        company_size=snapshot["organisation"]["company_size"],
+        ai_uplift=snapshot["modifiers"]["ai_uplift"],
     )
 
 
-def build_layer_payload():
+def build_layer_payload(snapshot):
     """Serialise the chosen techniques as an ATT&CK Navigator layer.
 
     The multiselect carries no phase information, so techniques are emitted
@@ -97,12 +97,13 @@ def build_layer_payload():
     JSON, or ``None`` when the matrix has no Navigator.
     """
     techniques = []
-    for display in selected_techniques:
+    for display in snapshot["selected_techniques"]:
         technique_id = parse_technique_id(display)
         if technique_id:
             techniques.append((technique_id, None))
     if not techniques:
         return None
+    matrix = snapshot["matrix"]
     layer = build_layer(
         name=f"AttackGen: Custom Scenario ({matrix})",
         matrix=matrix,
@@ -114,15 +115,20 @@ def build_layer_payload():
     return dumps(layer)
 
 
-def build_defense_payload():
+def build_defense_payload(snapshot):
     """Join the selected techniques to their detection strategies + mitigations.
 
     Parses the same multiselect the prompt and layer were built from. Returns
     ``None`` when nothing is selected or there's no defensive data.
     """
-    technique_ids = [tid for tid in (parse_technique_id(d) for d in selected_techniques) if tid]
+    technique_ids = [
+        tid
+        for tid in (parse_technique_id(d) for d in snapshot["selected_techniques"])
+        if tid
+    ]
     if not technique_ids:
         return None
+    matrix = snapshot["matrix"]
     if matrix == "ATLAS":
         return build_defense_report(
             matrix=matrix, technique_ids=technique_ids, atlas_data=attack_data["atlas"]
@@ -221,15 +227,6 @@ if not techniques_df.empty:
         st.info("📝 Techniques are searchable by either their name or technique ID.")
 
 
-messages = None
-try:
-    if selected_techniques:
-        selected_techniques_string = '\n'.join(selected_techniques)
-        template_info = f"This is a '{selected_template}' scenario." if selected_template else ""
-        messages = build_messages(selected_techniques_string, template_info)
-except Exception as e:
-    st.error(f"An error occurred: {str(e)}")
-
 st.markdown("")
 st.markdown(
     """
@@ -237,7 +234,7 @@ st.markdown(
 
     Click the button below to generate a scenario based on the selected technique(s).
 
-    It normally takes between 30-50 seconds to generate a scenario, although for local models this is highly dependent on your hardware and the selected model. ⏱️
+    Generation often takes 30–50 seconds. Reasoning models and local models can take several minutes, depending on the selected model and hardware. Progress and elapsed time are shown below. ⏱️
     """
 )
 
@@ -248,14 +245,34 @@ def _ready() -> bool:
     if not selected_techniques:
         st.info("Please select at least one technique.")
         return False
-    if messages is None:
-        return False
     return True
+
+
+def _capture_inputs():
+    return {
+        "scenario_type": "custom",
+        "matrix": matrix,
+        "organisation": {"industry": industry, "company_size": company_size},
+        "selected_entity": (
+            {"type": "template", "name": selected_template}
+            if selected_template
+            else None
+        ),
+        "selected_techniques": list(selected_techniques),
+        "sampled_techniques": list(selected_techniques),
+        "template_info": (
+            f"This is a '{selected_template}' scenario." if selected_template else ""
+        ),
+        "modifiers": {
+            "ai_uplift": is_ai_uplift_on("custom"),
+            "purple_team_narrative": is_defense_narrative_on("custom"),
+        },
+    }
 
 
 run_scenario_page(
     page_id="custom",
-    build_messages=lambda: messages,
+    build_messages=build_messages,
     is_ready=_ready,
     download_name=f"AttackGen Custom {selected_template} {matrix}.md",
     trace_name="Custom Scenario",
@@ -264,6 +281,7 @@ run_scenario_page(
     build_layer=build_layer_payload,
     build_defense=build_defense_payload,
     defense_narrative=is_defense_narrative_on("custom"),
+    capture_inputs=_capture_inputs,
 )
 
 

--- a/pages/3_🤖_AI_Insider_Threat_Scenarios.py
+++ b/pages/3_🤖_AI_Insider_Threat_Scenarios.py
@@ -56,24 +56,17 @@ company_size = setup.company_size
 # only threads its own inputs into the shared builder.
 
 
-def build_messages(
-    archetype_name,
-    selected_categories,
-    selected_stride,
-    selected_capabilities,
-    scenario_seed=None,
-    required_decisions=None,
-):
-    """Build the system + user message dicts for an AI insider threat scenario."""
+def build_messages(snapshot):
+    """Build messages exclusively from the Generate-time input snapshot."""
     return build_ai_insider_messages(
-        archetype_name=archetype_name,
-        selected_categories=selected_categories,
-        selected_stride=selected_stride,
-        selected_capabilities=selected_capabilities,
-        industry=industry,
-        company_size=company_size,
-        scenario_seed=scenario_seed,
-        required_decisions=required_decisions,
+        archetype_name=snapshot["selected_entity"]["name"],
+        selected_categories=snapshot["selected_categories"],
+        selected_stride=snapshot["selected_stride"],
+        selected_capabilities=snapshot["selected_capabilities"],
+        industry=snapshot["organisation"]["industry"],
+        company_size=snapshot["organisation"]["company_size"],
+        scenario_seed=snapshot["scenario_seed"],
+        required_decisions=snapshot["required_decisions"],
     )
 
 
@@ -210,21 +203,6 @@ if required_decisions:
         + "."
     )
 
-# Build the prompt messages if a valid selection exists.
-messages = None
-if selected_categories or selected_stride:
-    try:
-        messages = build_messages(
-            selected_archetype,
-            selected_categories,
-            selected_stride,
-            selected_capabilities,
-            scenario_seed=scenario_seed,
-            required_decisions=required_decisions,
-        )
-    except Exception as e:
-        st.error(f"An error occurred while building the prompt: {str(e)}")
-
 st.markdown("")
 st.markdown("---")
 st.markdown(
@@ -233,7 +211,7 @@ st.markdown(
 
     Click the button below to generate an AI insider threat scenario based on your selections.
 
-    It normally takes between 30-50 seconds to generate a scenario, although for local models this is highly dependent on your hardware and the selected model. ⏱️
+    Generation often takes 30–50 seconds. Reasoning models and local models can take several minutes, depending on the selected model and hardware. Progress and elapsed time are shown below. ⏱️
     """
 )
 
@@ -244,18 +222,37 @@ def _ready() -> bool:
     if not selected_categories and not selected_stride:
         st.info("Please select at least one threat category (or specific STRIDE threat) to continue.")
         return False
-    if messages is None:
-        return False
     return True
+
+
+def _capture_inputs():
+    return {
+        "scenario_type": "ai_insider",
+        "matrix": None,
+        "organisation": {"industry": industry, "company_size": company_size},
+        "selected_entity": {
+            "type": "deployment_archetype",
+            "name": selected_archetype,
+        },
+        "selected_techniques": [],
+        "sampled_techniques": [],
+        "selected_categories": list(selected_categories),
+        "selected_stride": list(selected_stride),
+        "selected_capabilities": list(selected_capabilities),
+        "scenario_seed": scenario_seed,
+        "required_decisions": list(required_decisions),
+        "modifiers": {"template": selected_template or None},
+    }
 
 
 run_scenario_page(
     page_id="ai_insider",
-    build_messages=lambda: messages,
+    build_messages=build_messages,
     is_ready=_ready,
     download_name="AttackGen AI Insider Threat.md",
     trace_name="AI Insider Threat Scenario",
     trace_tags=("ai_insider_scenario",),
+    capture_inputs=_capture_inputs,
 )
 
 

--- a/tests/test_scenario_page.py
+++ b/tests/test_scenario_page.py
@@ -49,15 +49,26 @@ def stub_streamlit(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     Returns a dict the test can mutate to control widget return values:
       - `button_returns`: bool returned by `st.button`
     """
-    controls: dict[str, Any] = {"button_returns": False}
+    controls: dict[str, Any] = {
+        "button_returns": False,
+        "status_labels": [],
+        "stream_chunks": [],
+        "on_stream_chunk": None,
+    }
 
     def _button(*_args, **_kwargs):
         return controls["button_returns"]
 
     @contextmanager
-    def _status(*_args, **_kwargs):
-        # Yield a real object: production code calls `status.update(...)`.
-        yield SimpleNamespace(update=lambda *_a, **_k: None)
+    def _status(*args, **_kwargs):
+        if args:
+            controls["status_labels"].append(args[0])
+
+        def _update(*_args, **kwargs):
+            if "label" in kwargs:
+                controls["status_labels"].append(kwargs["label"])
+
+        yield SimpleNamespace(update=_update)
 
     @contextmanager
     def _expander(*_args, **_kwargs):
@@ -70,9 +81,11 @@ def stub_streamlit(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         return None
 
     def _write_stream(stream):
-        # Drain the generator so the production code's `_tee` captures chunks.
-        for _ in stream:
-            pass
+        # Drain the generator while recording what became visible incrementally.
+        for chunk in stream:
+            controls["stream_chunks"].append(chunk)
+            if controls["on_stream_chunk"]:
+                controls["on_stream_chunk"](chunk, list(controls["stream_chunks"]))
 
     monkeypatch.setattr(st, "button", _button)
     monkeypatch.setattr(st, "status", _status)
@@ -698,3 +711,172 @@ def test_persisted_defense_survives_rerun(
     ]
     assert len(detection_downloads) == 1
     assert detection_downloads[0]["file_name"] == "scn_20260714-153045_detection.md"
+
+
+# --- Phased generation coordinator ------------------------------------------
+
+
+def test_phase_sequence_and_base_is_persisted_before_optional_enrichment(
+    stub_streamlit,
+    fake_session_state,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_streamlit["button_returns"] = True
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+    fake_session_state["llm_api_key"] = "k"
+    downloads = _capture_downloads(monkeypatch)
+    calls = 0
+
+    def controlled_stream(_config, _messages):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            yield "# Base "
+            yield "scenario"
+            return
+
+        # The base and every deterministic export must be usable before the
+        # optional second model call starts yielding.
+        assert fake_session_state["threat_group_scenario_generated"] is True
+        assert fake_session_state["threat_group_scenario_text"] == "# Base scenario"
+        assert fake_session_state["last_scenario_text"] == "# Base scenario"
+        assert fake_session_state["last_defense_narrative"] is None
+        assert fake_session_state["threat_group_scenario_layer"][0] == (
+            '{"domain": "enterprise-attack"}'
+        )
+        assert any(d.get("label") == "Download Scenario" for d in downloads)
+        assert any(d.get("mime") == "application/json" for d in downloads)
+        yield "## Defender walkthrough"
+
+    monkeypatch.setattr("core.scenario_page.call_llm_stream", controlled_stream)
+
+    run_scenario_page(
+        page_id="threat_group",
+        build_messages=lambda _snapshot: [{"role": "user", "content": "x"}],
+        is_ready=lambda: True,
+        download_name="AttackGen APT29 Enterprise.md",
+        trace_name="Threat Group Scenario",
+        trace_tags=("threat_group_scenario",),
+        build_layer=lambda _snapshot: '{"domain": "enterprise-attack"}',
+        build_defense=lambda _snapshot: _DEFENSE_REPORT,
+        defense_narrative=True,
+        capture_inputs=lambda: {"matrix": "Enterprise"},
+    )
+
+    assert calls == 2
+    phase_names = [
+        "Preparing inputs",
+        "Generating base scenario",
+        "Base scenario available",
+        "Building deterministic exports",
+        "Generating purple-team narrative",
+        "Complete",
+    ]
+    cursor = 0
+    for phase in phase_names:
+        cursor = next(
+            i + 1
+            for i, label in enumerate(stub_streamlit["status_labels"][cursor:], cursor)
+            if label.startswith(phase) and "elapsed" in label
+        )
+    assert fake_session_state["last_defense_narrative"] == "## Defender walkthrough"
+
+
+def test_generate_captures_input_and_identity_metadata(
+    stub_streamlit,
+    fake_session_state,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_streamlit["button_returns"] = True
+    fake_session_state["chosen_model_provider"] = "Anthropic API"
+    fake_session_state["llm_model_name"] = "claude-sonnet-4-6"
+    source = {
+        "scenario_type": "custom",
+        "matrix": "Enterprise",
+        "organisation": {"industry": "Finance", "company_size": "Large"},
+        "selected_techniques": ["PowerShell (T1059.001)"],
+        "sampled_techniques": ["PowerShell (T1059.001)"],
+        "modifiers": {"ai_uplift": True},
+    }
+    callback_snapshots = []
+
+    def build_messages(snapshot):
+        callback_snapshots.append(snapshot)
+        # Mutating the original widget-backed mapping after capture must not
+        # affect prompt/export callbacks or persisted metadata.
+        source["matrix"] = "ICS"
+        source["selected_techniques"].append("Changed later")
+        return [{"role": "user", "content": snapshot["matrix"]}]
+
+    def stream(_config, messages):
+        assert messages[0]["content"] == "Enterprise"
+        yield "# Scenario"
+
+    monkeypatch.setattr("core.scenario_page.call_llm_stream", stream)
+
+    run_scenario_page(
+        page_id="custom",
+        build_messages=build_messages,
+        is_ready=lambda: True,
+        download_name="AttackGen Custom Enterprise.md",
+        trace_name="Custom Scenario",
+        trace_tags=("custom_scenario", "ai_enhanced"),
+        build_layer=lambda snapshot: (
+            '{"domain": "enterprise-attack"}'
+            if snapshot["matrix"] == "Enterprise"
+            else None
+        ),
+        capture_inputs=lambda: source,
+    )
+
+    captured = fake_session_state["custom_scenario_input_snapshot"]
+    assert captured["matrix"] == "Enterprise"
+    assert captured["selected_techniques"] == ["PowerShell (T1059.001)"]
+    assert captured["identity"] == {
+        "page_id": "custom",
+        "trace_name": "Custom Scenario",
+        "trace_tags": ["custom_scenario", "ai_enhanced"],
+        "provider": "Anthropic API",
+        "model": "claude-sonnet-4-6",
+        "download_name": "AttackGen Custom Enterprise.md",
+    }
+    assert captured["captured_at"]
+    assert callback_snapshots[0]["matrix"] == "Enterprise"
+    assert fake_session_state["custom_scenario_layer"] is not None
+
+
+def test_streamed_base_text_is_visible_chunk_by_chunk(
+    stub_streamlit,
+    fake_session_state,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_streamlit["button_returns"] = True
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+    visible_steps: list[str] = []
+    stub_streamlit["on_stream_chunk"] = (
+        lambda _chunk, chunks: visible_steps.append("".join(chunks))
+    )
+
+    def controlled_stream(_config, _messages):
+        yield "# Partial"
+        yield " scenario"
+
+    monkeypatch.setattr("core.scenario_page.call_llm_stream", controlled_stream)
+
+    run_scenario_page(
+        page_id="custom",
+        build_messages=lambda: [{"role": "user", "content": "x"}],
+        is_ready=lambda: True,
+        download_name="custom.md",
+        trace_name="Custom Scenario",
+        trace_tags=("custom_scenario",),
+    )
+
+    visible = stub_streamlit["stream_chunks"]
+    assert len(visible) > 1
+    assert "".join(visible) == "# Partial scenario"
+    assert visible_steps[0] != visible_steps[-1]
+    assert visible_steps[-1] == "# Partial scenario"
+    assert fake_session_state["custom_scenario_text"] == "# Partial scenario"


### PR DESCRIPTION
Automated by **agent-loop** — pi worked this issue on a fresh clone of `mrwadams/attackgen`; changes were gated outside the agent on agent-1.

Closes #48

## How to test
```bash
git fetch origin && git checkout agent/issue-48
python3 -m venv .venv && . .venv/bin/activate
pip install -r requirements.txt
streamlit run "00_👋_Welcome.py"
```
Then open the printed local URL.

**Confirm each acceptance criterion:**
- [ ] The base scenario, base download, and Navigator layer become available as soon as the base stream completes, while an optional narrative is still generating
- [ ] The Assistant handoff is set from the base result and does not wait for the optional narrative
- [ ] An input snapshot is captured at Generate press; rendering and downloads use the snapshot, not mutable current widgets
- [ ] The active phase and elapsed time are visible during generation; duration messaging acknowledges multi-minute runs
- [ ] Coordinator tests cover the phase sequence, base-result persistence before optional enrichment, captured-input metadata, and streamed partial-text visibility using a controllable streaming fixture

## Gates (non-authoritative)
- ✅ **files_non_empty** — 5 non-empty file(s) changed
- ✅ **containment** — diff stays within the allowed lane
- ✅ **verify** — pytest: 246 passed, no failures (browser/e2e excluded)

> **Draft.** Browser/e2e tests were NOT run in-gate — run them and review before merging. Nothing here is auto-merged.