### PR TITLE
Pin feedback to the result's own run, with no session fallback

### DIFF
--- a/core/feedback.py
+++ b/core/feedback.py
@@ -1,9 +1,10 @@
 """LangSmith feedback widget for scenario pages.
 
 Pages don't see the LangSmith client — `render_feedback_widget` initialises one
-lazily from ``st.secrets['LANGCHAIN_API_KEY']`` and reads the active run id
-from ``st.session_state['run_id']`` (set by ``core.llm.call_llm`` when a
-LangSmith client is configured for tracing).
+lazily from ``st.secrets['LANGCHAIN_API_KEY']``. The run it rates is the one the
+caller passes in: ``core.llm.call_llm`` sets ``st.session_state['run_id']`` when
+a LangSmith client is configured for tracing, and ``core.scenario_page`` copies
+it into the page's own result namespace so it stays with that result.
 """
 
 from __future__ import annotations
@@ -47,8 +48,9 @@ def render_feedback_widget(
     `run_id` pins the feedback to the run that produced the scenario on screen.
     Pages persist it alongside the result, so rating a result after navigating
     away and back — or after another page has generated its own scenario —
-    cannot submit feedback against a different run. It falls back to the
-    session's most recent run when a caller has none.
+    cannot submit feedback against a different run. There is deliberately no
+    fallback to the session's most recent run: that is whatever any page last
+    generated, so a caller with no run id has no run to rate and gets a warning.
     """
     if _get_secret("LANGCHAIN_API_KEY") is None:
         st.info(
@@ -80,9 +82,8 @@ def render_feedback_widget(
 
 
 def _submit(
-    client: Any, placeholder: Any, *, kind: str, score: int, run_id: str | None = None
+    client: Any, placeholder: Any, *, kind: str, score: int, run_id: str | None
 ) -> None:
-    run_id = run_id or st.session_state.get("run_id")
     if not run_id:
         placeholder.warning("No run ID found. Please generate a scenario first.")
         return

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -83,7 +83,25 @@ def test_submit_warns_when_run_id_missing(fake_session_state: dict[str, Any]) ->
     client = _FakeClient()
     placeholder = _FakePlaceholder()
 
-    _submit(client, placeholder, kind="positive", score=1)
+    _submit(client, placeholder, kind="positive", score=1, run_id=None)
+
+    assert client.calls == []
+    assert placeholder.messages == [("warning", "No run ID found. Please generate a scenario first.")]
+
+
+def test_submit_never_falls_back_to_the_sessions_latest_run(
+    fake_session_state: dict[str, Any],
+) -> None:
+    """A result with no run id of its own has nothing to rate.
+
+    The session-wide ``run_id`` is whichever page generated last, so borrowing
+    it would attach this rating to someone else's scenario (issue #98).
+    """
+    fake_session_state["run_id"] = "run-from-another-page"
+    client = _FakeClient()
+    placeholder = _FakePlaceholder()
+
+    _submit(client, placeholder, kind="positive", score=1, run_id=None)
 
     assert client.calls == []
     assert placeholder.messages == [("warning", "No run ID found. Please generate a scenario first.")]
@@ -92,11 +110,10 @@ def test_submit_warns_when_run_id_missing(fake_session_state: dict[str, Any]) ->
 def test_submit_posts_feedback_and_records_success(
     fake_session_state: dict[str, Any],
 ) -> None:
-    fake_session_state["run_id"] = "run-abc"
     client = _FakeClient(record_id="fb-1")
     placeholder = _FakePlaceholder()
 
-    _submit(client, placeholder, kind="positive", score=1)
+    _submit(client, placeholder, kind="positive", score=1, run_id="run-abc")
 
     assert client.calls == [("run-abc", "positive", {"score": 1, "comment": ""})]
     assert fake_session_state["feedback"] == {"feedback_id": "fb-1", "score": 1}
@@ -106,11 +123,10 @@ def test_submit_posts_feedback_and_records_success(
 def test_submit_records_negative_with_score_zero(
     fake_session_state: dict[str, Any],
 ) -> None:
-    fake_session_state["run_id"] = "run-abc"
     client = _FakeClient(record_id="fb-2")
     placeholder = _FakePlaceholder()
 
-    _submit(client, placeholder, kind="negative", score=0)
+    _submit(client, placeholder, kind="negative", score=0, run_id="run-abc")
 
     assert client.calls == [("run-abc", "negative", {"score": 0, "comment": ""})]
     assert fake_session_state["feedback"] == {"feedback_id": "fb-2", "score": 0}
@@ -164,11 +180,10 @@ def test_thumbs_buttons_have_meaningful_accessible_names(
 def test_submit_surfaces_client_errors(
     fake_session_state: dict[str, Any],
 ) -> None:
-    fake_session_state["run_id"] = "run-abc"
     client = _FakeClient(raises=RuntimeError("network down"))
     placeholder = _FakePlaceholder()
 
-    _submit(client, placeholder, kind="positive", score=1)
+    _submit(client, placeholder, kind="positive", score=1, run_id="run-abc")
 
     assert "feedback" not in fake_session_state
     assert len(placeholder.messages) == 1


### PR DESCRIPTION
Fixes item 1 of #98. Items 2 and 3 are still open, so this doesn't close that issue.

## Problem
`core/feedback.py:_submit` fell back to `st.session_state["run_id"]` whenever a caller passed no run id:

```python
run_id = run_id or st.session_state.get("run_id")
```

That key holds whichever page generated last. #97 made each page save its own `<page_id>_scenario_run_id` so a rating stays with the scenario on screen. This fallback undid that, and it contradicted the widget's own docstring.

## Change
- **No fallback.** A result with no run id of its own gets the existing "No run ID found" warning instead of borrowing another page's run.
- **`run_id` is required on `_submit`.** A future caller can't leave it out by accident. The only production caller, `core/scenario_page.py`, already passes the page-scoped id.
- **Docstrings corrected.** Both the module and widget docstrings still described the old fallback.

## Tests
- **New regression test:** `test_submit_never_falls_back_to_the_sessions_latest_run` sets the session's `run_id`, passes none for the result, and asserts nothing is posted. It **fails against `main`** and passes here.
- **Existing tests:** they now pass `run_id` directly instead of setting it in session state.
- **Full suite:** 331 passed, 7 skipped (the browser checks). I deselected one test, `test_tenacity_is_installed_for_litellms_retry_path`, because it fails only in my local venv, which is missing `tenacity`. CI installs `requirements.txt` and is unaffected.

## Follow-up
This was the last open gap in #54's feedback criterion. I'll close #54 once this merges; its retry buttons stay in the failure notice rather than moving into "Next steps".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017omGXvhyJhY5zRKrsgt8cu
