### PR TITLE
Threat Group page: empty-result and lookup-failure branches are pre-empted by the dropdown filter

### DIFF
--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -177,6 +177,12 @@ try:
             # tear down the readiness summary and any result this page is
             # already holding. The empty technique set becomes a readiness
             # blocker instead (see `_requirements`).
+            #
+            # In practice this can't happen through the UI: `load_groups` only
+            # offers entries from `list_usable_scenario_options`, which already
+            # probes every candidate and drops any that resolve no techniques
+            # (core/attack_data.py). Kept as defence in depth in case that
+            # invariant ever changes.
             st.warning(
                 f"There are no {matrix} techniques associated with the {entity}: {selected_group_alias}"
             )
@@ -218,11 +224,20 @@ def _requirements() -> list[str]:
     if selected_group_alias is None:
         return [f"Select a {entity_label} for the scenario."]
     if lookup_error is not None:
+        # Reachable even though the dropdown pre-filters candidates: the probe
+        # in `list_usable_scenario_options` uses a fixed `seed=0`, while this
+        # page's own resolution (above) uses the run's real seed for ATT&CK
+        # matrices, and only catches a narrower set of exception types. A
+        # candidate that only fails on the real draw, or raises something
+        # outside that set, still reaches here.
         return [
             f"Could not load the {matrix} techniques for "
             f"'{selected_group_alias}' — see the error above."
         ]
     if techniques_df.empty or not kill_chain_string:
+        # Same defence-in-depth caveat as the warning above: the dropdown
+        # already excludes candidates with no techniques, so this branch
+        # shouldn't be reachable through the UI today.
         return [
             f"Select a {entity_label} with associated {matrix} techniques — "
             f"'{selected_group_alias}' has none."

--- a/pages/1_🛡️_Threat_Group_Scenarios.py
+++ b/pages/1_🛡️_Threat_Group_Scenarios.py
@@ -225,11 +225,12 @@ def _requirements() -> list[str]:
         return [f"Select a {entity_label} for the scenario."]
     if lookup_error is not None:
         # Reachable even though the dropdown pre-filters candidates: the probe
-        # in `list_usable_scenario_options` uses a fixed `seed=0`, while this
-        # page's own resolution (above) uses the run's real seed for ATT&CK
-        # matrices, and only catches a narrower set of exception types. A
-        # candidate that only fails on the real draw, or raises something
-        # outside that set, still reaches here.
+        # in `list_usable_scenario_options` resolves with a fixed `seed=0`,
+        # while this page resolves with the run's real, unseeded draw for
+        # ATT&CK matrices. A candidate that only fails on the real draw passes
+        # the probe and lands here. A failure the probe does hit never gets
+        # this far: the filter drops it if its type is in the filter's catch
+        # list, and otherwise it escapes `load_groups` and crashes the page.
         return [
             f"Could not load the {matrix} techniques for "
             f"'{selected_group_alias}' — see the error above."

--- a/tests/test_attack_data.py
+++ b/tests/test_attack_data.py
@@ -178,6 +178,45 @@ def test_every_shipped_threat_group_option_resolves(matrix):
             ).techniques
 
 
+def test_usable_options_exclude_raising_and_empty_candidates(monkeypatch):
+    """Pins the guarantee `pages/1_...py` relies on to treat these as unreachable.
+
+    `list_usable_scenario_options` probes every candidate with `seed=0` and
+    drops one that raises or resolves no techniques (core/attack_data.py:180).
+    """
+    monkeypatch.setattr(
+        ad,
+        "list_threat_groups",
+        lambda matrix: (
+            {"group": "RAISES", "url": "https://example.com/raises"},
+            {"group": "EMPTY", "url": "https://example.com/empty"},
+            {"group": "OK", "url": "https://example.com/ok"},
+        ),
+    )
+    monkeypatch.setattr(
+        ad,
+        "mitre_data_for_matrix",
+        lambda matrix: SimpleNamespace(get_groups_by_alias=lambda name: []),
+    )
+
+    def fake_resolve(matrix, name, seed=0):
+        if name == "RAISES":
+            raise ValueError("boom")
+        if name == "EMPTY":
+            return SimpleNamespace(techniques=[])
+        return SimpleNamespace(techniques=[{"Technique Name": "Web Protocols"}])
+
+    monkeypatch.setattr(ad, "resolve_threat_group_kill_chain", fake_resolve)
+
+    ad.list_usable_scenario_options.cache_clear()
+    try:
+        options = ad.list_usable_scenario_options("Enterprise")
+    finally:
+        ad.list_usable_scenario_options.cache_clear()
+
+    assert {option["group"] for option in options} == {"OK"}
+
+
 def test_natural_sort_key_orders_apt_numbers_numerically():
     # A plain string sort interleaves APT3 between APT29 and APT30; the natural
     # key must read the digit run as a number so APT3 precedes both.


### PR DESCRIPTION
Automated by **agent-loop** — the agent worked this issue on a fresh clone of `mrwadams/attackgen` inside a disposable sandbox; changes were gated outside the agent.

Closes #106

## How to test
```bash
git fetch origin && git checkout agent/issue-106
python3 -m venv .venv && . .venv/bin/activate
pip install -r requirements.txt
streamlit run "00_👋_Welcome.py"
```
Then open the printed local URL.

**Confirm each acceptance criterion:**
- [x] Review against the issue's acceptance criteria.

## Gates (non-authoritative)
- ✅ **files_non_empty** — 2 non-empty file(s) changed
- ✅ **containment** — diff stays within the allowed lane
- ✅ **verify** — pytest: 333 passed, no failures (browser/e2e excluded)

> **Draft.** Browser/e2e tests were NOT run in-gate — run them and review before merging. Nothing here is auto-merged.
