### PR TITLE
ci: drop Python 3.10 in favour of a 3.11 floor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        # 3.10 was dropped in favour of a 3.11 floor: litellm 1.98.0+ imports
+        # `NotRequired`/`Required` from stdlib `typing` (3.11+) on the `import
+        # litellm` path, so `import core` — and therefore every test — fails to
+        # collect on 3.10. litellm still declares `requires-python >=3.10`, but
+        # has broken it repeatedly (BerriAI/litellm#38076, #38892); 1.100.0 is
+        # still broken even after the #39448 fix. 3.10 reaches EOL in Oct 2026
+        # and the shipped Docker image runs 3.14, so capping litellm to keep it
+        # alive would freeze the model registry for no real benefit.
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        # 3.10 was dropped in favour of a 3.11 floor: litellm 1.98.0+ imports
+        # `NotRequired`/`Required` from stdlib `typing` (3.11+) on the `import
+        # litellm` path, so `import core` — and therefore every test — fails to
+        # collect on 3.10. litellm still declares `requires-python >=3.10`, but
+        # has broken it repeatedly (BerriAI/litellm#38076, #38892); 1.100.0 is
+        # still broken even after the #39448 fix. 3.10 reaches EOL in Oct 2026
+        # and the shipped Docker image runs 3.14, so capping litellm to keep it
+        # alive would freeze the model registry for no real benefit.
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ pytest
 ```
 `pyproject.toml` sets `testpaths = ["tests"]` and `pythonpath = ["."]`, so `pytest` from the repo root discovers everything under `tests/` with no extra flags. It also declares `[project]`/`[build-system]` metadata and the `attackgen-mcp = "mcp_server:main"` console script, so `pip install -e .` makes the package importable and installs the MCP entry point.
 
-In CI, `.github/workflows/tests.yml` runs the same suite on Python 3.10–3.14 for every push and pull request to `main`. `release.yml` keeps its own copy of that job so a release gates on its own tag rather than on whatever last ran against `main`.
+In CI, `.github/workflows/tests.yml` runs the same suite on Python 3.11–3.14 for every push and pull request to `main`. `release.yml` keeps its own copy of that job so a release gates on its own tag rather than on whatever last ran against `main`.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,10 @@ pytest
 ```
 `pyproject.toml` sets `testpaths = ["tests"]` and `pythonpath = ["."]`, so `pytest` from the repo root discovers everything under `tests/` with no extra flags. It also declares `[project]`/`[build-system]` metadata and the `attackgen-mcp = "mcp_server:main"` console script, so `pip install -e .` makes the package importable and installs the MCP entry point.
 
-In CI, `.github/workflows/tests.yml` runs the same suite on Python 3.10–3.14 for every push and pull request to `main`. `release.yml` keeps its own copy of that job so a release gates on its own tag rather than on whatever last ran against `main`.
+In CI, `.github/workflows/tests.yml` runs the same suite on Python 3.11–3.14 for every push and pull request to `main`. `release.yml` keeps its own copy of that job so a release gates on its own tag rather than on whatever last ran against `main`.
 
 ### Cutting a Release
-Releases are automated by `.github/workflows/release.yml`, which fires on **3-component semver tags** (`v*.*.*`, e.g. `v0.14.0`). Pushing such a tag runs the whole pipeline: **verify** the tag matches the packaged version → **test** (pytest on Python 3.10–3.14) → **build & push** a multi-arch (`linux/amd64,linux/arm64`) image to Docker Hub as `mrwadams/attackgen` (tagged `{version}`, `{major}.{minor}`, and `latest`) → **cut a GitHub Release** with generated notes. The image builds from the existing `Dockerfile` (its pinned base is a multi-arch OCI index, so arm64 works unchanged).
+Releases are automated by `.github/workflows/release.yml`, which fires on **3-component semver tags** (`v*.*.*`, e.g. `v0.14.0`). Pushing such a tag runs the whole pipeline: **verify** the tag matches the packaged version → **test** (pytest on Python 3.11–3.14) → **build & push** a multi-arch (`linux/amd64,linux/arm64`) image to Docker Hub as `mrwadams/attackgen` (tagged `{version}`, `{major}.{minor}`, and `latest`) → **cut a GitHub Release** with generated notes. The image builds from the existing `Dockerfile` (its pinned base is a multi-arch OCI index, so arm64 works unchanged).
 
 To cut a release:
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ build-backend = "setuptools.build_meta"
 name = "attackgen"
 version = "0.16.0"
 description = "Generate tailored incident-response scenarios from MITRE ATT&CK / ATLAS using LLMs"
-requires-python = ">=3.10"
+# 3.11 floor, not 3.10: litellm 1.98.0+ imports `NotRequired`/`Required` from
+# stdlib `typing` on the `import litellm` path, which is 3.11+ only. See the
+# matrix comment in .github/workflows/tests.yml.
+requires-python = ">=3.11"
 dependencies = [
     "langsmith",
     "litellm>=1.83.7",


### PR DESCRIPTION
## The problem

Every test module has been failing to **collect** on the Python 3.10 matrix leg since litellm 1.98.0. This is why PRs #92, #93 and #94 all show an identical `Test (Python 3.10)` failure regardless of what they change — none of them caused it.

```
core/__init__.py -> core.llm -> import litellm
litellm/llms/anthropic/experimental_pass_through/context_management/editors/compact.py:17:
    from typing import TYPE_CHECKING, Any, Final, Literal, NotRequired, Optional, TypedDict, Union, cast
E   ImportError: cannot import name 'NotRequired' from 'typing'
```

`NotRequired` only reached stdlib `typing` in 3.11 (it lives in `typing_extensions` before that). Because `import litellm` sits on the `import core` path, this takes out collection of the entire suite — 15 collection errors, 0 tests run — rather than failing one test.

## Why not just pin litellm

The break is upstream and **still unfixed**:

- `compact.py` first appears in **litellm 1.98.0**; 1.97.0 and earlier are clean, which is why `main` was last green on 22 Aug.
- litellm declares `requires-python = ">=3.10"` but has broken it repeatedly — BerriAI/litellm#38076, #38892, #38003 are all open on this exact import.
- The upstream fix (BerriAI/litellm#39448) merged 2026-09-03, but **1.100.0 (released 2026-09-06) still ships the bad import** in `compact.py`, plus a second one — `from typing import Literal, Required` in `types/llms/gemini_audio_transcription.py`. I verified this against the published wheel, not just the repo.

Capping `litellm<1.98` would restore 3.10, but it freezes the model registry — the whole reason the `>=1.83.7` floor exists — to keep alive an interpreter that reaches **EOL next month (Oct 2026)** and that the shipped Docker image (`python:3.14-slim`) never used.

## The change

- `pyproject.toml`: `requires-python = ">=3.10"` → `">=3.11"`
- `tests.yml` / `release.yml`: matrices drop `'3.10'` → `['3.11', '3.12', '3.13', '3.14']`
- `CLAUDE.md` / `AGENTS.md`: the "Python 3.10–3.14" descriptions follow suit

Each matrix change carries a comment recording why, so the next person doesn't try to add 3.10 back.

`litellm` stays unpinned.

## How to test

CI on this PR is the test: the four remaining legs should be green with no 3.10 leg present. Once this lands, rebasing #92/#93/#94 should clear their failures without any change to their own code.

Note: I have no pytest available locally in this environment, so the suite was not run outside CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167LMN1sG7UeCoPM6ZV7BJ4