### PR TITLE
Make the technique-lookup failure blocker actionable

### DIFF
--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -220,11 +220,13 @@ def _requirements() -> list[str]:
     if lookup_error is not None:
         # Phrased as something the user can act on: every other line in the
         # readiness box is a step they can complete, so a bare "could not
-        # load" would read as a status report with no way forward.
+        # load" would read as a status report with no way forward. Reloading
+        # is deliberately not offered: it starts a new session, dropping a
+        # key typed into the sidebar and any scenario already generated.
         return [
-            f"Pick a different {entity_label}, or reload the page — loading "
-            f"the {matrix} techniques for '{selected_group_alias}' failed "
-            f"(see the error above)."
+            f"Pick a different {entity_label} — loading the {matrix} "
+            f"techniques for '{selected_group_alias}' failed (see the error "
+            f"above)."
         ]
     if techniques_df.empty or not kill_chain_string:
         return [

--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -218,9 +218,13 @@ def _requirements() -> list[str]:
     if selected_group_alias is None:
         return [f"Select a {entity_label} for the scenario."]
     if lookup_error is not None:
+        # Phrased as something the user can act on: every other line in the
+        # readiness box is a step they can complete, so a bare "could not
+        # load" would read as a status report with no way forward.
         return [
-            f"Could not load the {matrix} techniques for "
-            f"'{selected_group_alias}' — see the error above."
+            f"Pick a different {entity_label}, or reload the page — loading "
+            f"the {matrix} techniques for '{selected_group_alias}' failed "
+            f"(see the error above)."
         ]
     if techniques_df.empty or not kill_chain_string:
         return [


### PR DESCRIPTION
Automated by **agent-loop** — the agent worked this issue on a fresh clone of `mrwadams/attackgen` inside a disposable sandbox; changes were gated outside the agent.

Closes #105

## How to test
```bash
git fetch origin && git checkout agent/issue-105
python3 -m venv .venv && . .venv/bin/activate
pip install -r requirements.txt
streamlit run "00_👋_Welcome.py"
```
Then open the printed local URL.

**Confirm each acceptance criterion:**
- [x] The lookup-failure blocker tells the user what they can do.
- [x] It reads correctly for Enterprise, ICS and ATLAS.

## Gates (non-authoritative)
- ✅ **files_non_empty** — 1 non-empty file(s) changed
- ✅ **containment** — diff stays within the allowed lane
- ✅ **verify** — pytest: 332 passed, no failures (browser/e2e excluded)

> **Draft.** Browser/e2e tests were NOT run in-gate — run them and review before merging. Nothing here is auto-merged.
