### PR TITLE
release: bump version to 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attackgen"
-version = "0.15.0"
+version = "0.16.0"
 description = "Generate tailored incident-response scenarios from MITRE ATT&CK / ATLAS using LLMs"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
Bumps `pyproject.toml` to `0.16.0` so the `v0.16.0` tag can be cut.

The Release workflow's `verify` job fails the release unless the tag matches the packaged version, so this bump must merge before tagging.

## Release sequence
1. Merge this PR (squash).
2. Tag the merge commit `v0.16.0` and push the tag; the Release workflow verifies, tests, builds the multi-arch image, and cuts the GitHub Release with auto-generated notes.
3. Optionally paste the human-written summary from the draft on top of the auto-generated "What's Changed" list.

## What v0.16.0 contains (since v0.15.0)
- Base-scenario-first phased generation (#88)
- Neutral, dead-end-free threat-group and case-study selectors (#87)
- Shared setup sidebar on every scenario page (#69)
- MCP server on the mcp 2.x SDK (#86), base image on python 3.14-slim (#82)
- CI security-scan gating and image CVE cleanup (#73, #74, #84, #85), Actions off Node 20 (#83), Dependabot tracks Actions (#75)
- Feedback widget tolerates a missing secrets.toml (#72), release-notes housekeeping (#71)

🤖 Generated with [Claude Code](https://claude.com/claude-code)