### PR TITLE
Degraded success and retry for optional enrichment

### DIFF
--- a/core/scenario_page.py
+++ b/core/scenario_page.py
@@ -8,6 +8,16 @@ state keys, widget keys) comes in via ``page_id``.
 
 Adding a new scenario page is now: write the widgets and prompt builder, then
 ``run_scenario_page(page_id=..., build_messages=..., is_ready=..., ...)``.
+
+Generation runs in phases, and only the *base* phase is allowed to fail the
+run. Once the base scenario and its deterministic exports are persisted, the
+optional purple-team narrative is enrichment: if it errors, is skipped, or
+never finishes, the run still ends as a degraded success — everything already
+produced stays on screen and downloadable, a notice explains what is missing,
+and a focused **Retry purple-team narrative** action re-runs *only* the
+narrative against the persisted base. A base-phase failure is attributed to the
+base phase instead, and its retry replays the inputs captured when Generate was
+pressed.
 """
 
 from __future__ import annotations
@@ -18,6 +28,7 @@ import json
 import re
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -35,10 +46,149 @@ from core.navigator import layer_filename, navigator_for_domain
 from core.response import clean_model_response, stream_filter_thinking
 from core.schemas import LLMConfig
 
+try:  # Streamlit >= 1.37
+    from streamlit.runtime.scriptrunner_utils.exceptions import (
+        RerunException,
+        StopException,
+    )
+except ImportError:  # pragma: no cover - older Streamlit module layout
+    try:
+        from streamlit.runtime.scriptrunner.exceptions import (
+            RerunException,
+            StopException,
+        )
+    except ImportError:
+        RerunException = StopException = None
+
+_SCRIPT_CONTROL = tuple(
+    exc for exc in (RerunException, StopException) if exc is not None
+)
+"""Streamlit's rerun/stop signals, which travel as ordinary exceptions."""
+
 Message = dict
 """A single chat message: ``{"role": "...", "content": "..."}``."""
 
 Snapshot = dict[str, Any]
+
+Status = dict[str, str]
+"""Why a phase produced no output: ``{"phase": ..., "reason": ..., "detail": ...}``."""
+
+
+@dataclass(frozen=True)
+class _Keys:
+    """The session-state keys one scenario page owns.
+
+    ``page_id`` namespaces every key so the three pages can coexist in one
+    Streamlit session; grouping them here keeps the phase helpers' signatures
+    readable now that a run also tracks progress and failure state.
+
+    None of these are widget keys — the phase helpers set and clear them
+    directly, which Streamlit only permits for keys no widget owns.
+    """
+
+    page_id: str
+
+    @property
+    def generated(self) -> str:
+        return f"{self.page_id}_scenario_generated"
+
+    @property
+    def text(self) -> str:
+        return f"{self.page_id}_scenario_text"
+
+    @property
+    def layer(self) -> str:
+        return f"{self.page_id}_scenario_layer"
+
+    @property
+    def filename(self) -> str:
+        return f"{self.page_id}_scenario_filename"
+
+    @property
+    def defense(self) -> str:
+        return f"{self.page_id}_scenario_defense"
+
+    @property
+    def defense_report(self) -> str:
+        """The structured report a narrative retry needs to rebuild its prompt."""
+        return f"{self.page_id}_scenario_defense_report"
+
+    @property
+    def snapshot(self) -> str:
+        return f"{self.page_id}_scenario_input_snapshot"
+
+    @property
+    def status(self) -> str:
+        """The current phase failure, if any (see ``Status``)."""
+        return f"{self.page_id}_generation_status"
+
+    @property
+    def narrative_running(self) -> str:
+        """Set while the optional narrative streams; survives a torn-down run."""
+        return f"{self.page_id}_narrative_running"
+
+    @property
+    def narrative_stop(self) -> str:
+        return f"{self.page_id}_narrative_stop_requested"
+
+    @property
+    def retry_base(self) -> str:
+        return f"{self.page_id}_retry_base_requested"
+
+    @property
+    def retry_narrative(self) -> str:
+        return f"{self.page_id}_retry_narrative_requested"
+
+
+BASE_PHASE = "base"
+NARRATIVE_PHASE = "narrative"
+
+_BASE_KEPT = (
+    "The scenario, its downloads, the ATT&CK Navigator layer and the "
+    "deterministic Detection & Response reference are complete and usable."
+)
+
+_NARRATIVE_REASONS = {
+    "error": "The purple-team narrative failed: {detail}.",
+    "stopped": "You skipped the purple-team narrative before it finished.",
+    "interrupted": "The purple-team narrative didn't finish.",
+}
+
+
+def _is_script_control(exc: BaseException) -> bool:
+    """Is this Streamlit tearing the run down rather than a phase failing?
+
+    A queued rerun — which is exactly what pressing Skip, or any other widget,
+    does mid-stream — surfaces as an exception inside the running script. A
+    bare ``except Exception`` would swallow it, dropping the rerun the click
+    asked for and reporting a control signal as a generation error. Every broad
+    handler below re-raises these instead, which also leaves the in-flight
+    marker set so the next run can report the phase as skipped.
+    """
+    return bool(_SCRIPT_CONTROL) and isinstance(exc, _SCRIPT_CONTROL)
+
+
+def _failure(phase: str, reason: str, detail: str = "") -> Status:
+    """Record why a phase produced no output."""
+    return {"phase": phase, "reason": reason, "detail": detail}
+
+
+def _degraded_message(status: Status) -> str:
+    """Explain a missing optional phase without implying the run failed."""
+    template = _NARRATIVE_REASONS.get(
+        status.get("reason", ""), _NARRATIVE_REASONS["interrupted"]
+    )
+    reason = template.format(detail=status.get("detail") or "no output was returned")
+    return f"{reason} {_BASE_KEPT}"
+
+
+def _base_failure_message(status: Status) -> str:
+    detail = status.get("detail") or "the model returned nothing"
+    return (
+        f"The base scenario failed to generate: {detail}. Nothing downstream "
+        "ran. The inputs captured when you pressed Generate are preserved — "
+        "retry to run them again unchanged."
+    )
 
 
 def _invoke_with_snapshot(callback: Callable, snapshot: Snapshot):
@@ -124,24 +274,30 @@ def run_scenario_page(
     from the scenario. When ``defense_narrative`` is true, a second model call
     weaves those detections/mitigations into a stage-by-stage defender's
     walkthrough; the flag is read at generation time from the page's toggle.
+    That second call is optional enrichment — see the module docstring for how
+    a failed, skipped or unfinished narrative degrades rather than blocks.
 
     ``capture_inputs`` returns JSON-native metadata describing the inputs at
     the instant Generate is pressed. Snapshot-aware build callbacks receive a
     deep copy of that mapping; no-argument callbacks remain supported for
-    compatibility. The snapshot is persisted with the result.
+    compatibility. The snapshot is persisted with the result, which is also
+    what lets a base-phase retry replay the run unchanged.
 
     ``download_name`` is a human base label (e.g. ``"AttackGen APT29
     Enterprise.md"``); the markdown and layer downloads get a sanitised,
     timestamped variant so files are meaningful and unique across scenarios.
     """
-    generated_key = f"{page_id}_scenario_generated"
-    text_key = f"{page_id}_scenario_text"
-    layer_key = f"{page_id}_scenario_layer"
-    filename_key = f"{page_id}_scenario_filename"
-    defense_key = f"{page_id}_scenario_defense"
-    snapshot_key = f"{page_id}_scenario_input_snapshot"
+    keys = _Keys(page_id)
+    st.session_state.setdefault(keys.generated, False)
 
-    st.session_state.setdefault(generated_key, False)
+    # A narrative still flagged in-flight belongs to a previous script run that
+    # never finished it; settle that into a degraded status before rendering.
+    _settle_interrupted_narrative(keys)
+
+    # Retry buttons use on_click callbacks, which Streamlit fires before this
+    # script runs — so the request is known here, whatever the notice's position.
+    retry_base = bool(st.session_state.pop(keys.retry_base, False))
+    retry_narrative = bool(st.session_state.pop(keys.retry_narrative, False))
 
     if inline_control is not None:
         button_col, control_col = st.columns([1, 2], vertical_alignment="center")
@@ -151,6 +307,27 @@ def run_scenario_page(
             inline_control()
     else:
         clicked = st.button(button_label, key=f"{page_id}_generate")
+
+    # Reserve the notice's position now; it's written at the end of the run,
+    # once we know whether this run's phases produced everything they should.
+    notice_slot = st.empty()
+
+    def run_generation(snapshot: Snapshot) -> bool:
+        """Run every phase for one snapshot; report whether it rendered."""
+        st.session_state.pop(keys.status, None)
+        _generate_and_render(
+            snapshot=snapshot,
+            keys=keys,
+            build_messages=build_messages,
+            build_layer=build_layer,
+            build_defense=build_defense,
+            trace_name=trace_name,
+            trace_tags=trace_tags,
+            status_text=status_text,
+            human_name=download_name,
+            defense_narrative=defense_narrative,
+        )
+        return bool(st.session_state.get(keys.generated))
 
     rendered = False
     if clicked and is_ready():
@@ -166,63 +343,45 @@ def run_scenario_page(
         identity.setdefault("provider", st.session_state.get("chosen_model_provider"))
         identity.setdefault("model", st.session_state.get("llm_model_name"))
         identity.setdefault("download_name", download_name)
-        st.session_state[snapshot_key] = snapshot
-
-        _generate_and_render(
-            snapshot=snapshot,
-            build_messages=build_messages,
-            build_layer=build_layer,
-            build_defense=build_defense,
-            page_id=page_id,
-            trace_name=trace_name,
-            trace_tags=trace_tags,
-            status_text=status_text,
-            human_name=download_name,
-            generated_key=generated_key,
-            text_key=text_key,
-            layer_key=layer_key,
-            filename_key=filename_key,
-            defense_key=defense_key,
-            defense_narrative=defense_narrative,
+        st.session_state[keys.snapshot] = snapshot
+        rendered = run_generation(snapshot)
+    elif retry_base:
+        # Replay the captured inputs rather than the live widgets, so a retry
+        # regenerates the run the user actually asked for.
+        rendered = run_generation(
+            copy.deepcopy(st.session_state.get(keys.snapshot) or {})
         )
-        rendered = bool(st.session_state.get(generated_key))
+    elif retry_narrative:
+        rendered = _retry_narrative(
+            keys=keys, trace_name=trace_name, download_name=download_name
+        )
 
     # Re-render the persisted scenario on a plain rerun (e.g. after clicking a
     # download button, which reruns the script with the generate button
     # unpressed). Without this the scenario and its downloads would vanish.
-    if not rendered and st.session_state.get(generated_key) and st.session_state.get(text_key):
+    if not rendered and st.session_state.get(keys.generated) and st.session_state.get(keys.text):
         st.markdown("---")
-        _render_previous(
-            page_id=page_id,
-            text_key=text_key,
-            filename_key=filename_key,
-            download_name=download_name,
-            layer_key=layer_key,
-            defense_key=defense_key,
-        )
+        _render_previous(keys=keys, download_name=download_name)
+
+    _render_recovery_notice(keys, slot=notice_slot)
 
     render_feedback_widget(
         key_prefix=page_id,
-        scenario_generated=st.session_state.get(generated_key, False),
+        scenario_generated=st.session_state.get(keys.generated, False),
     )
 
 
 def _generate_and_render(
     *,
     snapshot: Snapshot,
+    keys: _Keys,
     build_messages: Callable[..., list[Message] | None],
     build_layer: Callable[..., str | None] | None,
     build_defense: Callable[..., dict | None] | None,
-    page_id: str,
     trace_name: str,
     trace_tags: tuple[str, ...],
     status_text: str,
     human_name: str,
-    generated_key: str,
-    text_key: str,
-    layer_key: str,
-    filename_key: str,
-    defense_key: str,
     defense_narrative: bool,
 ) -> None:
     """Coordinate and expose each phase of a scenario generation."""
@@ -231,6 +390,7 @@ def _generate_and_render(
     result_placeholder = st.empty()
     raw_chunks: list[str] = []
     scenario_text: str | None = None
+    base_persisted = False
 
     def set_phase(status, phase: str, *, state: str = "running") -> None:
         status.update(label=_elapsed_label(phase, started), state=state)
@@ -244,6 +404,9 @@ def _generate_and_render(
             messages = _invoke_with_snapshot(build_messages, snapshot)
             if messages is None:
                 status.update(label="No scenario inputs were available.", state="error")
+                st.session_state[keys.status] = _failure(
+                    BASE_PHASE, "error", "no scenario inputs were available"
+                )
                 return
             config = LLMConfig.from_session_state(
                 trace_name=trace_name,
@@ -271,6 +434,9 @@ def _generate_and_render(
             thinking, cleaned = clean_model_response(scenario_text)
             if not cleaned:
                 status.update(label="The model returned no scenario.", state="error")
+                st.session_state[keys.status] = _failure(
+                    BASE_PHASE, "error", "the model returned no scenario"
+                )
                 return
 
             # Deterministic artifacts are built only after the base model has
@@ -295,6 +461,8 @@ def _generate_and_render(
 
             # This is the key phase boundary: persist the base result, exports,
             # and Assistant handoff before starting optional model enrichment.
+            # Everything after this point can fail without costing the user the
+            # scenario they are already reading.
             stream_placeholder.empty()
             st.markdown("---")
             if thinking:
@@ -303,64 +471,69 @@ def _generate_and_render(
             with result_placeholder.container():
                 _persist_and_render(
                     cleaned=cleaned,
-                    page_id=page_id,
+                    keys=keys,
                     download_name=md_name,
-                    generated_key=generated_key,
-                    text_key=text_key,
-                    layer_key=layer_key,
-                    filename_key=filename_key,
-                    defense_key=defense_key,
                     layer_payload=layer_payload,
                     defense_state=defense_state,
+                    defense_report=defense_report,
                 )
+            base_persisted = True
 
             run_narrative = snapshot.get("modifiers", {}).get(
                 "purple_team_narrative", defense_narrative
             )
             if defense_report and run_narrative:
                 set_phase(status, "Generating purple-team narrative")
-                narrative_md = _stream_defense_narrative(
+                enriched = _run_narrative_phase(
+                    keys=keys,
                     report=defense_report,
                     scenario_text=cleaned,
+                    defense_state=defense_state,
+                    human_name=snapshot_human_name,
                     trace_name=trace_name,
-                    on_chunk=lambda: set_phase(
+                    on_progress=lambda: set_phase(
                         status, "Generating purple-team narrative"
                     ),
                 )
-                if narrative_md:
-                    defense_state = _add_narrative_to_defense_state(
-                        defense_state=defense_state,
-                        narrative_md=narrative_md,
-                        human_name=snapshot_human_name,
-                    )
-                    st.session_state[defense_key] = defense_state
-                    st.session_state["last_defense_narrative"] = narrative_md
+                if enriched:
                     # Replace, rather than duplicate, the already available base
                     # render now that its optional companion is complete.
                     result_placeholder.empty()
                     with result_placeholder.container():
                         _render_result(
-                            page_id=page_id,
+                            page_id=keys.page_id,
                             cleaned=cleaned,
                             file_name=md_name,
                             layer_payload=layer_payload,
-                            defense_state=defense_state,
+                            defense_state=enriched,
                             variant="current_enriched",
                         )
 
-            set_phase(status, "Complete", state="complete")
+            # A missing optional phase is a degraded success, not a failed run:
+            # the status closes complete and the notice explains the gap.
+            if st.session_state.get(keys.status):
+                set_phase(
+                    status, "Complete without purple-team narrative", state="complete"
+                )
+            else:
+                set_phase(status, "Complete", state="complete")
     except Exception as e:
+        if _is_script_control(e):
+            raise
         st.error(f"An error occurred while generating the scenario: {e}")
-
-    if not scenario_text and st.session_state.get(generated_key) and st.session_state.get(text_key):
-        _render_previous(
-            page_id=page_id,
-            text_key=text_key,
-            filename_key=filename_key,
-            download_name=human_name,
-            layer_key=layer_key,
-            defense_key=defense_key,
+        # Past the phase boundary everything is optional enrichment, so blame
+        # that phase — never tell the user to regenerate a base scenario that
+        # is already sitting on the page, intact.
+        st.session_state[keys.status] = _failure(
+            NARRATIVE_PHASE if base_persisted else BASE_PHASE, "error", str(e)
         )
+
+    if (
+        not scenario_text
+        and st.session_state.get(keys.generated)
+        and st.session_state.get(keys.text)
+    ):
+        _render_previous(keys=keys, download_name=human_name)
 
 
 def _build_defense_state(
@@ -397,30 +570,139 @@ def _add_narrative_to_defense_state(
     return state
 
 
+# --- Optional narrative phase ------------------------------------------------
+
+
+def _request_narrative_stop(stop_key: str) -> None:
+    st.session_state[stop_key] = True
+
+
+def _request_retry(request_key: str) -> None:
+    st.session_state[request_key] = True
+
+
+def _settle_interrupted_narrative(keys: _Keys) -> None:
+    """Turn a narrative left in flight by a torn-down run into a status record.
+
+    Streamlit aborts the running script as soon as a rerun is queued — which is
+    exactly what pressing Skip (or refreshing, or stopping the run) does while
+    the narrative streams. The base scenario is already persisted at that
+    point, but so is the in-progress marker, so on the next run we can tell the
+    optional phase never finished and offer a retry instead of silently
+    dropping it.
+    """
+    if not st.session_state.pop(keys.narrative_running, False):
+        st.session_state.pop(keys.narrative_stop, None)
+        return
+    stopped = bool(st.session_state.pop(keys.narrative_stop, False))
+    st.session_state[keys.status] = _failure(
+        NARRATIVE_PHASE, "stopped" if stopped else "interrupted"
+    )
+
+
+def _render_skip_control(keys: _Keys) -> None:
+    """Offer a way out of a slow or stalled optional phase.
+
+    Clicking this queues a rerun, which tears down the in-flight narrative
+    stream; ``_settle_interrupted_narrative`` then reports it as skipped on the
+    next run. The base scenario is already persisted, so the rerun re-renders
+    it with its downloads intact.
+    """
+    st.button(
+        "Skip purple-team narrative",
+        key=f"{keys.page_id}_skip_narrative",
+        on_click=_request_narrative_stop,
+        args=(keys.narrative_stop,),
+        help=(
+            "Stop waiting for the optional narrative. The scenario and its "
+            "downloads are already saved, and you can retry the narrative later."
+        ),
+    )
+
+
+def _run_narrative_phase(
+    *,
+    keys: _Keys,
+    report: dict,
+    scenario_text: str,
+    defense_state: dict | None,
+    human_name: str,
+    trace_name: str,
+    on_progress: Callable[[], None] | None = None,
+) -> dict | None:
+    """Run the optional narrative and merge it into the persisted companion.
+
+    Returns the enriched Detection & Response state on success. On failure —
+    error, skip, or no output — it returns ``None``, leaves the persisted base
+    result and deterministic companion exactly as they were, and records the
+    degraded status that drives the notice and its Retry action.
+    """
+    st.session_state.pop(keys.narrative_stop, None)
+    # Flag the phase in flight *before* the call, so a run torn down mid-stream
+    # is recognisable on the next one.
+    st.session_state[keys.narrative_running] = True
+    _render_skip_control(keys)
+    # Deliberately not in a `finally`: if the run is torn down here the marker
+    # must survive, so the next run knows this phase never finished.
+    narrative_md, failure = _stream_defense_narrative(
+        report=report,
+        scenario_text=scenario_text,
+        trace_name=trace_name,
+        stop_key=keys.narrative_stop,
+        on_chunk=on_progress,
+    )
+    st.session_state.pop(keys.narrative_running, None)
+
+    if failure:
+        st.session_state[keys.status] = failure
+        return None
+
+    enriched = _add_narrative_to_defense_state(
+        defense_state=defense_state,
+        narrative_md=narrative_md,
+        human_name=human_name,
+    )
+    st.session_state[keys.defense] = enriched
+    st.session_state["last_defense_narrative"] = narrative_md
+    st.session_state.pop(keys.status, None)
+    return enriched
+
+
 def _stream_defense_narrative(
     *,
     report: dict,
     scenario_text: str,
     trace_name: str,
+    stop_key: str,
     on_chunk: Callable[[], None] | None = None,
-) -> str | None:
-    """Stream the optional purple-team narrative pass; return its cleaned text."""
-    config = LLMConfig.from_session_state(
-        trace_name=f"{trace_name} — Detection & Response",
-        trace_tags=("purple_team_narrative",),
-    )
-    messages = build_narrative_messages(scenario_text, report)
+) -> tuple[str | None, Status | None]:
+    """Stream the optional purple-team narrative pass.
+
+    Returns ``(narrative_md, failure)`` with exactly one side set: the cleaned
+    narrative, or a status record saying why there isn't one. Errors are
+    contained here — the caller's base result must survive them.
+    """
     placeholder = st.empty()
     chunks: list[str] = []
 
     def _tee(gen):
         for chunk in gen:
+            # A skip requested mid-stream ends the phase here and discards the
+            # partial narrative. In a browser this rarely fires (the rerun tears
+            # the run down first), but it also stops a stalled stream cleanly.
+            if st.session_state.get(stop_key):
+                return
             chunks.append(chunk)
             if on_chunk:
                 on_chunk()
             yield chunk
 
     try:
+        config = LLMConfig.from_session_state(
+            trace_name=f"{trace_name} — Detection & Response",
+            trace_tags=("purple_team_narrative",),
+        )
+        messages = build_narrative_messages(scenario_text, report)
         # Reasoning models can spend minutes on this second call before emitting
         # any text; the elapsed label only advances as chunks arrive, so it looks
         # stalled during that wait. Say so, so a still spinner reads as "working".
@@ -434,34 +716,142 @@ def _stream_defense_narrative(
                 stream_filter_thinking(_tee(call_llm_stream(config, messages)))
             )
     except Exception as e:
+        if _is_script_control(e):
+            raise
         st.error(f"An error occurred while generating the purple-team narrative: {e}")
-        return None
+        return None, _failure(NARRATIVE_PHASE, "error", str(e))
 
     # Replace the live stream with the canonical cleaned render (done by the
     # caller via _render_defense_body), mirroring the main scenario's handling.
     placeholder.empty()
+    if st.session_state.pop(stop_key, False):
+        return None, _failure(NARRATIVE_PHASE, "stopped")
     _, cleaned = clean_model_response("".join(chunks))
-    return cleaned or None
+    if not cleaned:
+        return None, _failure(
+            NARRATIVE_PHASE, "error", "the model returned no narrative"
+        )
+    return cleaned, None
+
+
+def _retry_narrative(*, keys: _Keys, trace_name: str, download_name: str) -> bool:
+    """Re-run only the narrative against the already-persisted base scenario.
+
+    Nothing about the base is regenerated — no second base-scenario model call,
+    no resampled techniques, no new filenames. Returns whether this rendered
+    the (now enriched) result, so the caller doesn't render it twice.
+    """
+    report = st.session_state.get(keys.defense_report)
+    scenario_text = st.session_state.get(keys.text)
+    defense_state = st.session_state.get(keys.defense)
+    if not (report and scenario_text and defense_state):
+        # Nothing to enrich — e.g. state was cleared since the notice rendered.
+        st.session_state.pop(keys.status, None)
+        return False
+
+    snapshot = st.session_state.get(keys.snapshot) or {}
+    human_name = snapshot.get("identity", {}).get("download_name") or download_name
+    started = time.monotonic()
+    phase = "Retrying purple-team narrative"
+    try:
+        with st.status(_elapsed_label(phase, started), expanded=True) as status:
+            enriched = _run_narrative_phase(
+                keys=keys,
+                report=report,
+                scenario_text=scenario_text,
+                defense_state=defense_state,
+                human_name=human_name,
+                trace_name=trace_name,
+                on_progress=lambda: status.update(label=_elapsed_label(phase, started)),
+            )
+            status.update(
+                label=_elapsed_label(
+                    "Complete" if enriched else "Purple-team narrative still unavailable",
+                    started,
+                ),
+                state="complete",
+            )
+
+        if not enriched:
+            return False
+
+        _render_result(
+            page_id=keys.page_id,
+            cleaned=scenario_text,
+            file_name=st.session_state.get(keys.filename) or download_name,
+            layer_payload=st.session_state.get(keys.layer),
+            defense_state=enriched,
+            variant="retry_enriched",
+        )
+        return True
+    except Exception as e:
+        if _is_script_control(e):
+            raise
+        # A retry of optional enrichment must never cost the base result: fall
+        # through to the caller's re-render of the persisted scenario.
+        st.error(f"An error occurred while retrying the purple-team narrative: {e}")
+        st.session_state[keys.status] = _failure(NARRATIVE_PHASE, "error", str(e))
+        return False
+
+
+def _render_recovery_notice(keys: _Keys, *, slot) -> None:
+    """Explain the current phase failure and offer its focused retry.
+
+    A missing optional narrative reads as a degraded success (warning, base
+    intact); a base-phase failure reads as an error against that phase. Both
+    retries go through ``on_click`` so the request is handled at the top of the
+    next run, wherever this notice sits on the page.
+    """
+    status = st.session_state.get(keys.status)
+    if not status:
+        return
+    with slot.container():
+        if status.get("phase") == NARRATIVE_PHASE:
+            st.warning(_degraded_message(status))
+            st.button(
+                "Retry purple-team narrative",
+                key=f"{keys.page_id}_retry_narrative",
+                on_click=_request_retry,
+                args=(keys.retry_narrative,),
+                help=(
+                    "Re-runs only the narrative against the scenario above — "
+                    "the scenario itself is not generated again."
+                ),
+            )
+        else:
+            st.error(_base_failure_message(status))
+            st.button(
+                "Retry base scenario",
+                key=f"{keys.page_id}_retry_base",
+                on_click=_request_retry,
+                args=(keys.retry_base,),
+                help=(
+                    "Re-runs the scenario with the inputs captured when you "
+                    "pressed Generate."
+                ),
+            )
+
+
+# --- Rendering ---------------------------------------------------------------
 
 
 def _persist_and_render(
     *,
     cleaned: str,
-    page_id: str,
+    keys: _Keys,
     download_name: str,
-    generated_key: str,
-    text_key: str,
-    layer_key: str,
-    filename_key: str,
-    defense_key: str,
     layer_payload: tuple[str, str] | None,
     defense_state: dict | None,
+    defense_report: dict | None,
 ) -> None:
-    st.session_state[generated_key] = True
-    st.session_state[text_key] = cleaned
-    st.session_state[layer_key] = layer_payload
-    st.session_state[filename_key] = download_name
-    st.session_state[defense_key] = defense_state
+    st.session_state[keys.generated] = True
+    st.session_state[keys.text] = cleaned
+    st.session_state[keys.layer] = layer_payload
+    st.session_state[keys.filename] = download_name
+    st.session_state[keys.defense] = defense_state
+    # The structured report is kept so a narrative retry can rebuild its prompt
+    # from the same data, without re-deriving it from (possibly changed) widgets.
+    st.session_state[keys.defense_report] = defense_report
     # Cross-page handoff for the AttackGen Assistant chat page. The defense
     # narrative rides along so the Assistant can refine it too; set it
     # unconditionally (None when there's no narrative) so a stale one from an
@@ -473,7 +863,7 @@ def _persist_and_render(
     )
 
     _render_result(
-        page_id=page_id,
+        page_id=keys.page_id,
         cleaned=cleaned,
         file_name=download_name,
         layer_payload=layer_payload,
@@ -482,26 +872,18 @@ def _persist_and_render(
     )
 
 
-def _render_previous(
-    *,
-    page_id: str,
-    text_key: str,
-    filename_key: str,
-    download_name: str,
-    layer_key: str,
-    defense_key: str,
-) -> None:
-    text = st.session_state.get(text_key, "")
+def _render_previous(*, keys: _Keys, download_name: str) -> None:
+    text = st.session_state.get(keys.text, "")
     # Prefer the name fixed at generation time so it stays stable (and matches
     # the layer) across the reruns a download click triggers.
-    file_name = st.session_state.get(filename_key) or download_name
+    file_name = st.session_state.get(keys.filename) or download_name
     st.markdown("Displaying previously generated scenario:")
     _render_result(
-        page_id=page_id,
+        page_id=keys.page_id,
         cleaned=text,
         file_name=file_name,
-        layer_payload=st.session_state.get(layer_key),
-        defense_state=st.session_state.get(defense_key),
+        layer_payload=st.session_state.get(keys.layer),
+        defense_state=st.session_state.get(keys.defense),
         variant="previous",
     )
 

--- a/core/scenario_page.py
+++ b/core/scenario_page.py
@@ -176,17 +176,29 @@ def _failure(phase: str, reason: str, detail: str = "") -> Status:
     return {"phase": phase, "reason": reason, "detail": detail}
 
 
+def _detail_phrase(detail: str) -> str:
+    """Trim a failure detail so the sentence around it ends in one full stop.
+
+    Client errors are quoted verbatim into these notices, and they routinely
+    arrive already punctuated — litellm's connection errors end in ".", giving
+    "Connection error.." once the template adds its own. Strip whatever
+    sentence-ending punctuation the detail brought and let the template supply it.
+    """
+    return detail.rstrip().rstrip(".!?") or detail
+
+
 def _degraded_message(status: Status) -> str:
     """Explain a missing optional phase without implying the run failed."""
     template = _NARRATIVE_REASONS.get(
         status.get("reason", ""), _NARRATIVE_REASONS["interrupted"]
     )
-    reason = template.format(detail=status.get("detail") or "no output was returned")
+    detail = _detail_phrase(status.get("detail", "")) or "no output was returned"
+    reason = template.format(detail=detail)
     return f"{reason} {_BASE_KEPT}"
 
 
 def _base_failure_message(status: Status) -> str:
-    detail = status.get("detail") or "the model returned nothing"
+    detail = _detail_phrase(status.get("detail", "")) or "the model returned nothing"
     return (
         f"The base scenario failed to generate: {detail}. Nothing downstream "
         "ran. The inputs captured when you pressed Generate are preserved — "
@@ -727,24 +739,31 @@ def _settle_interrupted_narrative(keys: _Keys) -> None:
     )
 
 
-def _render_skip_control(keys: _Keys) -> None:
+def _render_skip_control(keys: _Keys):
     """Offer a way out of a slow or stalled optional phase.
 
     Clicking this queues a rerun, which tears down the in-flight narrative
     stream; ``_settle_interrupted_narrative`` then reports it as skipped on the
     next run. The base scenario is already persisted, so the rerun re-renders
     it with its downloads intact.
+
+    Returns the placeholder holding the button so the caller can clear it once
+    the phase is over — a Skip control left on screen after the narrative has
+    settled offers to interrupt something that is no longer running.
     """
-    st.button(
-        "Skip purple-team narrative",
-        key=f"{keys.page_id}_skip_narrative",
-        on_click=_request_narrative_stop,
-        args=(keys.narrative_stop,),
-        help=(
-            "Stop waiting for the optional narrative. The scenario and its "
-            "downloads are already saved, and you can retry the narrative later."
-        ),
-    )
+    slot = st.empty()
+    with slot.container():
+        st.button(
+            "Skip purple-team narrative",
+            key=f"{keys.page_id}_skip_narrative",
+            on_click=_request_narrative_stop,
+            args=(keys.narrative_stop,),
+            help=(
+                "Stop waiting for the optional narrative. The scenario and its "
+                "downloads are already saved, and you can retry the narrative later."
+            ),
+        )
+    return slot
 
 
 def _run_narrative_phase(
@@ -768,9 +787,11 @@ def _run_narrative_phase(
     # Flag the phase in flight *before* the call, so a run torn down mid-stream
     # is recognisable on the next one.
     st.session_state[keys.narrative_running] = True
-    _render_skip_control(keys)
+    skip_slot = _render_skip_control(keys)
     # Deliberately not in a `finally`: if the run is torn down here the marker
-    # must survive, so the next run knows this phase never finished.
+    # must survive, so the next run knows this phase never finished. The Skip
+    # control is cleared on the same terms — only once the phase has settled,
+    # so a run torn down mid-stream leaves it on screen for the rerun to replace.
     narrative_md, failure = _stream_defense_narrative(
         report=report,
         scenario_text=scenario_text,
@@ -779,6 +800,7 @@ def _run_narrative_phase(
         on_progress=on_progress,
     )
     st.session_state.pop(keys.narrative_running, None)
+    skip_slot.empty()
 
     if failure:
         st.session_state[keys.status] = failure

--- a/tests/test_scenario_page.py
+++ b/tests/test_scenario_page.py
@@ -17,7 +17,7 @@ import pytest
 import streamlit as st
 
 import core.llm as llm_module
-from core.scenario_page import _unique_filenames, run_scenario_page
+from core.scenario_page import _SCRIPT_CONTROL, _unique_filenames, run_scenario_page
 
 
 class TestUniqueFilenames:
@@ -48,15 +48,25 @@ def stub_streamlit(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
 
     Returns a dict the test can mutate to control widget return values:
       - `button_returns`: bool returned by `st.button`
+
+    and read to see what was rendered: `buttons` (every `st.button` call's
+    kwargs, so a test can press one via its `on_click`), `warnings`, `errors`
+    and `status_labels`.
     """
     controls: dict[str, Any] = {
         "button_returns": False,
         "status_labels": [],
         "stream_chunks": [],
         "on_stream_chunk": None,
+        "buttons": [],
+        "warnings": [],
+        "errors": [],
     }
 
-    def _button(*_args, **_kwargs):
+    def _button(*args, **kwargs):
+        controls["buttons"].append(
+            {"label": args[0] if args else kwargs.get("label"), **kwargs}
+        )
         return controls["button_returns"]
 
     @contextmanager
@@ -97,8 +107,8 @@ def stub_streamlit(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     monkeypatch.setattr(st, "write_stream", _write_stream)
     monkeypatch.setattr(st, "download_button", _noop)
     monkeypatch.setattr(st, "info", _noop)
-    monkeypatch.setattr(st, "warning", _noop)
-    monkeypatch.setattr(st, "error", _noop)
+    monkeypatch.setattr(st, "warning", lambda msg, *a, **k: controls["warnings"].append(msg))
+    monkeypatch.setattr(st, "error", lambda msg, *a, **k: controls["errors"].append(msg))
     # `render_feedback_widget` calls `st.empty()` then `st.markdown('---')`.
     monkeypatch.setattr(st, "empty", _FakePlaceholder)
     # Pretend no LangSmith key is configured so the feedback widget
@@ -880,3 +890,411 @@ def test_streamed_base_text_is_visible_chunk_by_chunk(
     assert visible_steps[0] != visible_steps[-1]
     assert visible_steps[-1] == "# Partial scenario"
     assert fake_session_state["custom_scenario_text"] == "# Partial scenario"
+
+
+# --- Degraded success and retry for optional enrichment ----------------------
+
+
+@pytest.fixture
+def controllable_stream(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    """A scripted stand-in for `call_llm_stream`, one script per model call.
+
+    Set `.scripts` to a list of step-lists — the first is played by the base
+    scenario call, the second by the purple-team narrative call, and so on
+    (calls past the end yield a single default chunk). Each step is either:
+
+      - a string, yielded as a stream chunk;
+      - a callable, invoked *between* chunks (to land a click mid-stream);
+      - an exception instance, raised from inside the stream.
+
+    Every call's config and messages are recorded in `.calls`, so a test can
+    prove which phase ran — and, for a retry, which phase *didn't*.
+    """
+    scripted = SimpleNamespace(scripts=[], calls=[])
+
+    def _stream(config, messages):
+        scripted.calls.append(SimpleNamespace(config=config, messages=messages))
+        index = len(scripted.calls) - 1
+        steps = scripted.scripts[index] if index < len(scripted.scripts) else ["# Scenario"]
+        for step in steps:
+            if isinstance(step, BaseException):
+                raise step
+            if callable(step):
+                step()
+                continue
+            yield step
+
+    monkeypatch.setattr("core.scenario_page.call_llm_stream", _stream)
+    return scripted
+
+
+def _is_narrative_call(call) -> bool:
+    """The purple-team pass is the one tagged for it in LangSmith."""
+    return call.config.trace_tags == ("purple_team_narrative",)
+
+
+def _click(stub_streamlit: dict[str, Any], key: str) -> None:
+    """Fire the `on_click` callback Streamlit runs when that button is pressed.
+
+    Streamlit runs the callback before the next script run, which is exactly
+    how the page picks the request up — so a test presses a button by calling
+    its callback and then running the page again.
+    """
+    for record in stub_streamlit["buttons"]:
+        if record.get("key") == key:
+            record["on_click"](*record.get("args", ()))
+            return
+    raise AssertionError(f"no button was rendered with key {key!r}")
+
+
+def _run_page(**overrides) -> None:
+    """Run the threat-group page with a defence report and narrative enabled."""
+    kwargs: dict[str, Any] = {
+        "page_id": "threat_group",
+        "build_messages": lambda _snapshot: [{"role": "user", "content": "x"}],
+        "is_ready": lambda: True,
+        "download_name": "AttackGen APT29 Enterprise.md",
+        "trace_name": "Threat Group Scenario",
+        "trace_tags": ("threat_group_scenario",),
+        "build_layer": lambda _snapshot: '{"domain": "enterprise-attack"}',
+        "build_defense": lambda _snapshot: _DEFENSE_REPORT,
+        "defense_narrative": True,
+        "capture_inputs": lambda: {"matrix": "Enterprise"},
+    }
+    kwargs.update(overrides)
+    run_scenario_page(**kwargs)
+
+
+def _generate_with_narrative(
+    stub_streamlit, fake_session_state, controllable_stream, narrative_script
+) -> None:
+    """Generate a scenario, playing `narrative_script` for the optional phase."""
+    stub_streamlit["button_returns"] = True
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+    fake_session_state["llm_api_key"] = "k"
+    controllable_stream.scripts = [["# Base scenario"], narrative_script]
+    _run_page()
+
+
+def test_failed_narrative_leaves_base_scenario_and_exports_usable(
+    stub_streamlit,
+    fake_session_state,
+    controllable_stream,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    downloads = _capture_downloads(monkeypatch)
+    _generate_with_narrative(
+        stub_streamlit,
+        fake_session_state,
+        controllable_stream,
+        [RuntimeError("upstream 503")],
+    )
+
+    # The base phase's output survives the optional phase's failure, whole.
+    assert fake_session_state["threat_group_scenario_generated"] is True
+    assert fake_session_state["threat_group_scenario_text"] == "# Base scenario"
+    assert fake_session_state["last_scenario_text"] == "# Base scenario"
+    assert fake_session_state["threat_group_scenario_layer"][0] == (
+        '{"domain": "enterprise-attack"}'
+    )
+    defense = fake_session_state["threat_group_scenario_defense"]
+    assert "Command and Scripting Interpreter (T1059)" in defense["deterministic_md"]
+    assert defense["narrative_md"] is None
+    assert fake_session_state["last_defense_narrative"] is None
+
+    # All three downloads are offered: scenario, Navigator layer, defence.
+    assert any(d.get("label") == "Download Scenario" for d in downloads)
+    assert any(d.get("mime") == "application/json" for d in downloads)
+    assert any(d.get("file_name", "").endswith("_detection.md") for d in downloads)
+
+    # The run still closes as a (degraded) success, not an error.
+    assert any(
+        label.startswith("Complete without purple-team narrative")
+        for label in stub_streamlit["status_labels"]
+    )
+
+
+def test_degraded_message_explains_failure_and_offers_narrative_retry(
+    stub_streamlit, fake_session_state, controllable_stream
+) -> None:
+    _generate_with_narrative(
+        stub_streamlit,
+        fake_session_state,
+        controllable_stream,
+        [RuntimeError("upstream 503")],
+    )
+
+    status = fake_session_state["threat_group_generation_status"]
+    assert status["phase"] == "narrative"
+    assert status["reason"] == "error"
+
+    # A warning (degraded success), not an error — and it says what failed.
+    notice = "\n".join(stub_streamlit["warnings"])
+    assert "purple-team narrative failed" in notice
+    assert "upstream 503" in notice
+    assert "complete and usable" in notice
+
+    retry = [
+        b for b in stub_streamlit["buttons"] if b.get("key") == "threat_group_retry_narrative"
+    ]
+    assert len(retry) == 1
+    assert retry[0]["label"] == "Retry purple-team narrative"
+
+
+def test_narrative_retry_reruns_only_the_narrative_and_merges_it(
+    stub_streamlit,
+    fake_session_state,
+    controllable_stream,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _generate_with_narrative(
+        stub_streamlit,
+        fake_session_state,
+        controllable_stream,
+        [RuntimeError("upstream 503")],
+    )
+    md_name = fake_session_state["threat_group_scenario_filename"]
+
+    _click(stub_streamlit, "threat_group_retry_narrative")
+
+    # The rerun the click triggers: Generate is not pressed, and the page's
+    # readiness has since lapsed — the retry must not depend on either.
+    stub_streamlit["button_returns"] = False
+    stub_streamlit["warnings"].clear()
+    controllable_stream.scripts = [[], [], ["## Defender walkthrough"]]
+    downloads = _capture_downloads(monkeypatch)
+    _run_page(is_ready=lambda: False)
+
+    # Three model calls in total, and the retry's is the narrative — the base
+    # scenario is never generated a second time.
+    assert len(controllable_stream.calls) == 3
+    assert _is_narrative_call(controllable_stream.calls[2])
+    assert sum(1 for c in controllable_stream.calls if not _is_narrative_call(c)) == 1
+
+    # The narrative is merged into the Detection & Response view and download.
+    defense = fake_session_state["threat_group_scenario_defense"]
+    assert defense["narrative_md"] == "## Defender walkthrough"
+    assert "Defender walkthrough" in defense["download_md"]
+    assert "Detection & Response Reference" in defense["download_md"]
+    assert fake_session_state["last_defense_narrative"] == "## Defender walkthrough"
+    detection_downloads = [
+        d for d in downloads if d.get("file_name", "").endswith("_detection.md")
+    ]
+    assert detection_downloads[-1]["data"] == defense["download_md"]
+
+    # The base result is untouched — same text, same download names.
+    assert fake_session_state["threat_group_scenario_text"] == "# Base scenario"
+    assert fake_session_state["threat_group_scenario_filename"] == md_name
+
+    # No degraded state left behind, so no notice on the next rerun.
+    assert "threat_group_generation_status" not in fake_session_state
+    assert stub_streamlit["warnings"] == []
+
+
+def test_skip_requested_mid_stream_abandons_narrative_and_keeps_base(
+    stub_streamlit, fake_session_state, controllable_stream
+) -> None:
+    def request_skip():
+        st.session_state["threat_group_narrative_stop_requested"] = True
+
+    _generate_with_narrative(
+        stub_streamlit,
+        fake_session_state,
+        controllable_stream,
+        ["## Half a walk", request_skip, "through"],
+    )
+
+    # The partial narrative is discarded; the base result stands on its own.
+    assert fake_session_state["threat_group_scenario_text"] == "# Base scenario"
+    assert fake_session_state["threat_group_scenario_defense"]["narrative_md"] is None
+    assert fake_session_state["last_defense_narrative"] is None
+    status = fake_session_state["threat_group_generation_status"]
+    assert status == {"phase": "narrative", "reason": "stopped", "detail": ""}
+    assert "You skipped the purple-team narrative" in "\n".join(stub_streamlit["warnings"])
+    assert any(
+        b.get("key") == "threat_group_retry_narrative" for b in stub_streamlit["buttons"]
+    )
+
+
+def test_skip_button_requests_the_stop(
+    stub_streamlit, fake_session_state, controllable_stream
+) -> None:
+    """The Skip control is what sets the flag the narrative phase watches."""
+    stub_streamlit["button_returns"] = True
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+    controllable_stream.scripts = [["# Base scenario"], ["## Walkthrough"]]
+    _run_page()
+
+    skip = [
+        b for b in stub_streamlit["buttons"] if b.get("key") == "threat_group_skip_narrative"
+    ]
+    assert len(skip) == 1
+    _click(stub_streamlit, "threat_group_skip_narrative")
+    assert fake_session_state["threat_group_narrative_stop_requested"] is True
+
+
+def test_narrative_left_in_flight_by_a_torn_down_run_is_reported_next_run(
+    stub_streamlit, fake_session_state, controllable_stream
+) -> None:
+    """Pressing Skip reruns the script, which kills the in-flight stream.
+
+    The next run finds the in-progress marker with no narrative and must report
+    the optional phase as skipped — with the base result still on the page —
+    rather than pretend it completed.
+    """
+    stub_streamlit["button_returns"] = False
+    fake_session_state.update(
+        {
+            "threat_group_scenario_generated": True,
+            "threat_group_scenario_text": "# Base scenario",
+            "threat_group_scenario_filename": "scn_20260714-153045.md",
+            "threat_group_scenario_layer": None,
+            "threat_group_scenario_defense": {
+                "deterministic_md": "## 🛡️ Detection & Response",
+                "narrative_md": None,
+                "download_md": "# Detection & Response — scn",
+                "filename": "scn_20260714-153045_detection.md",
+            },
+            # Left behind by the run the rerun tore down.
+            "threat_group_narrative_running": True,
+            "threat_group_narrative_stop_requested": True,
+        }
+    )
+
+    _run_page(is_ready=lambda: False)
+
+    assert controllable_stream.calls == []  # nothing is regenerated
+    assert fake_session_state["threat_group_generation_status"] == {
+        "phase": "narrative",
+        "reason": "stopped",
+        "detail": "",
+    }
+    # The markers are consumed, so the next rerun doesn't re-report it.
+    assert "threat_group_narrative_running" not in fake_session_state
+    assert "threat_group_narrative_stop_requested" not in fake_session_state
+    assert fake_session_state["threat_group_scenario_text"] == "# Base scenario"
+    assert any(
+        b.get("key") == "threat_group_retry_narrative" for b in stub_streamlit["buttons"]
+    )
+
+
+def test_degraded_state_renders_base_and_notice_on_a_plain_rerun(
+    stub_streamlit,
+    fake_session_state,
+    controllable_stream,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A degraded run stays degraded-but-complete across reruns: every base
+    download is re-offered, and the notice keeps offering the retry."""
+    _generate_with_narrative(
+        stub_streamlit,
+        fake_session_state,
+        controllable_stream,
+        [RuntimeError("upstream 503")],
+    )
+
+    stub_streamlit["button_returns"] = False
+    stub_streamlit["buttons"].clear()
+    stub_streamlit["warnings"].clear()
+    downloads = _capture_downloads(monkeypatch)
+    _run_page(is_ready=lambda: False)
+
+    assert len(controllable_stream.calls) == 2  # no phase re-ran on this rerun
+    assert any(d.get("label") == "Download Scenario" for d in downloads)
+    assert any(d.get("mime") == "application/json" for d in downloads)
+    assert any(d.get("file_name", "").endswith("_detection.md") for d in downloads)
+    assert "purple-team narrative failed" in "\n".join(stub_streamlit["warnings"])
+    assert any(
+        b.get("key") == "threat_group_retry_narrative" for b in stub_streamlit["buttons"]
+    )
+
+
+def test_base_failure_is_attributed_to_the_base_phase(
+    stub_streamlit, fake_session_state, controllable_stream
+) -> None:
+    stub_streamlit["button_returns"] = True
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+    controllable_stream.scripts = [[RuntimeError("rate limited")]]
+
+    _run_page()
+
+    status = fake_session_state["threat_group_generation_status"]
+    assert status["phase"] == "base"
+    assert status["detail"] == "rate limited"
+    # Nothing usable was produced, so this reads as an error, not degraded.
+    assert stub_streamlit["warnings"] == []
+    assert fake_session_state["threat_group_scenario_generated"] is False
+    notice = "\n".join(stub_streamlit["errors"])
+    assert "base scenario failed to generate" in notice.lower()
+    assert "rate limited" in notice
+    retry = [
+        b for b in stub_streamlit["buttons"] if b.get("key") == "threat_group_retry_base"
+    ]
+    assert len(retry) == 1
+    assert retry[0]["label"] == "Retry base scenario"
+
+
+def test_base_retry_replays_the_captured_inputs(
+    stub_streamlit, fake_session_state, controllable_stream
+) -> None:
+    stub_streamlit["button_returns"] = True
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+    controllable_stream.scripts = [[RuntimeError("rate limited")]]
+    source = {"matrix": "Enterprise"}
+
+    _run_page(
+        defense_narrative=False,
+        build_messages=lambda snapshot: [
+            {"role": "user", "content": snapshot["matrix"]}
+        ],
+        capture_inputs=lambda: source,
+    )
+
+    # The widgets move on after the failure; the retry must not follow them.
+    source["matrix"] = "ICS"
+    _click(stub_streamlit, "threat_group_retry_base")
+    stub_streamlit["button_returns"] = False
+    controllable_stream.scripts = [[], ["# Base scenario"]]
+
+    _run_page(
+        is_ready=lambda: False,
+        defense_narrative=False,
+        build_messages=lambda snapshot: [
+            {"role": "user", "content": snapshot["matrix"]}
+        ],
+        capture_inputs=lambda: source,
+    )
+
+    assert len(controllable_stream.calls) == 2
+    assert controllable_stream.calls[1].messages == [
+        {"role": "user", "content": "Enterprise"}
+    ]
+    assert fake_session_state["threat_group_scenario_text"] == "# Base scenario"
+    assert fake_session_state["threat_group_scenario_generated"] is True
+    assert "threat_group_generation_status" not in fake_session_state
+
+
+@pytest.mark.skipif(
+    not _SCRIPT_CONTROL, reason="Streamlit exposes no script-control exceptions"
+)
+def test_rerun_signal_during_the_narrative_is_not_swallowed(
+    stub_streamlit, fake_session_state, controllable_stream
+) -> None:
+    """Pressing Skip queues a rerun, which Streamlit raises inside the running
+    script. Swallowing it would drop the rerun and report a control signal as a
+    generation failure, so it propagates — with the in-flight marker left set,
+    which is how the next run knows the optional phase never finished."""
+    rerun = _SCRIPT_CONTROL[0](None)
+
+    with pytest.raises(type(rerun)):
+        _generate_with_narrative(
+            stub_streamlit, fake_session_state, controllable_stream, [rerun]
+        )
+
+    assert fake_session_state["threat_group_scenario_text"] == "# Base scenario"
+    assert fake_session_state["threat_group_narrative_running"] is True
+    assert "threat_group_generation_status" not in fake_session_state

--- a/tests/test_scenario_page.py
+++ b/tests/test_scenario_page.py
@@ -69,12 +69,16 @@ def stub_streamlit(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         "buttons": [],
         "warnings": [],
         "errors": [],
+        # Every placeholder `st.empty()` handed out, so a test can ask whether
+        # the one holding a transient control was cleared before the run ended.
+        "placeholders": [],
     }
 
     def _button(*args, **kwargs):
-        controls["buttons"].append(
-            {"label": args[0] if args else kwargs.get("label"), **kwargs}
-        )
+        label = args[0] if args else kwargs.get("label")
+        controls["buttons"].append({"label": label, **kwargs})
+        if _OPEN_PLACEHOLDERS:
+            _OPEN_PLACEHOLDERS[-1].rendered.append(label)
         return controls["button_returns"]
 
     @contextmanager
@@ -117,8 +121,13 @@ def stub_streamlit(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     monkeypatch.setattr(st, "info", _noop)
     monkeypatch.setattr(st, "warning", lambda msg, *a, **k: controls["warnings"].append(msg))
     monkeypatch.setattr(st, "error", lambda msg, *a, **k: controls["errors"].append(msg))
+    def _empty():
+        slot = _FakePlaceholder()
+        controls["placeholders"].append(slot)
+        return slot
+
     # `render_feedback_widget` calls `st.empty()` then `st.markdown('---')`.
-    monkeypatch.setattr(st, "empty", _FakePlaceholder)
+    monkeypatch.setattr(st, "empty", _empty)
     # Pretend no LangSmith key is configured so the feedback widget
     # short-circuits cleanly during these general scenario-page tests.
     monkeypatch.setattr(st, "secrets", {})
@@ -135,14 +144,35 @@ class _FakeTab:
 
 
 class _FakePlaceholder:
+    """A stand-in for `st.empty()` that remembers what was put in it.
+
+    `rendered` collects the buttons written through `container()`, and
+    `cleared` records whether `empty()` was called — together they let a test
+    say "this control was rendered into a slot, and that slot was cleared".
+    """
+
+    def __init__(self):
+        self.rendered: list[str] = []
+        self.cleared = False
+
     def success(self, *_a, **_k): pass
     def warning(self, *_a, **_k): pass
     def error(self, *_a, **_k): pass
-    def empty(self, *_a, **_k): pass
+
+    def empty(self, *_a, **_k):
+        self.cleared = True
 
     @contextmanager
     def container(self, *_a, **_k):
-        yield None
+        _OPEN_PLACEHOLDERS.append(self)
+        try:
+            yield None
+        finally:
+            _OPEN_PLACEHOLDERS.pop()
+
+
+_OPEN_PLACEHOLDERS: list[_FakePlaceholder] = []
+"""The `st.empty()` containers currently open, innermost last."""
 
 
 @pytest.fixture
@@ -1217,6 +1247,116 @@ def test_degraded_state_renders_base_and_notice_on_a_plain_rerun(
     assert any(
         b.get("key") == "threat_group_retry_narrative" for b in stub_streamlit["buttons"]
     )
+
+
+_BASE_KEPT_PREFIX = "The scenario, its downloads,"
+"""Opening of the reassurance clause the degraded notice appends."""
+
+
+def _skip_slot(stub_streamlit: dict[str, Any]):
+    """The placeholder the Skip control was rendered into, if any."""
+    for slot in stub_streamlit["placeholders"]:
+        if "Skip purple-team narrative" in slot.rendered:
+            return slot
+    return None
+
+
+def test_skip_control_is_cleared_once_the_narrative_settles(
+    stub_streamlit, fake_session_state, controllable_stream
+) -> None:
+    """A Skip button outliving its phase offers to interrupt nothing.
+
+    The control belongs to the window where the narrative is actually in
+    flight, so once the phase settles — here, by failing — the slot holding it
+    must be cleared rather than left on screen beside the retry.
+    """
+    _generate_with_narrative(
+        stub_streamlit,
+        fake_session_state,
+        controllable_stream,
+        [RuntimeError("upstream 503")],
+    )
+
+    slot = _skip_slot(stub_streamlit)
+    assert slot is not None, "the Skip control was never rendered"
+    assert slot.cleared, "the Skip control outlived the phase it interrupts"
+
+
+@pytest.mark.skipif(
+    not _SCRIPT_CONTROL, reason="Streamlit exposes no script-control exceptions"
+)
+def test_skip_control_survives_a_run_torn_down_mid_stream(
+    stub_streamlit, fake_session_state, controllable_stream
+) -> None:
+    """Clearing it is conditional on the phase settling, not on leaving the call.
+
+    A rerun tears the script down mid-stream; the phase has not settled, so the
+    control must still be standing for the next run to replace — the same terms
+    on which the in-flight marker survives.
+    """
+    rerun = _SCRIPT_CONTROL[0](None)
+
+    def _tear_down_on_narrative_chunk(chunk: str, _seen: list[str]) -> None:
+        if chunk.startswith("##"):
+            raise rerun
+
+    stub_streamlit["on_stream_chunk"] = _tear_down_on_narrative_chunk
+
+    with pytest.raises(type(rerun)):
+        _generate_with_narrative(
+            stub_streamlit,
+            fake_session_state,
+            controllable_stream,
+            ["## Defender walkthrough"],
+        )
+
+    slot = _skip_slot(stub_streamlit)
+    assert slot is not None, "the Skip control was never rendered"
+    assert not slot.cleared
+    assert fake_session_state["threat_group_narrative_running"] is True
+
+
+_PUNCTUATED_DETAILS = ["Connection error.", "Connection error", "rate limited!"]
+"""Client error strings as they actually arrive: punctuated, bare, emphatic."""
+
+
+@pytest.mark.parametrize("detail", _PUNCTUATED_DETAILS)
+def test_degraded_notice_ends_in_a_single_full_stop(
+    stub_streamlit, fake_session_state, controllable_stream, detail: str
+) -> None:
+    """Client errors are quoted verbatim and often arrive already punctuated.
+
+    litellm's connection errors end in "."; appending the template's own stop
+    gave users "Connection error..". Whatever punctuation the detail brought,
+    the sentence around it must close exactly once.
+    """
+    _generate_with_narrative(
+        stub_streamlit, fake_session_state, controllable_stream, [RuntimeError(detail)]
+    )
+
+    notice = "\n".join(stub_streamlit["warnings"])
+    assert notice.startswith("The purple-team narrative failed: ")
+    assert f"{detail.rstrip('.!')}. {_BASE_KEPT_PREFIX}" in notice
+    assert ".." not in notice
+    assert "!." not in notice
+
+
+@pytest.mark.parametrize("detail", _PUNCTUATED_DETAILS)
+def test_base_failure_notice_ends_in_a_single_full_stop(
+    stub_streamlit, fake_session_state, controllable_stream, detail: str
+) -> None:
+    """The base-phase notice quotes the same details and must read the same."""
+    stub_streamlit["button_returns"] = True
+    fake_session_state["chosen_model_provider"] = "OpenAI API"
+    fake_session_state["llm_model_name"] = "gpt-5.5"
+    controllable_stream.scripts = [[RuntimeError(detail)]]
+
+    _run_page()
+
+    notice = "\n".join(stub_streamlit["errors"])
+    assert f"{detail.rstrip('.!')}. Nothing downstream ran." in notice
+    assert ".." not in notice
+    assert "!." not in notice
 
 
 def test_base_failure_is_attributed_to_the_base_phase(


### PR DESCRIPTION
Automated by **agent-loop** — the agent worked this issue on a fresh clone of `mrwadams/attackgen` inside a disposable sandbox; changes were gated outside the agent.

Closes #50

## How to test
```bash
git fetch origin && git checkout agent/issue-50
python3 -m venv .venv && . .venv/bin/activate
pip install -r requirements.txt
streamlit run "00_👋_Welcome.py"
```
Then open the printed local URL.

**Confirm each acceptance criterion:**
- [x] A failed or stopped narrative leaves the base scenario, base downloads, Navigator layer, and deterministic defense reference fully usable
- [x] A degraded-success message explains what failed and offers Retry purple-team narrative
- [x] Retry re-runs only the narrative (no second base-scenario model call) and merges it into the Detection & Response view/download on success
- [x] A stalled optional phase can be skipped/stopped while retaining the base result
- [x] A base-phase failure is associated with the base phase and offers a retry that preserves the captured inputs
- [x] Tests cover narrative error, narrative stop/skip, retry-without-second-base-call, and degraded-complete rendering using a controllable streaming fixture

## Gates (non-authoritative)
- ✅ **files_non_empty** — 2 non-empty file(s) changed
- ✅ **containment** — diff stays within the allowed lane
- ✅ **verify** — pytest: 263 passed, no failures (browser/e2e excluded)

> **Draft.** Browser/e2e tests were NOT run in-gate — run them and review before merging. Nothing here is auto-merged.
