### PR TITLE
One AI-insider selection rule for the page and the MCP server

### DIFF
--- a/core/prompts.py
+++ b/core/prompts.py
@@ -25,6 +25,7 @@ from data.ai_insider_threats import (
     CONTROLS_FRAMEWORK,
     DEPLOYMENT_ARCHETYPES,
     DETECTION_STRATEGIES,
+    THREAT_CATEGORIES,
     build_threat_context,
 )
 
@@ -226,14 +227,24 @@ def build_ai_insider_messages(
     *,
     archetype_name: str,
     selected_categories: list[str],
-    selected_stride: list[str],
-    selected_capabilities: list[str],
+    selected_stride: list[str] | None = None,
+    selected_capabilities: list[str] | None = None,
     industry: str,
     company_size: str,
     scenario_seed: str | None = None,
     required_decisions: list[str] | None = None,
 ) -> list[Message]:
     """Build the [system, user] messages for an AI Insider Threat scenario.
+
+    ``selected_stride`` left empty is derived from ``selected_categories`` (the
+    STRIDE codes each category maps to), so a category-only selection still
+    produces the "Specific STRIDE threats in scope" block. This is the one
+    place that derivation happens — the page and the MCP server both pass
+    their raw selections through instead of deriving it themselves.
+
+    ``selected_capabilities`` distinguishes "not specified" from "deliberately
+    none": omitted (``None``, the default) means every capability; an explicit
+    ``[]`` means the deliberate opt-out line.
 
     ``scenario_seed`` is optional free-text narrative framing (a template's
     ``brief``, or whatever the user typed into the page's seed box).
@@ -242,7 +253,19 @@ def build_ai_insider_messages(
     prompt byte-identical to a build without them.
     """
     archetype = DEPLOYMENT_ARCHETYPES[archetype_name]
+
+    if not selected_stride and selected_categories:
+        derived = []
+        for category in selected_categories:
+            derived.extend(THREAT_CATEGORIES.get(category, {}).get("stride", []))
+        selected_stride = list(dict.fromkeys(derived))
+    else:
+        selected_stride = list(selected_stride or [])
+
     threat_context = build_threat_context(selected_categories, selected_stride)
+
+    if selected_capabilities is None:
+        selected_capabilities = list(AGENT_CAPABILITIES)
 
     if selected_capabilities:
         capability_lines = "\n".join(

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -266,12 +266,11 @@ def _resolve_ai_insider_inputs(
     the organisation context is missing — ``template`` gives those arguments
     defaults, so they are no longer required by the tool schema.
 
-    ``capabilities`` is the one selection no template supplies, so it defaults
-    to the full set — matching page 3's multiselect, which ships all of them
-    selected. Omitting it otherwise fell through to ``[]``, which the builder
-    reads as "no capabilities highlighted" and answers with a generic line,
-    silently giving MCP callers a weaker prompt than UI users for the same
-    template. Pass ``[]`` explicitly to opt out and get that line deliberately.
+    No template supplies ``capabilities``, so it passes through unresolved
+    (``None`` when the caller omits it too) — ``build_ai_insider_messages``
+    is the one place that turns "not specified" into the full capability set,
+    shared with page 3's multiselect default. Category-to-STRIDE derivation
+    for a category-only selection lives there too.
     """
     preset = aip.resolve_template(template) if template else {}
     resolved_archetype = archetype or preset.get("archetype", "")
@@ -284,9 +283,7 @@ def _resolve_ai_insider_inputs(
         "archetype_name": resolved_archetype,
         "selected_categories": categories or preset.get("categories", []),
         "selected_stride": stride or preset.get("stride", []),
-        "selected_capabilities": (
-            list(aip.AGENT_CAPABILITIES) if capabilities is None else capabilities
-        ),
+        "selected_capabilities": capabilities,
         "industry": industry,
         "company_size": company_size,
         "scenario_seed": seed,

--- a/pages/3_🤖_AI_Insider_Threat_Scenarios.py
+++ b/pages/3_🤖_AI_Insider_Threat_Scenarios.py
@@ -154,12 +154,8 @@ selected_stride_options = st.multiselect(
 )
 st.session_state['ai_insider_stride'] = selected_stride_options
 selected_stride = [stride_code_from_option(opt) for opt in selected_stride_options]
-
-if not selected_stride and selected_categories:
-    derived = []
-    for category in selected_categories:
-        derived.extend(THREAT_CATEGORIES[category]['stride'])
-    selected_stride = list(dict.fromkeys(derived))
+# Left empty, build_ai_insider_messages derives STRIDE codes from
+# selected_categories itself — shared with the MCP server.
 
 # --- Agent capabilities ---
 st.markdown("### 4. Frontier Agent Capabilities (Optional)")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,16 +9,17 @@ from __future__ import annotations
 
 import asyncio
 import json
-from pathlib import Path
 
 import pytest
 
 import core.llm as llm_module
 import mcp_server as s
 from core.attack_data import KillChain
+from core.prompts import build_ai_insider_messages
 from data.ai_insider_threats import (
     AGENT_CAPABILITIES,
     DEPLOYMENT_ARCHETYPES,
+    THREAT_CATEGORIES,
     resolve_template,
 )
 from tests.test_detections import FakeMitreData
@@ -190,19 +191,33 @@ class TestDataTools:
         for other in list(AGENT_CAPABILITIES)[1:]:
             assert other not in user
 
-    def test_mcp_default_matches_the_streamlit_page(self):
-        """Page 3 defaults its multiselect to `list(AGENT_CAPABILITIES)`. If that
-        changes, this default should change with it or the two surfaces drift
-        apart again."""
-        page = (
-            Path(__file__).resolve().parent.parent
-            / "pages" / "3_🤖_AI_Insider_Threat_Scenarios.py"
-        ).read_text(encoding="utf-8")
-        assert "default=list(AGENT_CAPABILITIES.keys())" in page
-        kwargs = s._resolve_ai_insider_inputs(
-            EVAL_ESCAPE, "", None, None, None, "Technology", "Large", None,
+    def test_category_only_selection_matches_the_streamlit_page(self):
+        """Selecting categories with no explicit STRIDE threats used to
+        silently drop the "Specific STRIDE threats in scope" block over MCP,
+        because only page 3 derived STRIDE codes from categories itself. Both
+        entry points now funnel through `build_ai_insider_messages`, so an MCP
+        call must produce the same prompt as a direct call built the way the
+        page builds it (raw selections, capabilities defaulted to the full
+        set to match the page's multiselect default)."""
+        archetype = next(iter(DEPLOYMENT_ARCHETYPES))
+        category = next(iter(THREAT_CATEGORIES))
+
+        mcp_messages = s.get_ai_insider_prompt(
+            archetype, categories=[category],
+            industry="Technology", company_size="Large",
+        )["messages"]
+
+        page_equivalent_messages = build_ai_insider_messages(
+            archetype_name=archetype,
+            selected_categories=[category],
+            selected_stride=[],
+            selected_capabilities=list(AGENT_CAPABILITIES),
+            industry="Technology",
+            company_size="Large",
         )
-        assert kwargs["selected_capabilities"] == list(AGENT_CAPABILITIES)
+
+        assert mcp_messages == page_equivalent_messages
+        assert "Specific STRIDE threats in scope" in mcp_messages[1]["content"]
 
 
 class TestGenerateTools:


### PR DESCRIPTION
Automated by **agent-loop** — the agent worked this issue on a fresh clone of `mrwadams/attackgen` inside a disposable sandbox; changes were gated outside the agent.

Closes #112

## How to test
```bash
git fetch origin && git checkout agent/issue-112
python3 -m venv .venv && . .venv/bin/activate
pip install -r requirements.txt
streamlit run "00_👋_Welcome.py"
```
Then open the printed local URL.

**Confirm each acceptance criterion:**
- [x] With categories selected and no STRIDE threats, the MCP AI-insider tools and the page produce the same prompt, including the "Specific STRIDE threats in scope" block.
- [x] Omitting agent capabilities yields the full capability set; passing an empty list yields the deliberate opt-out line. Both hold for the page and for both MCP AI-insider tools.
- [x] Category-to-STRIDE derivation and the capability default each exist in exactly one place, behind `build_ai_insider_messages`.
- [x] The page's derivation block and the MCP server's capability default are gone.
- [x] The test that asserts a literal default string appears in the page's source text is deleted, replaced by a test comparing the two entry points' prompts for the same selection.
- [x] Prompts are byte-identical to today for an existing page generation and for an MCP call that passes explicit STRIDE threats.
- [x] `pytest` is green, including the pinned prompt-template tests.

## Gates (non-authoritative)
- ✅ **files_non_empty** — 4 non-empty file(s) changed
- ✅ **containment** — diff stays within the allowed lane
- ✅ **verify** — pytest: 333 passed, no failures (browser/e2e excluded)

> **Draft.** Browser/e2e tests were NOT run in-gate — run them and review before merging. Nothing here is auto-merged.
