### PR TITLE
Trim the verbose UI copy across the app

### DIFF
--- a/core/scenario_page.py
+++ b/core/scenario_page.py
@@ -1159,9 +1159,8 @@ def _render_modifier_controls(render_modifiers: Callable[[], None]) -> None:
     st.markdown("**Generation options**")
     render_modifiers()
     st.caption(
-        "Options apply to the next generation. The purple-team narrative makes a "
-        "second model call after the scenario is complete, so the full run can take "
-        "several minutes on a reasoning model."
+        "The purple-team narrative adds a second model call, so the run takes "
+        "longer."
     )
 
 
@@ -1194,17 +1193,19 @@ def _render_readiness(
     if not line:
         return
     st.caption(f"Ready to generate — {line}")
-    with st.expander("Review the inputs for this generation"):
-        _render_fact_table(describe_inputs(snapshot))
 
 
 def _render_no_result_note() -> None:
-    """Explain a missing result on a deep-linked page, rather than say nothing."""
+    """Answer "where did my scenario go?" after a reload, rather than say nothing.
+
+    The setup that came back is mirrored through the query string, but that is
+    our plumbing, not something the user asked for or can see — so this says
+    what was lost and how to get it back, not how the restore works.
+    """
     if setup_was_restored_from_link():
         st.caption(
-            "Setup was restored from this page's link. Generated scenarios are kept "
-            "for the current browser session only, so anything generated before a "
-            "refresh isn't available here — generate again to recreate it."
+            "Scenarios aren't kept when the page reloads — generate again to "
+            "recreate one."
         )
 
 
@@ -1332,11 +1333,8 @@ def _render_result_meta(snapshot: Snapshot | None, *, stale: bool) -> None:
     if line:
         st.caption(f"Generated from — {line}")
     if stale:
-        st.info(
-            "Your current selections differ from the inputs that produced this "
-            "result. It stays available until you regenerate or clear it."
-        )
-    with st.expander("Inputs captured when this scenario was generated"):
+        st.info("Your selections have changed since this scenario was generated.")
+    with st.expander("Full inputs"):
         _render_fact_table(describe_inputs(snapshot))
 
 

--- a/core/sidebar.py
+++ b/core/sidebar.py
@@ -157,13 +157,10 @@ def render_setup_sidebar() -> SetupState:
             else 0
         )
         provider = st.selectbox(
-            "Select your preferred model provider:",
+            "Model provider",
             provider_options,
             index=provider_idx,
-            help=(
-                "Select the model provider you would like to use. This will determine "
-                "the models available for selection."
-            ),
+            help="Determines which models are available below.",
         )
         st.session_state["chosen_model_provider"] = provider
         provider_info = PROVIDERS[provider]
@@ -193,9 +190,9 @@ def render_setup_sidebar() -> SetupState:
                 )
             st.session_state["llm_api_key"] = st.text_input(
                 (
-                    f"Enter your {provider_info.name} API key:"
+                    f"{provider_info.name} API key"
                     if provider_info.needs_api_key
-                    else "API key (optional):"
+                    else "API key (optional)"
                 ),
                 type="password",
                 value=existing_key,
@@ -210,7 +207,7 @@ def render_setup_sidebar() -> SetupState:
                 or ""
             )
             st.session_state["llm_api_base"] = st.text_input(
-                "Base URL:",
+                "Base URL",
                 value=initial_base,
                 help=(
                     "Base URL of your OpenAI-compatible endpoint. Example: "
@@ -228,7 +225,7 @@ def render_setup_sidebar() -> SetupState:
             help_map = {model.model_id: model.help_text for model in models}
             model_idx = labels.index(persisted_model) if persisted_model in labels else 0
             st.session_state["llm_model_name"] = st.selectbox(
-                "Select the model you would like to use:",
+                "Model",
                 labels,
                 index=model_idx,
                 help="\n".join(
@@ -239,7 +236,7 @@ def render_setup_sidebar() -> SetupState:
         else:
             initial_model = persisted_model or os.getenv("CUSTOM_MODEL_NAME") or ""
             st.session_state["llm_model_name"] = st.text_input(
-                "Model name:",
+                "Model name",
                 value=initial_model,
                 help=(
                     "Model identifier as expected by your endpoint "
@@ -256,7 +253,7 @@ def render_setup_sidebar() -> SetupState:
             else 0
         )
         st.session_state["matrix"] = st.radio(
-            "Select MITRE Framework:",
+            "MITRE framework",
             MATRIX_OPTIONS,
             index=matrix_idx,
             help=(
@@ -267,7 +264,7 @@ def render_setup_sidebar() -> SetupState:
 
         persisted_industry = st.session_state.get("industry")
         st.session_state["industry"] = st.selectbox(
-            "Select your company's industry:",
+            "Industry",
             INDUSTRIES,
             index=(
                 INDUSTRIES.index(persisted_industry)
@@ -279,7 +276,7 @@ def render_setup_sidebar() -> SetupState:
 
         persisted_size = st.session_state.get("company_size")
         st.session_state["company_size"] = st.selectbox(
-            "Select your company's size:",
+            "Company size",
             COMPANY_SIZES,
             index=(
                 COMPANY_SIZES.index(persisted_size)

--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -128,27 +128,11 @@ matrix = setup.matrix or "Enterprise"
 groups = load_groups(matrix)
 
 if matrix == "ATLAS":
-    st.markdown(
-        """
-        ### Select a Case Study
-
-        Use the drop-down selector below to select a case study from the MITRE ATLAS framework.
-
-        You can then optionally view all of the ATLAS techniques associated with the case study and/or the case study's page on the MITRE ATLAS site.
-        """
-    )
+    st.markdown("### Select a Case Study")
     entity_label = "case study"
     select_placeholder = "Select Case Study"
 else:
-    st.markdown(
-        f"""
-        ### Select a Threat Actor Group
-
-        Use the drop-down selector below to select a threat actor group from the MITRE ATT&CK framework.
-
-        You can then optionally view all of the {matrix} ATT&CK techniques associated with the group and/or the group's page on the MITRE ATT&CK site.
-        """
-    )
+    st.markdown("### Select a Threat Actor Group")
     entity_label = "threat actor group"
     select_placeholder = "Select Group"
 
@@ -213,24 +197,13 @@ except Exception as e:
 st.markdown("")
 
 if matrix == "ATLAS":
-    st.markdown(
-        """
-        ### Generate a Scenario
-
-        Click the button below to generate a scenario based on the selected case study. The documented attack procedure from the case study will be used to generate the scenario.
-
-        Generation runs in phases and reports the elapsed time for each one. ⏱️
-        """
-    )
+    st.markdown("### Generate a Scenario")
+    st.caption("Built from the case study's documented attack procedure.")
 else:
-    st.markdown(
-        """
-        ### Generate a Scenario
-
-        Click the button below to generate a scenario based on the selected threat actor group. A selection of the group's known techniques will be chosen at random and used to generate the scenario.
-
-        Generation runs in phases and reports the elapsed time for each one. ⏱️
-        """
+    st.markdown("### Generate a Scenario")
+    st.caption(
+        "Built from a random selection of the group's techniques, so each run "
+        "differs."
     )
 
 

--- a/pages/2_🛠️_Custom_Scenarios.py
+++ b/pages/2_🛠️_Custom_Scenarios.py
@@ -179,11 +179,6 @@ else:
     st.markdown("### Select ATT&CK Techniques")
 
 with st.expander("Use a Template (Optional)"):
-    if matrix == "ATLAS":
-        st.markdown("Select a template to quickly generate a custom scenario based on a predefined set of ATLAS techniques.")
-    else:
-        st.markdown("Select a template to quickly generate a custom scenario based on a predefined set of ATT&CK techniques.")
-
     selected_template = st.selectbox(
         "Select a template",
         options=[""] + list(incident_response_templates[matrix].keys()),
@@ -193,11 +188,6 @@ with st.expander("Use a Template (Optional)"):
         template_selection(selected_template, matrix)
 
 st.markdown("")
-
-if matrix == "ATLAS":
-    st.markdown("Use the multi-select box below to add or update the ATLAS techniques that you would like to include in a custom incident response testing scenario.")
-else:
-    st.markdown("Use the multi-select box below to add or update the ATT&CK techniques that you would like to include in a custom incident response testing scenario.")
 
 selected_techniques = []
 if not techniques_df.empty:
@@ -228,15 +218,7 @@ if not techniques_df.empty:
 
 
 st.markdown("")
-st.markdown(
-    """
-    ### Generate a Scenario
-
-    Click the button below to generate a scenario based on the selected technique(s).
-
-    Generation runs in phases and reports the elapsed time for each one. ⏱️
-    """
-)
+st.markdown("### Generate a Scenario")
 
 
 def _requirements() -> list[str]:

--- a/pages/3_🤖_AI_Insider_Threat_Scenarios.py
+++ b/pages/3_🤖_AI_Insider_Threat_Scenarios.py
@@ -85,11 +85,8 @@ st.markdown("---")
 # --- Optional template selection ---
 with st.expander("Use a Template (Optional)"):
     st.markdown(
-        "Select a template to pre-populate the deployment archetype, threat categories and "
-        "STRIDE threats for a common AI insider threat scenario, along with the decisions the "
-        "exercise must force. Most templates leave the narrative to the model, so re-running "
-        "one gives a fresh exercise; templates that rehearse a specific incident also fill in "
-        "the scenario seed. You can adjust everything afterwards."
+        "Pre-populates the selections below, which you can then adjust. Templates "
+        "that rehearse a specific incident also fill in the scenario seed."
     )
     selected_template = st.selectbox(
         "Select a template",
@@ -136,11 +133,7 @@ st.info(
 
 # --- Threat categories ---
 st.markdown("### 2. Threat Categories (required)")
-st.markdown(
-    "Select one or more insider threat categories the scenario should focus on. This is the "
-    "form's one required selection — the STRIDE threats and agent capabilities below are "
-    "optional refinements of it."
-)
+st.markdown("The insider threat categories the scenario should focus on.")
 selected_categories = st.multiselect(
     "Select threat categories:",
     options=list(THREAT_CATEGORIES.keys()),
@@ -151,8 +144,8 @@ st.session_state['ai_insider_categories'] = selected_categories
 # --- STRIDE threats ---
 st.markdown("### 3. Specific STRIDE Threats (Optional)")
 st.markdown(
-    "Optionally narrow the scenario to specific STRIDE threats. If left empty, the STRIDE threats "
-    "associated with your selected categories will be used."
+    "Narrows the scenario to specific STRIDE threats. Left empty, the threats "
+    "associated with your categories are used."
 )
 selected_stride_options = st.multiselect(
     "Select STRIDE threats:",
@@ -180,11 +173,9 @@ selected_capabilities = st.multiselect(
 # --- Scenario seed ---
 st.markdown("### 5. Scenario Seed (Optional)")
 st.markdown(
-    "Describe the specific situation you want to rehearse — the deployment, what goes wrong, "
-    "and who is affected. The model builds the narrative around it rather than inventing its "
-    "own premise. Leave it empty and the model invents a premise from your selections, which "
-    "is usually what you want when re-running the same threat profile for a fresh exercise. "
-    "Templates that rehearse a specific incident fill this in for you; edit it freely."
+    "Describe the situation you want to rehearse — the deployment, what goes wrong, "
+    "and who is affected. Left empty, the model invents a premise from your "
+    "selections, so each run gives a fresh exercise."
 )
 scenario_seed = st.text_area(
     "Scenario seed:",
@@ -209,15 +200,7 @@ if required_decisions:
 
 st.markdown("")
 st.markdown("---")
-st.markdown(
-    """
-    ### Generate a Scenario
-
-    Click the button below to generate an AI insider threat scenario based on your selections.
-
-    Generation runs in phases and reports the elapsed time for each one. ⏱️
-    """
-)
+st.markdown("### Generate a Scenario")
 
 
 def _requirements() -> list[str]:

--- a/tests/test_scenario_page.py
+++ b/tests/test_scenario_page.py
@@ -2028,7 +2028,7 @@ def test_editing_the_form_keeps_the_result_and_says_it_is_out_of_date(
     assert fake_session_state["threat_group_scenario_text"].startswith("# APT29")
     assert downloads
     # ...but it is not passed off as matching the new selection either.
-    assert any("differ from the inputs" in info for info in stub_streamlit["infos"])
+    assert any("selections have changed" in info for info in stub_streamlit["infos"])
 
 
 def test_regenerate_action_runs_again_with_the_current_inputs(
@@ -2166,7 +2166,7 @@ def test_feedback_is_pinned_to_the_run_that_produced_the_result(
     assert fake_session_state["custom_scenario_run_id"] == "run-xyz"
 
 
-def test_deep_link_without_a_result_explains_that_scenarios_are_session_only(
+def test_a_restored_page_without_a_result_says_scenarios_do_not_survive_a_reload(
     stub_streamlit, fake_session_state
 ) -> None:
     from core.state import RESTORED_KEY
@@ -2184,7 +2184,7 @@ def test_deep_link_without_a_result_explains_that_scenarios_are_session_only(
     )
 
     note = "\n".join(stub_streamlit["captions"])
-    assert "current browser session only" in note
+    assert "aren't kept when the page reloads" in note
 
 
 def test_regenerate_says_why_nothing_happened_when_the_form_is_not_ready(


### PR DESCRIPTION
The scenario pages had grown chatty: they said things twice, narrated their own widgets, and explained our state management to people who hadn't asked.

## 1. The duplicated pre-flight block

Before Generate, the page rendered both a summary caption and an expander repeating the same facts:

> Ready to generate — Enterprise ATT&CK · Automotive · Large (201-1,000 employees) · APT19 · 6 techniques · AI-enhanced adversary

> **Review the inputs for this generation** → Framework, Industry, Company size, Threat group, Techniques, Modifiers

The expander is gone. The caption already names every choice, so nothing is lost.

The matching expander *below a finished result* stays (retitled `Full inputs`). Unlike the pre-flight one it isn't a restatement: `summary_line` deliberately omits the model, the generation timestamp and, on page 3, the STRIDE threats and agent capabilities, so it is the only record of what produced a result.

## 2. The reload note

The note on a page whose setup came back from the query string explained our own state management:

> Setup was restored from this page's link. Generated scenarios are kept for the current browser session only, so anything generated before a refresh isn't available here — generate again to recreate it.

Nobody shares those URLs — they're opaque (`?p=…&m=…&x=…`) and nothing in the UI offers them. `RESTORED_KEY` really fires on a refresh or a reopened tab, so the message now answers the question the user actually has:

> Scenarios aren't kept when the page reloads — generate again to recreate one.

## 3. Prose narrating self-evident controls

Every scenario page introduced its own widgets, under a heading that already said the same thing, above a control that labels itself:

- "Use the drop-down selector below to select a threat actor group from the MITRE ATT&CK framework." + a second paragraph describing the technique expander and the MITRE link that follow it
- "Use the multi-select box below to add or update the ATT&CK techniques that you would like to include in a custom incident response testing scenario."
- "Click the button below to generate a scenario based on the selected technique(s)."
- "Generation runs in phases and reports the elapsed time for each one. ⏱️" — the same app-mechanics narration, on four pages, aimed at people about to watch it happen

All cut to their headings. What survives is what a user can't see for themselves, each now one sentence: a threat group's techniques are **sampled at random** so a re-run differs (an ATLAS case study instead uses its documented procedure), an empty **scenario seed** means the model invents the premise, and empty **STRIDE threats** fall back to the ones implied by the categories. Page 3's template blurb and the five-sentence seed paragraph got the same treatment.

## 4. Two smaller trims

- Generation options: three sentences about a second model call and reasoning-model timings → "The purple-team narrative adds a second model call, so the run takes longer."
- Stale result: "Your current selections differ from the inputs that produced this result. It stays available until you regenerate or clear it." → "Your selections have changed since this scenario was generated."

## 5. Setup sidebar labels

A 300px sidebar spent most of each line on the verb: `Select your preferred model provider:`, `Select the model you would like to use:`, `Select your company's industry:`, `Select your company's size:`, `Select MITRE Framework:`. The widget already *is* the selecting, so the label now just names the field — **Model provider**, **Model**, **Industry**, **Company size**, **MITRE framework** — and the trailing colons go with them so the API key and Base URL fields read the same way. The provider help text dropped the half that restated its label.

`test_accessibility_smoke` reads the labels from the rendered sidebar rather than pinning strings, and asserts they are non-empty and distinct, which still holds. The blocker messages ("Select your company's size in the Setup sidebar.") are untouched — they are instructions, not field names.

## Not touched

The Welcome page's introduction and Getting Started list (a landing page has a different job), and page 2's "techniques are searchable by name or ID" hint, which teaches non-obvious behaviour.

## Tests

Copy-only change; no behaviour moves. Three tests that pinned the old wording now assert the new behaviour, and one is renamed away from "deep link". Full suite passes (`tests/test_llm.py::test_tenacity_is_installed_for_litellms_retry_path` fails locally only because `tenacity` isn't in my venv — unrelated, and green in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016c9un2kagTvaPEMsBWDyBM
