### PR TITLE
Custom Scenarios hides the technique picker and blames the user when techniques fail to load

### DIFF
--- a/pages/2_🛠️_Custom_Scenarios.py
+++ b/pages/2_🛠️_Custom_Scenarios.py
@@ -69,17 +69,21 @@ attack_data = load_attack_data()
 def load_techniques():
     """Returns (techniques_df, error). ``error`` is ``None`` on success.
 
-    A failed lookup leaves ``techniques_df`` at its empty default, which on
-    its own is indistinguishable from a matrix with no techniques (never
-    happens in practice, but nothing enforces that). The error is threaded
-    back to ``_requirements`` so it can name the load failure instead of
-    telling the user to select a technique from a picker that never rendered.
+    An empty list is reported as a failure too: a matrix always has
+    techniques, so an empty one means the bundle didn't parse as expected, and
+    the picker has nothing to offer either way. The error is threaded back to
+    ``_requirements`` so it can name the load failure instead of telling the
+    user to select a technique from a picker that never rendered.
     """
     try:
-        return pd.DataFrame(list_technique_options(matrix)), None
+        options = list_technique_options(matrix)
     except Exception as e:
         logger.error("Error in load_techniques: %s", e)
         return pd.DataFrame(), str(e)
+    if not options:
+        logger.error("Error in load_techniques: no %s techniques found", matrix)
+        return pd.DataFrame(), "the technique list came back empty."
+    return pd.DataFrame(options), None
 
 
 techniques_df, techniques_load_error = load_techniques()

--- a/pages/2_🛠️_Custom_Scenarios.py
+++ b/pages/2_🛠️_Custom_Scenarios.py
@@ -1,3 +1,5 @@
+import logging
+
 import pandas as pd
 import streamlit as st
 
@@ -13,6 +15,8 @@ from core.navigator import build_layer, dumps, parse_technique_id
 from core.scenario_page import run_scenario_page
 from core.sidebar import render_setup_sidebar
 from core.styles import inject_emoji_fonts
+
+logger = logging.getLogger(__name__)
 
 
 # ------------------ Streamlit Configuration ------------------ #
@@ -63,14 +67,22 @@ attack_data = load_attack_data()
 
 
 def load_techniques():
+    """Returns (techniques_df, error). ``error`` is ``None`` on success.
+
+    A failed lookup leaves ``techniques_df`` at its empty default, which on
+    its own is indistinguishable from a matrix with no techniques (never
+    happens in practice, but nothing enforces that). The error is threaded
+    back to ``_requirements`` so it can name the load failure instead of
+    telling the user to select a technique from a picker that never rendered.
+    """
     try:
-        return pd.DataFrame(list_technique_options(matrix))
+        return pd.DataFrame(list_technique_options(matrix)), None
     except Exception as e:
-        print(f"Error in load_techniques: {e}")
-        return pd.DataFrame()
+        logger.error("Error in load_techniques: %s", e)
+        return pd.DataFrame(), str(e)
 
 
-techniques_df = load_techniques()
+techniques_df, techniques_load_error = load_techniques()
 
 
 # ------------------ Prompt Construction ------------------ #
@@ -178,6 +190,9 @@ if matrix == "ATLAS":
 else:
     st.markdown("### Select ATT&CK Techniques")
 
+if techniques_load_error is not None:
+    st.error(f"Could not load the {matrix} techniques: {techniques_load_error}")
+
 with st.expander("Use a Template (Optional)"):
     selected_template = st.selectbox(
         "Select a template",
@@ -190,7 +205,7 @@ with st.expander("Use a Template (Optional)"):
 st.markdown("")
 
 selected_techniques = []
-if not techniques_df.empty:
+if techniques_load_error is None:
     if matrix == "ATLAS":
         technique_options = techniques_df['Display Name'].tolist()
     else:
@@ -222,9 +237,11 @@ st.markdown("### Generate a Scenario")
 
 
 def _requirements() -> list[str]:
-    """This page's own readiness blocker: at least one technique."""
+    """This page's own readiness blockers, in the order the form presents them."""
+    label = "ATLAS" if matrix == "ATLAS" else "ATT&CK"
+    if techniques_load_error is not None:
+        return [f"Could not load the {label} techniques — see the error above."]
     if not selected_techniques:
-        label = "ATLAS" if matrix == "ATLAS" else "ATT&CK"
         return [f"Select at least one {label} technique for the scenario."]
     return []
 


### PR DESCRIPTION
Automated by **agent-loop** — the agent worked this issue on a fresh clone of `mrwadams/attackgen` inside a disposable sandbox; changes were gated outside the agent.

Closes #104

## How to test
```bash
git fetch origin && git checkout agent/issue-104
python3 -m venv .venv && . .venv/bin/activate
pip install -r requirements.txt
streamlit run "00_👋_Welcome.py"
```
Then open the printed local URL.

**Confirm each acceptance criterion:**
- [x] A failing `list_technique_options` shows an error on the page.
- [x] The readiness blocker names the load failure rather than asking the user to select a technique.
- [x] Generate stays disabled.
- [x] The healthy path is unchanged: the multiselect renders, and the "select at least one" blocker still fires when nothing is chosen.

## Gates (non-authoritative)
- ✅ **files_non_empty** — 1 non-empty file(s) changed
- ✅ **containment** — diff stays within the allowed lane
- ✅ **verify** — pytest: 332 passed, no failures (browser/e2e excluded)

> **Draft.** Browser/e2e tests were NOT run in-gate — run them and review before merging. Nothing here is auto-merged.
