### PR TITLE
Follow-ups from verifying #97: feedback run id, misreported technique-lookup failure, upstream sidebar label

### DIFF
--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -154,6 +154,7 @@ selected_group_alias = st.selectbox(
 kill_chain_string = ""
 techniques_df = pd.DataFrame()
 selected_techniques_df = pd.DataFrame()
+lookup_error = None
 
 try:
     if selected_group_alias is not None:
@@ -191,7 +192,12 @@ try:
 
             kill_chain_string = kill_chain.kill_chain_string
 except Exception as e:
-    st.error("An error occurred: " + str(e))
+    # A failed lookup leaves the DataFrames at their empty defaults, which on
+    # its own is indistinguishable from a group that genuinely has no
+    # techniques. Record the failure so `_requirements` can say what actually
+    # happened instead of contradicting the error above.
+    lookup_error = str(e)
+    st.error("An error occurred: " + lookup_error)
 
 
 st.markdown("")
@@ -211,6 +217,11 @@ def _requirements() -> list[str]:
     """This page's own readiness blockers, in the order the form presents them."""
     if selected_group_alias is None:
         return [f"Select a {entity_label} for the scenario."]
+    if lookup_error is not None:
+        return [
+            f"Could not load the {matrix} techniques for "
+            f"'{selected_group_alias}' — see the error above."
+        ]
     if techniques_df.empty or not kill_chain_string:
         return [
             f"Select a {entity_label} with associated {matrix} techniques — "


### PR DESCRIPTION
Automated by **agent-loop** — the agent worked this issue on a fresh clone of `mrwadams/attackgen` inside a disposable sandbox; changes were gated outside the agent.

Closes #98

## How to test
```bash
git fetch origin && git checkout agent/issue-98
python3 -m venv .venv && . .venv/bin/activate
pip install -r requirements.txt
streamlit run "00_👋_Welcome.py"
```
Then open the printed local URL.

**Confirm each acceptance criterion:**
- [x] Review against the issue's acceptance criteria.

## Gates (non-authoritative)
- ✅ **files_non_empty** — 1 non-empty file(s) changed
- ✅ **containment** — diff stays within the allowed lane
- ✅ **verify** — pytest: 332 passed, no failures (browser/e2e excluded)

> **Draft.** Browser/e2e tests were NOT run in-gate — run them and review before merging. Nothing here is auto-merged.
