### PR TITLE
Keep the elapsed timer ticking during long model-streaming waits

### DIFF
--- a/core/scenario_page.py
+++ b/core/scenario_page.py
@@ -12,6 +12,7 @@ Adding a new scenario page is now: write the widgets and prompt builder, then
 
 from __future__ import annotations
 
+import contextlib
 import copy
 import inspect
 import json
@@ -57,14 +58,40 @@ def _invoke_with_snapshot(callback: Callable, snapshot: Snapshot):
     return callback(snapshot)
 
 
+# Bound once, module-locally, so a test can patch *this* name instead of
+# reaching into the stdlib `time` module object — which patches it for every
+# thread in the process, including the stream worker running concurrently.
+_monotonic = time.monotonic
+
+
 def _elapsed_label(phase: str, started: float) -> str:
-    elapsed = max(0, int(time.monotonic() - started))
+    elapsed = max(0, int(_monotonic() - started))
     minutes, seconds = divmod(elapsed, 60)
     return f"{phase} · elapsed {minutes}:{seconds:02d}"
 
 
 _STREAM_POLL_INTERVAL = 0.2
 """Seconds between elapsed-label refreshes while waiting for the next chunk."""
+
+_STREAM_QUEUE_MAX = 64
+"""Chunks the worker may run ahead of the consumer before it blocks."""
+
+
+def _attach_script_run_ctx(thread: threading.Thread) -> None:
+    """Give a worker thread the calling script's Streamlit context, if any.
+
+    Guarded: this reaches into `streamlit.runtime.scriptrunner`, which is not a
+    stability-guaranteed API, and there is no context at all off the UI (the
+    MCP server, tests). Failing here must not stop the stream — the cost of
+    losing it is a missing run id, not a broken generation."""
+    try:
+        from streamlit.runtime.scriptrunner import add_script_run_ctx, get_script_run_ctx
+    except Exception:  # noqa: BLE001 - older/newer Streamlit, or no runtime
+        return
+    with contextlib.suppress(Exception):
+        ctx = get_script_run_ctx()
+        if ctx is not None:
+            add_script_run_ctx(thread, ctx)
 
 
 def _stream_on_worker(
@@ -82,36 +109,77 @@ def _stream_on_worker(
     while producing ``chunks`` is relayed and re-raised on the main thread,
     from the same call site a synchronous iteration would have raised it.
     """
-    items: queue.Queue[tuple[str, object]] = queue.Queue()
+    # Bounded: if the consumer stops reading, the worker must block rather than
+    # accumulate the rest of the response in memory.
+    items: queue.Queue[tuple[str, object]] = queue.Queue(maxsize=_STREAM_QUEUE_MAX)
+    stop = threading.Event()
 
     def _worker() -> None:
         try:
             for chunk in chunks:
-                items.put(("chunk", chunk))
+                # Re-checked every iteration AND around the blocking put, so a
+                # cancelled stream stops pulling from the model promptly instead
+                # of draining the whole response into a queue nobody reads.
+                if stop.is_set():
+                    break
+                while not stop.is_set():
+                    try:
+                        items.put(("chunk", chunk), timeout=_STREAM_POLL_INTERVAL)
+                        break
+                    except queue.Full:
+                        continue
+                # Checked again here, not just at the top: if the stop landed
+                # while we were blocked on the put, going round the `for` would
+                # pull another chunk from the model first — a network read that
+                # can block for seconds on exactly the slow models this exists
+                # for.
+                if stop.is_set():
+                    break
         except Exception as exc:  # noqa: BLE001 - relayed to the main thread
-            items.put(("error", exc))
+            if not stop.is_set():
+                with contextlib.suppress(queue.Full):
+                    items.put(("error", exc), timeout=_STREAM_POLL_INTERVAL)
         finally:
-            items.put(("done", None))
+            # Close the source so the underlying HTTP response is released
+            # rather than left open until the daemon thread is collected.
+            with contextlib.suppress(Exception):
+                close = getattr(chunks, "close", None)
+                if close is not None:
+                    close()
+            with contextlib.suppress(queue.Full):
+                items.put(("done", None), timeout=_STREAM_POLL_INTERVAL)
 
     thread = threading.Thread(target=_worker, daemon=True)
+    # Carry the Streamlit script run context onto the worker. Without it the
+    # thread has no session: `call_llm_stream`'s @traceable body runs here on
+    # the first `next()`, and its `_stash_run_id` write to `st.session_state`
+    # lands nowhere, so the LangSmith feedback widget never sees a run id. It
+    # also silences the per-call "missing ScriptRunContext!" warning.
+    _attach_script_run_ctx(thread)
     thread.start()
 
-    while True:
-        try:
-            kind, payload = items.get(timeout=_STREAM_POLL_INTERVAL)
-        except queue.Empty:
-            if on_progress:
-                on_progress()
-            continue
+    try:
+        while True:
+            try:
+                kind, payload = items.get(timeout=_STREAM_POLL_INTERVAL)
+            except queue.Empty:
+                if on_progress:
+                    on_progress()
+                continue
 
-        if kind == "chunk":
-            if on_progress:
-                on_progress()
-            yield payload
-        elif kind == "error":
-            raise payload
-        else:  # "done"
-            return
+            if kind == "chunk":
+                if on_progress:
+                    on_progress()
+                yield payload
+            elif kind == "error":
+                raise payload
+            else:  # "done"
+                return
+    finally:
+        # Reached on GeneratorExit too — Streamlit raises RerunException from
+        # status.update() when the user touches a widget mid-generation, which
+        # closes this generator without exhausting it.
+        stop.set()
 
 
 def _unique_filenames(download_name: str) -> tuple[str, str, str]:
@@ -279,7 +347,7 @@ def _generate_and_render(
     defense_narrative: bool,
 ) -> None:
     """Coordinate and expose each phase of a scenario generation."""
-    started = time.monotonic()
+    started = _monotonic()
     stream_placeholder = st.empty()
     result_placeholder = st.empty()
     raw_chunks: list[str] = []
@@ -483,8 +551,8 @@ def _stream_defense_narrative(
         # the elapsed label keep advancing during that silent wait.
         st.write(
             "Walking the scenario from the defender's side. Reasoning models can "
-            "take several minutes here and may show no progress until the first "
-            "text arrives."
+            "take several minutes here; the elapsed timer keeps ticking while "
+            "the model thinks."
         )
         with placeholder.container():
             st.write_stream(

--- a/core/scenario_page.py
+++ b/core/scenario_page.py
@@ -15,9 +15,11 @@ from __future__ import annotations
 import copy
 import inspect
 import json
+import queue
 import re
+import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Iterator
 from datetime import datetime, timezone
 from typing import Any
 
@@ -59,6 +61,57 @@ def _elapsed_label(phase: str, started: float) -> str:
     elapsed = max(0, int(time.monotonic() - started))
     minutes, seconds = divmod(elapsed, 60)
     return f"{phase} · elapsed {minutes}:{seconds:02d}"
+
+
+_STREAM_POLL_INTERVAL = 0.2
+"""Seconds between elapsed-label refreshes while waiting for the next chunk."""
+
+
+def _stream_on_worker(
+    chunks: Iterable[str], *, on_progress: Callable[[], None] | None = None
+) -> Iterator[str]:
+    """Relay a blocking chunk iterator from a worker thread, ticking while idle.
+
+    Streamlit runs the script on a single thread that blocks inside
+    ``st.write_stream``, so a call that stays silent before its first token
+    (reasoning models, a large prompt) freezes any progress label driven only
+    by chunk arrival. Running ``chunks`` on a worker thread lets the main
+    thread poll a queue with a short timeout, calling ``on_progress`` on every
+    poll — including the empty ones — so the elapsed label keeps advancing
+    during that wait as well as while chunks stream in. An exception raised
+    while producing ``chunks`` is relayed and re-raised on the main thread,
+    from the same call site a synchronous iteration would have raised it.
+    """
+    items: queue.Queue[tuple[str, object]] = queue.Queue()
+
+    def _worker() -> None:
+        try:
+            for chunk in chunks:
+                items.put(("chunk", chunk))
+        except Exception as exc:  # noqa: BLE001 - relayed to the main thread
+            items.put(("error", exc))
+        finally:
+            items.put(("done", None))
+
+    thread = threading.Thread(target=_worker, daemon=True)
+    thread.start()
+
+    while True:
+        try:
+            kind, payload = items.get(timeout=_STREAM_POLL_INTERVAL)
+        except queue.Empty:
+            if on_progress:
+                on_progress()
+            continue
+
+        if kind == "chunk":
+            if on_progress:
+                on_progress()
+            yield payload
+        elif kind == "error":
+            raise payload
+        else:  # "done"
+            return
 
 
 def _unique_filenames(download_name: str) -> tuple[str, str, str]:
@@ -256,14 +309,20 @@ def _generate_and_render(
             def _tee(chunks):
                 for chunk in chunks:
                     raw_chunks.append(chunk)
-                    # Streamlit renders the yielded delta immediately; refreshing
-                    # the label here keeps elapsed time visible as output arrives.
-                    set_phase(status, "Generating base scenario")
                     yield chunk
 
             with stream_placeholder.container():
                 st.write_stream(
-                    stream_filter_thinking(_tee(call_llm_stream(config, messages)))
+                    stream_filter_thinking(
+                        _tee(
+                            _stream_on_worker(
+                                call_llm_stream(config, messages),
+                                on_progress=lambda: set_phase(
+                                    status, "Generating base scenario"
+                                ),
+                            )
+                        )
+                    )
                 )
             scenario_text = "".join(raw_chunks)
             set_phase(status, "Base scenario available")
@@ -323,7 +382,7 @@ def _generate_and_render(
                     report=defense_report,
                     scenario_text=cleaned,
                     trace_name=trace_name,
-                    on_chunk=lambda: set_phase(
+                    on_progress=lambda: set_phase(
                         status, "Generating purple-team narrative"
                     ),
                 )
@@ -402,7 +461,7 @@ def _stream_defense_narrative(
     report: dict,
     scenario_text: str,
     trace_name: str,
-    on_chunk: Callable[[], None] | None = None,
+    on_progress: Callable[[], None] | None = None,
 ) -> str | None:
     """Stream the optional purple-team narrative pass; return its cleaned text."""
     config = LLMConfig.from_session_state(
@@ -416,14 +475,12 @@ def _stream_defense_narrative(
     def _tee(gen):
         for chunk in gen:
             chunks.append(chunk)
-            if on_chunk:
-                on_chunk()
             yield chunk
 
     try:
         # Reasoning models can spend minutes on this second call before emitting
-        # any text; the elapsed label only advances as chunks arrive, so it looks
-        # stalled during that wait. Say so, so a still spinner reads as "working".
+        # any text; running it on a worker thread (see _stream_on_worker) lets
+        # the elapsed label keep advancing during that silent wait.
         st.write(
             "Walking the scenario from the defender's side. Reasoning models can "
             "take several minutes here and may show no progress until the first "
@@ -431,7 +488,14 @@ def _stream_defense_narrative(
         )
         with placeholder.container():
             st.write_stream(
-                stream_filter_thinking(_tee(call_llm_stream(config, messages)))
+                stream_filter_thinking(
+                    _tee(
+                        _stream_on_worker(
+                            call_llm_stream(config, messages),
+                            on_progress=on_progress,
+                        )
+                    )
+                )
             )
     except Exception as e:
         st.error(f"An error occurred while generating the purple-team narrative: {e}")

--- a/tests/test_scenario_page.py
+++ b/tests/test_scenario_page.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import itertools
 import re
+import threading
 import time
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -912,7 +913,7 @@ def test_elapsed_label_advances_while_base_scenario_call_is_silent(
     fake_session_state["llm_model_name"] = "gpt-5.5"
 
     clock = itertools.count()
-    monkeypatch.setattr(scenario_page_module.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(scenario_page_module, "_monotonic", lambda: next(clock))
     monkeypatch.setattr(scenario_page_module, "_STREAM_POLL_INTERVAL", 0.005)
 
     def silent_then_stream(_config, _messages):
@@ -950,7 +951,7 @@ def test_elapsed_label_advances_while_narrative_call_is_silent(
     fake_session_state["llm_model_name"] = "gpt-5.5"
 
     clock = itertools.count()
-    monkeypatch.setattr(scenario_page_module.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(scenario_page_module, "_monotonic", lambda: next(clock))
     monkeypatch.setattr(scenario_page_module, "_STREAM_POLL_INTERVAL", 0.005)
 
     calls = 0
@@ -1000,8 +1001,26 @@ def test_streamed_output_still_renders_incrementally_via_worker_thread(
         lambda _chunk, chunks: visible_steps.append("".join(chunks))
     )
 
+    # The source BLOCKS after the first chunk until the consumer has actually
+    # seen it. If the relay buffered the response and only handed it over at
+    # the end, `seen_first` would never be set and this deadlocks -- the wait
+    # times out and the test fails. An assertion over the accumulated prefixes
+    # cannot do that job: the stub builds those prefixes itself, so they differ
+    # from the full text by construction whether or not anything was buffered.
+    seen_first = threading.Event()
+    stub_streamlit["on_stream_chunk"] = lambda _chunk, chunks: (
+        visible_steps.append("".join(chunks)),
+        seen_first.set(),
+    )
+
+    # Recorded, not asserted in-generator: the page wraps generation in a broad
+    # `except Exception`, so an assert raised here would be swallowed and the
+    # test would fail somewhere unrelated with a message about the wrong thing.
+    rendered_before_second: list[bool] = []
+
     def controlled_stream(_config, _messages):
         yield "# Part one "
+        rendered_before_second.append(seen_first.wait(timeout=5))
         yield "part two "
         yield "part three"
 
@@ -1016,13 +1035,14 @@ def test_streamed_output_still_renders_incrementally_via_worker_thread(
         trace_tags=("custom_scenario",),
     )
 
+    assert rendered_before_second == [True], (
+        "the first chunk was not rendered before the second was produced — the "
+        "relay buffered the response instead of streaming it"
+    )
     visible = stub_streamlit["stream_chunks"]
     full_text = "# Part one part two part three"
     assert len(visible) > 1
     assert "".join(visible) == full_text
-    # At least one intermediate step was visible before the full text -- i.e.
-    # chunks rendered as they arrived rather than only once, after the call.
-    assert any(step != full_text for step in visible_steps[:-1])
     assert visible_steps[-1] == full_text
     assert fake_session_state["custom_scenario_text"] == full_text
 
@@ -1062,3 +1082,66 @@ def test_threaded_stream_error_surfaces_same_message_and_no_completion(
     assert not any(
         label.startswith("Complete") for label in stub_streamlit["status_labels"]
     )
+
+
+def test_worker_thread_is_given_the_script_run_context_before_it_starts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The relay must attach the Streamlit script run context to the worker
+    BEFORE starting it.
+
+    `call_llm_stream` returns a @traceable generator whose body runs on the
+    first `next()` — which now happens on the worker. That body stashes the
+    LangSmith run id into `st.session_state`, and without a script run context
+    the write goes nowhere and the feedback widget reports "No run ID found".
+
+    This asserts the wiring, not the Streamlit behaviour, and deliberately so:
+    `fake_session_state` replaces session state with a plain dict, which every
+    thread can see, so the suite CANNOT reproduce the production failure. That
+    is how the original change passed 257 tests with this bug in it.
+    """
+    seen: dict[str, object] = {}
+
+    def fake_attach(thread: threading.Thread) -> None:
+        seen["thread"] = thread
+        seen["alive_at_attach"] = thread.is_alive()
+
+    monkeypatch.setattr(scenario_page_module, "_attach_script_run_ctx", fake_attach)
+
+    assert list(scenario_page_module._stream_on_worker(iter(["a", "b"]))) == ["a", "b"]
+    assert isinstance(seen.get("thread"), threading.Thread)
+    # Attaching after start() is a race the context may lose, so ordering is
+    # the whole point of the assertion.
+    assert seen["alive_at_attach"] is False
+
+
+def test_closing_the_stream_stops_the_worker_pulling_from_the_model() -> None:
+    """A cancelled generation must stop draining the model, not run to
+    completion into a queue nobody is reading.
+
+    Streamlit raises RerunException from `status.update()` when the user
+    touches a widget mid-generation, which closes this generator without
+    exhausting it. Before the stop event existed, the worker kept pulling and
+    held the HTTP response open.
+    """
+    produced: list[int] = []
+    closed = threading.Event()
+
+    def source():
+        try:
+            for i in range(100_000):
+                produced.append(i)
+                yield f"chunk-{i} "
+        finally:
+            closed.set()
+
+    gen = scenario_page_module._stream_on_worker(source())
+    assert next(gen).startswith("chunk-0")
+    gen.close()
+
+    assert closed.wait(timeout=5), "the source generator was never closed"
+    settled = len(produced)
+    time.sleep(0.3)
+    assert len(produced) == settled, "the worker kept pulling after cancellation"
+    # Bounded by the queue, so it stops early rather than draining the response.
+    assert settled < 1_000

--- a/tests/test_scenario_page.py
+++ b/tests/test_scenario_page.py
@@ -8,7 +8,9 @@ anything — we only care about the control flow at the seam.
 
 from __future__ import annotations
 
+import itertools
 import re
+import time
 from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
@@ -17,6 +19,7 @@ import pytest
 import streamlit as st
 
 import core.llm as llm_module
+import core.scenario_page as scenario_page_module
 from core.scenario_page import _unique_filenames, run_scenario_page
 
 
@@ -880,3 +883,182 @@ def test_streamed_base_text_is_visible_chunk_by_chunk(
     assert visible_steps[0] != visible_steps[-1]
     assert visible_steps[-1] == "# Partial scenario"
     assert fake_session_state["custom_scenario_text"] == "# Partial scenario"
+
+
+# --- Ticking elapsed timer during pre-first-token waits (issue #89) --------
+#
+# `call_llm_stream` now runs on a worker thread (`_stream_on_worker`) so the
+# main thread can poll a queue with a short timeout and refresh the elapsed
+# label even before any chunk has arrived. These tests use a real (short)
+# `time.sleep` inside a fixture stream to force that idle-polling window,
+# with `_STREAM_POLL_INTERVAL` shrunk so it resolves quickly, and replace
+# `time.monotonic` with a strictly-increasing counter so every poll produces
+# a distinct, deterministic elapsed label regardless of real-time jitter.
+
+
+def _phase_labels(labels: list[str], phase: str) -> list[str]:
+    return [label for label in labels if label.startswith(f"{phase} ·")]
+
+
+def test_elapsed_label_advances_while_base_scenario_call_is_silent(
+    stub_streamlit,
+    fake_session_state,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Before the base call's first token, the elapsed label must keep
+    ticking rather than freezing -- the core behaviour issue #89 asks for."""
+    stub_streamlit["button_returns"] = True
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+
+    clock = itertools.count()
+    monkeypatch.setattr(scenario_page_module.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(scenario_page_module, "_STREAM_POLL_INTERVAL", 0.005)
+
+    def silent_then_stream(_config, _messages):
+        # Real sleep on the worker thread: gives the main thread's polling
+        # loop room to tick several times before the first token arrives.
+        time.sleep(0.1)
+        yield "# Scenario"
+
+    monkeypatch.setattr("core.scenario_page.call_llm_stream", silent_then_stream)
+
+    run_scenario_page(
+        page_id="threat_group",
+        build_messages=lambda: [{"role": "user", "content": "x"}],
+        is_ready=lambda: True,
+        download_name="threat_group_scenario.md",
+        trace_name="Threat Group Scenario",
+        trace_tags=("threat_group_scenario",),
+    )
+
+    ticks = _phase_labels(stub_streamlit["status_labels"], "Generating base scenario")
+    # The fake clock advances by one on every tick, so distinct labels prove
+    # the wait produced repeated, advancing refreshes -- not a frozen one.
+    assert len(set(ticks)) >= 3
+
+
+def test_elapsed_label_advances_while_narrative_call_is_silent(
+    stub_streamlit,
+    fake_session_state,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same ticking behaviour applies to the second (purple-team narrative)
+    streamed call, the case the issue calls out as most visible."""
+    stub_streamlit["button_returns"] = True
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+
+    clock = itertools.count()
+    monkeypatch.setattr(scenario_page_module.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(scenario_page_module, "_STREAM_POLL_INTERVAL", 0.005)
+
+    calls = 0
+
+    def controlled_stream(_config, _messages):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            yield "# Base scenario"
+            return
+        time.sleep(0.1)
+        yield "## Defender walkthrough"
+
+    monkeypatch.setattr("core.scenario_page.call_llm_stream", controlled_stream)
+
+    run_scenario_page(
+        page_id="threat_group",
+        build_messages=lambda _snapshot: [{"role": "user", "content": "x"}],
+        is_ready=lambda: True,
+        download_name="AttackGen APT29 Enterprise.md",
+        trace_name="Threat Group Scenario",
+        trace_tags=("threat_group_scenario",),
+        build_defense=lambda _snapshot: _DEFENSE_REPORT,
+        defense_narrative=True,
+        capture_inputs=lambda: {},
+    )
+
+    assert calls == 2
+    ticks = _phase_labels(
+        stub_streamlit["status_labels"], "Generating purple-team narrative"
+    )
+    assert len(set(ticks)) >= 3
+
+
+def test_streamed_output_still_renders_incrementally_via_worker_thread(
+    stub_streamlit,
+    fake_session_state,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No regression: chunks relayed through the worker thread still arrive
+    at `st.write_stream` incrementally, not batched after the call ends."""
+    stub_streamlit["button_returns"] = True
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+    visible_steps: list[str] = []
+    stub_streamlit["on_stream_chunk"] = (
+        lambda _chunk, chunks: visible_steps.append("".join(chunks))
+    )
+
+    def controlled_stream(_config, _messages):
+        yield "# Part one "
+        yield "part two "
+        yield "part three"
+
+    monkeypatch.setattr("core.scenario_page.call_llm_stream", controlled_stream)
+
+    run_scenario_page(
+        page_id="custom",
+        build_messages=lambda: [{"role": "user", "content": "x"}],
+        is_ready=lambda: True,
+        download_name="custom.md",
+        trace_name="Custom Scenario",
+        trace_tags=("custom_scenario",),
+    )
+
+    visible = stub_streamlit["stream_chunks"]
+    full_text = "# Part one part two part three"
+    assert len(visible) > 1
+    assert "".join(visible) == full_text
+    # At least one intermediate step was visible before the full text -- i.e.
+    # chunks rendered as they arrived rather than only once, after the call.
+    assert any(step != full_text for step in visible_steps[:-1])
+    assert visible_steps[-1] == full_text
+    assert fake_session_state["custom_scenario_text"] == full_text
+
+
+def test_threaded_stream_error_surfaces_same_message_and_no_completion(
+    stub_streamlit,
+    fake_session_state,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A model error raised mid-stream on the worker thread must reach the
+    user the same way a synchronous error would, and the status must never
+    reach "Complete" -- i.e. no spinner is left running as if still working."""
+    stub_streamlit["button_returns"] = True
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+
+    errors: list[str] = []
+    monkeypatch.setattr(st, "error", lambda msg, *a, **k: errors.append(msg))
+
+    def failing_stream(_config, _messages):
+        yield "partial output"
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("core.scenario_page.call_llm_stream", failing_stream)
+
+    run_scenario_page(
+        page_id="threat_group",
+        build_messages=lambda: [{"role": "user", "content": "x"}],
+        is_ready=lambda: True,
+        download_name="threat_group_scenario.md",
+        trace_name="Threat Group Scenario",
+        trace_tags=("threat_group_scenario",),
+    )
+
+    assert errors == ["An error occurred while generating the scenario: boom"]
+    assert fake_session_state["threat_group_scenario_generated"] is False
+    assert not any(
+        label.startswith("Complete") for label in stub_streamlit["status_labels"]
+    )

--- a/tests/test_scenario_page.py
+++ b/tests/test_scenario_page.py
@@ -1000,9 +1000,6 @@ def test_streamed_output_still_renders_incrementally_via_worker_thread(
     fake_session_state["chosen_model_provider"] = "OpenAI API"
     fake_session_state["llm_model_name"] = "gpt-5.5"
     visible_steps: list[str] = []
-    stub_streamlit["on_stream_chunk"] = (
-        lambda _chunk, chunks: visible_steps.append("".join(chunks))
-    )
 
     # The source BLOCKS after the first chunk until the consumer has actually
     # seen it. If the relay buffered the response and only handed it over at

--- a/tests/test_scenario_page.py
+++ b/tests/test_scenario_page.py
@@ -20,8 +20,11 @@ import pytest
 import streamlit as st
 
 import core.llm as llm_module
-import core.scenario_page as scenario_page_module
-from core.scenario_page import _unique_filenames, run_scenario_page
+from core.scenario_page import (
+    _stream_on_worker,
+    _unique_filenames,
+    run_scenario_page,
+)
 
 
 class TestUniqueFilenames:
@@ -913,8 +916,8 @@ def test_elapsed_label_advances_while_base_scenario_call_is_silent(
     fake_session_state["llm_model_name"] = "gpt-5.5"
 
     clock = itertools.count()
-    monkeypatch.setattr(scenario_page_module, "_monotonic", lambda: next(clock))
-    monkeypatch.setattr(scenario_page_module, "_STREAM_POLL_INTERVAL", 0.005)
+    monkeypatch.setattr("core.scenario_page._monotonic", lambda: next(clock))
+    monkeypatch.setattr("core.scenario_page._STREAM_POLL_INTERVAL", 0.005)
 
     def silent_then_stream(_config, _messages):
         # Real sleep on the worker thread: gives the main thread's polling
@@ -951,8 +954,8 @@ def test_elapsed_label_advances_while_narrative_call_is_silent(
     fake_session_state["llm_model_name"] = "gpt-5.5"
 
     clock = itertools.count()
-    monkeypatch.setattr(scenario_page_module, "_monotonic", lambda: next(clock))
-    monkeypatch.setattr(scenario_page_module, "_STREAM_POLL_INTERVAL", 0.005)
+    monkeypatch.setattr("core.scenario_page._monotonic", lambda: next(clock))
+    monkeypatch.setattr("core.scenario_page._STREAM_POLL_INTERVAL", 0.005)
 
     calls = 0
 
@@ -1106,9 +1109,9 @@ def test_worker_thread_is_given_the_script_run_context_before_it_starts(
         seen["thread"] = thread
         seen["alive_at_attach"] = thread.is_alive()
 
-    monkeypatch.setattr(scenario_page_module, "_attach_script_run_ctx", fake_attach)
+    monkeypatch.setattr("core.scenario_page._attach_script_run_ctx", fake_attach)
 
-    assert list(scenario_page_module._stream_on_worker(iter(["a", "b"]))) == ["a", "b"]
+    assert list(_stream_on_worker(iter(["a", "b"]))) == ["a", "b"]
     assert isinstance(seen.get("thread"), threading.Thread)
     # Attaching after start() is a race the context may lose, so ordering is
     # the whole point of the assertion.
@@ -1135,7 +1138,7 @@ def test_closing_the_stream_stops_the_worker_pulling_from_the_model() -> None:
         finally:
             closed.set()
 
-    gen = scenario_page_module._stream_on_worker(source())
+    gen = _stream_on_worker(source())
     assert next(gen).startswith("chunk-0")
     gen.close()
 


### PR DESCRIPTION
Automated by **agent-loop** — the agent worked this issue on a fresh clone of `mrwadams/attackgen` inside a disposable sandbox; changes were gated outside the agent.

Closes #89

## How to test
```bash
git fetch origin && git checkout agent/issue-89
python3 -m venv .venv && . .venv/bin/activate
pip install -r requirements.txt
streamlit run "00_👋_Welcome.py"
```
Then open the printed local URL.

**Confirm each acceptance criterion:**
- [x] The elapsed time visibly advances during a model call's pre-first-token wait, for both the base-scenario and purple-team-narrative phases
- [x] The base-first persistence and phase sequence from #48 are unchanged — the base result and its downloads still render before any optional narrative
- [x] Streamed output still renders incrementally as tokens arrive (no regression in live streaming)
- [x] A model error during a threaded call surfaces the same user-facing error as today and leaves no spinner running
- [x] Tests cover the ticking-during-wait behaviour and the no-regression streaming path using a controllable streaming fixture (no real model call)

## Gates (non-authoritative)
- ✅ **files_non_empty** — 2 non-empty file(s) changed
- ✅ **containment** — diff stays within the allowed lane
- ✅ **verify** — pytest: 257 passed, no failures (browser/e2e excluded)

> **Draft.** Browser/e2e tests were NOT run in-gate — run them and review before merging. Nothing here is auto-merged.
